### PR TITLE
Remove custom css for parceldescriptions

### DIFF
--- a/frontend/site-registry/src/app/features/details/parcelDescriptions/parcelDescriptions.css
+++ b/frontend/site-registry/src/app/features/details/parcelDescriptions/parcelDescriptions.css
@@ -1,4 +1,0 @@
-.custom-input-text {
-  white-space: nowrap;
-  overflow-x: auto;
-}

--- a/frontend/site-registry/src/app/features/details/parcelDescriptions/parcelDescriptions.tsx
+++ b/frontend/site-registry/src/app/features/details/parcelDescriptions/parcelDescriptions.tsx
@@ -18,7 +18,6 @@ import {
   setSortByInputValue,
 } from './parcelDescriptionsSlice';
 import { columns } from './parcelDescriptionsConfig';
-import './parcelDescriptions.css';
 import { useParams } from 'react-router-dom';
 
 const ParcelDescriptions = () => {


### PR DESCRIPTION
This removes the CSS I made to make the table scroll horizontally because it was breaking the table header. I'll check with design to confirm what the desired behaviour with long strings should be, but for now I think it's okay to let it wrap even if it looks bad on mobile.