### PR TITLE
SRS-373 Implement getMostRecentSnapshot

### DIFF
--- a/backend/sites/src/app/services/snapshot/snapshot.service.spec.ts
+++ b/backend/sites/src/app/services/snapshot/snapshot.service.spec.ts
@@ -534,6 +534,79 @@ describe('SnapshotService', () => {
     });
   });
 
+  describe('getMostRecentSnapshot', () => {
+    it('should return a single snapshot for a given userId and siteId', async () => {
+      const userId = '1';
+      const siteId = '1';
+      const res: Snapshots = {
+        id: 1,
+        userId: '1',
+        siteId: '1',
+        transactionId: '1',
+        whenCreated: new Date(2024, 8, 28),
+        whoCreated: 'ABC',
+        whenUpdated: new Date(2024, 8, 28),
+        whoUpdated: 'ABC',
+        site: sampleSites[0],
+        snapshotData: {
+          sitesSummary: sampleSites[0],
+          documents: null,
+          events: null,
+          eventsParticipants: null,
+          landHistories: null,
+          profiles: null,
+          siteAssociations: null,
+          subDivisions: null,
+          siteParticipants: null,
+        },
+      };
+      jest
+        .spyOn(snapshotRepository, 'findOne')
+        .mockResolvedValueOnce(res as Snapshots);
+      const snapshot = await service.getMostRecentSnapshot(siteId, userId);
+
+      expect(snapshot).toEqual(res);
+      expect(snapshotRepository.findOne).toHaveBeenCalledTimes(1);
+      expect(snapshotRepository.findOne).toHaveBeenCalledWith({
+        where: { siteId, userId },
+        order: { whenCreated: 'DESC' },
+      });
+    });
+
+    it('should throw an error if repository throws an error', async () => {
+      const userId = '1';
+      const siteId = '1';
+      const errorMessage = 'Failed to retrieve the most recent snapshot';
+      jest
+        .spyOn(snapshotRepository, 'findOne')
+        .mockRejectedValueOnce(new Error(errorMessage));
+
+      await expect(
+        service.getMostRecentSnapshot(siteId, userId),
+      ).rejects.toThrow(errorMessage);
+      expect(snapshotRepository.findOne).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when there are no results', () => {
+    it('returns null', async () => {
+      const userId = '1';
+      const siteId = '1';
+      const res: Snapshots = null;
+      jest
+        .spyOn(snapshotRepository, 'findOne')
+        .mockResolvedValueOnce(res as Snapshots);
+      const snapshot = await service.getMostRecentSnapshot(siteId, userId);
+
+      expect(snapshot).toBeNull();
+      expect(snapshotRepository.findOne).toHaveBeenCalledTimes(1);
+      expect(snapshotRepository.findOne).toHaveBeenCalledWith({
+        where: { siteId, userId },
+        order: { whenCreated: 'DESC' },
+      });
+    });
+  });
+
   describe('getSnapshotsById', () => {
     it('should return an array of snapshots for a given id', async () => {
       const id = 1;

--- a/backend/sites/src/app/services/snapshot/snapshot.service.ts
+++ b/backend/sites/src/app/services/snapshot/snapshot.service.ts
@@ -72,6 +72,19 @@ export class SnapshotsService {
     }
   }
 
+  async getMostRecentSnapshot(siteId: string, userId: string) {
+    try {
+      const result = await this.snapshotRepository.findOne({
+        where: { siteId, userId },
+        order: { whenCreated: 'DESC' },
+      });
+
+      return result;
+    } catch (error) {
+      throw new Error('Failed to retrieve the most recent snapshot.');
+    }
+  }
+
   async getSnapshotsById(id: number) {
     try {
       const result = await this.snapshotRepository.find({ where: { id } });


### PR DESCRIPTION
This PR implements a helper method on the snapshot service to retrieve the most recent snapshot by user id and site id. I intend to use this in the Parcel Description service when finding data for external users.