### PR TITLE
Update the column names in BaseAuditEntity

### DIFF
--- a/backend/sites/src/app/entities/baseAuditEntity.ts
+++ b/backend/sites/src/app/entities/baseAuditEntity.ts
@@ -18,10 +18,18 @@ export class BaseAuditEntity {
   whoUpdated: string | null;
 
   @Field()
-  @CreateDateColumn({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  @CreateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP',
+    name: 'when_created',
+  })
   whenCreated: Date;
 
   @Field({ nullable: true })
-  @UpdateDateColumn({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  @UpdateDateColumn({
+    type: 'timestamp',
+    default: () => 'CURRENT_TIMESTAMP',
+    name: 'when_updated',
+  })
   whenUpdated: Date | null;
 }

--- a/backend/sites/src/migrations/1724794644045-master-script.ts
+++ b/backend/sites/src/migrations/1724794644045-master-script.ts
@@ -1,0 +1,131 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MasterScript1724794644045 implements MigrationInterface {
+  name = 'MasterScript1724794644045';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "sites"."cart" DROP COLUMN "whenCreated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."cart" DROP COLUMN "whenUpdated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."folio" DROP COLUMN "whenCreated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."folio" DROP COLUMN "whenUpdated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."folio_contents" DROP COLUMN "whenCreated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."folio_contents" DROP COLUMN "whenUpdated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."snapshots" DROP COLUMN "whenCreated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."snapshots" DROP COLUMN "whenUpdated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."user" DROP COLUMN "whenCreated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."user" DROP COLUMN "whenUpdated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."cart" ADD "when_created" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."cart" ADD "when_updated" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."folio" ADD "when_created" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."folio" ADD "when_updated" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."folio_contents" ADD "when_created" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."folio_contents" ADD "when_updated" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."snapshots" ADD "when_created" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."snapshots" ADD "when_updated" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."user" ADD "when_created" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."user" ADD "when_updated" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "sites"."user" DROP COLUMN "when_updated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."user" DROP COLUMN "when_created"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."snapshots" DROP COLUMN "when_updated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."snapshots" DROP COLUMN "when_created"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."folio_contents" DROP COLUMN "when_updated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."folio_contents" DROP COLUMN "when_created"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."folio" DROP COLUMN "when_updated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."folio" DROP COLUMN "when_created"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."cart" DROP COLUMN "when_updated"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."cart" DROP COLUMN "when_created"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."user" ADD "whenUpdated" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."user" ADD "whenCreated" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."snapshots" ADD "whenUpdated" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."snapshots" ADD "whenCreated" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."folio_contents" ADD "whenUpdated" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."folio_contents" ADD "whenCreated" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."folio" ADD "whenUpdated" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."folio" ADD "whenCreated" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."cart" ADD "whenUpdated" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."cart" ADD "whenCreated" TIMESTAMP NOT NULL DEFAULT now()`,
+    );
+  }
+}


### PR DESCRIPTION
The existing column names were not recognised due to some issue with the camelCase Convention. Thus renaming whenCreated to when_created and whenUpdated to when_updated.