### PR TITLE
Fix mock data, and graphql typing

### DIFF
--- a/backend/sites/src/app/dto/parcelDescription.dto.ts
+++ b/backend/sites/src/app/dto/parcelDescription.dto.ts
@@ -1,5 +1,12 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { IsInt, IsDate, IsString } from 'class-validator';
+import { PagedResponseDto } from './response/response.dto';
+
+@ObjectType()
+export class ParcelDescriptionsResponse extends PagedResponseDto {
+  @Field(() => [ParcelDescriptionDto], { nullable: true })
+  data: ParcelDescriptionDto[] | null;
+}
 
 @ObjectType()
 export class ParcelDescriptionDto {

--- a/backend/sites/src/app/dto/response/genericResponseProvider.ts
+++ b/backend/sites/src/app/dto/response/genericResponseProvider.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { GenericResponse } from './genericResponse';
+import { GenericPagedResponse, GenericResponse } from './genericResponse';
 
 @Injectable()
 export class GenericResponseProvider<T> {

--- a/backend/sites/src/app/dto/response/response.dto.ts
+++ b/backend/sites/src/app/dto/response/response.dto.ts
@@ -16,3 +16,15 @@ export class ResponseDto {
   @Field(() => String, { nullable: true })
   timestamp?: string;
 }
+
+@ObjectType()
+export class PagedResponseDto extends ResponseDto {
+  @Field(() => Number, { nullable: true })
+  count?: number;
+
+  @Field(() => Number, { nullable: true })
+  page?: number;
+
+  @Field(() => Number, { nullable: true })
+  pageSize?: number;
+}

--- a/backend/sites/src/app/mockData/site.mockData.ts
+++ b/backend/sites/src/app/mockData/site.mockData.ts
@@ -128,6 +128,8 @@ siteSubdivisions = [
     sendToSr: 'Y',
     site: null,
     subdivision: null,
+    userAction: '',
+    srAction: '',
   },
   {
     siteSubdivId: '457',
@@ -143,6 +145,8 @@ siteSubdivisions = [
     sendToSr: 'Y',
     site: null,
     subdivision: null,
+    userAction: '',
+    srAction: '',
   },
   {
     siteSubdivId: '458',
@@ -158,6 +162,8 @@ siteSubdivisions = [
     sendToSr: 'Y',
     site: null,
     subdivision: null,
+    userAction: '',
+    srAction: '',
   },
 ];
 

--- a/backend/sites/src/app/resolvers/parcelDescription/parcelDescription.resolver.ts
+++ b/backend/sites/src/app/resolvers/parcelDescription/parcelDescription.resolver.ts
@@ -3,8 +3,7 @@ import { Resource, RoleMatchingMode, Roles } from 'nest-keycloak-connect';
 import { Subdivisions } from '../../entities/subdivisions.entity';
 import { ParcelDescriptionsService } from '../../services/parcelDescriptions/parcelDescriptions.service';
 import { CustomRoles } from '../../common/role';
-import { GenericPagedResponse } from '../../dto/response/genericResponse';
-import { ParcelDescriptionDto } from '../../dto/parcelDescription.dto';
+import { ParcelDescriptionsResponse } from '../../dto/parcelDescription.dto';
 
 /**
  * Resolver for Parcel Description
@@ -30,7 +29,7 @@ export class ParcelDescriptionResolver {
     roles: [CustomRoles.Internal, CustomRoles.SiteRegistrar],
     mode: RoleMatchingMode.ANY,
   })
-  @Query(() => GenericPagedResponse<ParcelDescriptionDto>, {
+  @Query(() => ParcelDescriptionsResponse, {
     name: 'getParcelDescriptionsBySiteId',
   })
   async getParcelDescriptionsBySiteId(


### PR DESCRIPTION
I discovered some issues with my previous backend PR that prevent the site from starting and have corrected them here. Specifically, the mock data I added was from before we had the `useraction` and `sraction` columns, and when I changed the return type for the resolver to use a generic response, I didn't create one for nest-graphql to parse.