### PR TITLE
Update database schema

### DIFF
--- a/backend/sites/src/app/entities/siteSubdivisions.entity.ts
+++ b/backend/sites/src/app/entities/siteSubdivisions.entity.ts
@@ -1,12 +1,13 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { Sites } from './sites.entity';
+import { Subdivisions } from './subdivisions.entity';
 
 @ObjectType()
 @Index(
   'site_subdivisions_site_id_subdiv_id_sprof_date_completed_key',
   ['siteId', 'sprofDateCompleted', 'subdivId'],
-  { unique: true },
+  {},
 )
 @Index('sitesub_part_or_all_of_frgn', ['siteId'], {})
 @Index('site_subdivisions_pkey', ['siteSubdivId'], { unique: true })
@@ -15,11 +16,11 @@ import { Sites } from './sites.entity';
 @Entity('site_subdivisions')
 export class SiteSubdivisions {
   @Field()
-  @Column('bigint', { name: 'site_id', unique: true })
+  @Column('bigint', { name: 'site_id' })
   siteId: string;
 
   @Field()
-  @Column('bigint', { name: 'subdiv_id', unique: true })
+  @Column('bigint', { name: 'subdiv_id' })
   subdivId: string;
 
   @Field()
@@ -57,7 +58,6 @@ export class SiteSubdivisions {
   @Column('timestamp without time zone', {
     name: 'sprof_date_completed',
     nullable: true,
-    unique: true,
   })
   sprofDateCompleted: Date | null;
 
@@ -74,4 +74,10 @@ export class SiteSubdivisions {
   })
   @JoinColumn([{ name: 'site_id', referencedColumnName: 'id' }])
   site: Sites;
+
+  @ManyToOne(() => Subdivisions, (subdivisions) => subdivisions.siteSubdivisions, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn([{ name: 'subdiv_id', referencedColumnName: 'id' }])
+  subdivision: Subdivisions;
 }

--- a/backend/sites/src/app/entities/subdivisions.entity.ts
+++ b/backend/sites/src/app/entities/subdivisions.entity.ts
@@ -1,5 +1,6 @@
 import { Field, ObjectType } from '@nestjs/graphql';
-import { Column, Entity, Index } from 'typeorm';
+import { Column, Entity, Index, OneToMany } from 'typeorm';
+import { SiteSubdivisions } from './siteSubdivisions.entity';
 
 @ObjectType()
 @Index('subdivisions_pkey', ['id'], { unique: true })
@@ -138,4 +139,11 @@ export class Subdivisions {
   @Field()
   @Column('character', { name: 'valid_pid', nullable: true, length: 1 })
   validPid: string | null;
+
+  @Field(() => SiteSubdivisions)
+  @OneToMany(
+    () => SiteSubdivisions,
+    (siteSubdivisions) => siteSubdivisions.subdivision,
+  )
+  siteSubdivisions: SiteSubdivisions[];
 }

--- a/backend/sites/src/app/site.module.ts
+++ b/backend/sites/src/app/site.module.ts
@@ -11,6 +11,7 @@ import { SiteDocs } from './entities/siteDocs.entity';
 import { SitePartics } from './entities/sitePartics.entity';
 import { SiteProfiles } from './entities/siteProfiles.entity';
 import { SiteSubdivisions } from './entities/siteSubdivisions.entity';
+import { Subdivisions } from './entities/subdivisions.entity';
 import { BceRegionCd } from './entities/bceRegionCd.entity';
 import { ClassificationCd } from './entities/classificationCd.entity';
 import { SiteRiskCd } from './entities/siteRiskCd.entity';
@@ -93,6 +94,7 @@ import { AssociatedSiteService } from './services/associatedSite/associatedSite.
       SitePartics,
       SiteProfiles,
       SiteSubdivisions,
+      Subdivisions,
       BceRegionCd,
       ClassificationCd,
       SiteRiskCd,

--- a/backend/sites/src/migrations/1721142257872-master-script.ts
+++ b/backend/sites/src/migrations/1721142257872-master-script.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MasterScript1721142257872 implements MigrationInterface {
+    name = 'MasterScript1721142257872'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "sites"."site_subdivisions_site_id_subdiv_id_sprof_date_completed_key"`);
+        await queryRunner.query(`ALTER TABLE "sites"."site_subdivisions" DROP CONSTRAINT "FK_a832b6c43076e628fe78d50fb45"`);
+        await queryRunner.query(`ALTER TABLE "sites"."site_subdivisions" DROP CONSTRAINT "UQ_a832b6c43076e628fe78d50fb45"`);
+        await queryRunner.query(`ALTER TABLE "sites"."site_subdivisions" DROP CONSTRAINT "UQ_658bd2d307dc4205b529993cddd"`);
+        await queryRunner.query(`ALTER TABLE "sites"."site_subdivisions" DROP CONSTRAINT "UQ_71b14e3856335e7dc23fc28897b"`);
+        await queryRunner.query(`CREATE INDEX "site_subdivisions_site_id_subdiv_id_sprof_date_completed_key" ON "sites"."site_subdivisions" ("site_id", "sprof_date_completed", "subdiv_id") `);
+        await queryRunner.query(`ALTER TABLE "sites"."site_subdivisions" ADD CONSTRAINT "FK_a832b6c43076e628fe78d50fb45" FOREIGN KEY ("site_id") REFERENCES "sites"."sites"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "sites"."site_subdivisions" ADD CONSTRAINT "FK_658bd2d307dc4205b529993cddd" FOREIGN KEY ("subdiv_id") REFERENCES "sites"."subdivisions"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "sites"."site_subdivisions" DROP CONSTRAINT "FK_658bd2d307dc4205b529993cddd"`);
+        await queryRunner.query(`ALTER TABLE "sites"."site_subdivisions" DROP CONSTRAINT "FK_a832b6c43076e628fe78d50fb45"`);
+        await queryRunner.query(`DROP INDEX "sites"."site_subdivisions_site_id_subdiv_id_sprof_date_completed_key"`);
+        await queryRunner.query(`ALTER TABLE "sites"."site_subdivisions" ADD CONSTRAINT "UQ_71b14e3856335e7dc23fc28897b" UNIQUE ("sprof_date_completed")`);
+        await queryRunner.query(`ALTER TABLE "sites"."site_subdivisions" ADD CONSTRAINT "UQ_658bd2d307dc4205b529993cddd" UNIQUE ("subdiv_id")`);
+        await queryRunner.query(`ALTER TABLE "sites"."site_subdivisions" ADD CONSTRAINT "UQ_a832b6c43076e628fe78d50fb45" UNIQUE ("site_id")`);
+        await queryRunner.query(`ALTER TABLE "sites"."site_subdivisions" ADD CONSTRAINT "FK_a832b6c43076e628fe78d50fb45" FOREIGN KEY ("site_id") REFERENCES "sites"."sites"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "site_subdivisions_site_id_subdiv_id_sprof_date_completed_key" ON "sites"."site_subdivisions" ("site_id", "subdiv_id", "sprof_date_completed") `);
+    }
+
+}


### PR DESCRIPTION
# SRS-373 External - Parcel Description Page Purchased - Site Details

This update correctly models the One-To-Many relationship between `sites` and `site_subdivisions` and the One-To-Many relationship between `subdivisions` and `site_subdivisions`. The result is a Many-To-Many relationship between `sites` and `subdivisions` through `site_subdivisions`.

Due to the size and complexity of this feature I'll be making a number of pull requests:

[x] Database Migration
[ ] Backend functionality for internal users
[ ] Shared component updates
[ ] Front end functionality for internal users
[ ] External user (snapshot) support for both front end and back end.