### PR TITLE
SRS-373 Refactor parcel descriptions backend

### DIFF
--- a/backend/sites/src/app/services/parcelDescriptions/parcelDescriptions.queryBuilder.spec.ts
+++ b/backend/sites/src/app/services/parcelDescriptions/parcelDescriptions.queryBuilder.spec.ts
@@ -1,0 +1,174 @@
+import { getInternalUserQueries } from './parcelDescriptions.queryBuilder';
+
+describe('ParcelDescriptionsQueryBuilder', () => {
+  describe('getInternalUserQueries', () => {
+    let siteId: number = 1;
+    let filterTerm: string = 'filterTerm';
+    let offset: number = 0;
+    let limit: number = 5;
+    let orderBy: string = 'id';
+    let orderByDir: string = 'DESC';
+
+    describe('when everything is correct.', () => {
+      it('Returns the main query', () => {
+        const [query, _queryParams, _countQuery, _countQueryParams] =
+          getInternalUserQueries(
+            siteId,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(query).toEqual(
+          expect.stringMatching(/.*sites\.site_subdivisions\.site_id = \$1.*/),
+        );
+        expect(query).not.toEqual(expect.stringMatching(/.*COUNT.*/));
+      });
+
+      it('Sorts the main query', () => {
+        const [query, _queryParams, _countQuery, _countQueryParams] =
+          getInternalUserQueries(
+            siteId,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(query).toEqual(
+          expect.stringMatching(/.*ORDER BY parcel_descriptions\.id DESC.*/),
+        );
+      });
+
+      it('Pages the main query', () => {
+        const [query, _queryParams, _countQuery, _countQueryParams] =
+          getInternalUserQueries(
+            siteId,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(query).toEqual(expect.stringMatching(/.*OFFSET.*/));
+        expect(query).toEqual(expect.stringMatching(/.*LIMIT.*/));
+      });
+
+      it('Returns the expected main query parameters', () => {
+        const [_query, queryParams, _countQuery, _countQueryParams] =
+          getInternalUserQueries(
+            siteId,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(queryParams).toEqual(expect.arrayContaining([String(siteId)]));
+        expect(queryParams).toEqual(expect.arrayContaining([filterTerm]));
+        expect(queryParams).toEqual(expect.arrayContaining([String(offset)]));
+        expect(queryParams).toEqual(expect.arrayContaining([String(limit)]));
+      });
+
+      it('Returns a count query.', () => {
+        const [_query, _queryParams, countQuery, _countQueryParams] =
+          getInternalUserQueries(
+            siteId,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(countQuery).toEqual(
+          expect.stringMatching(/.*sites\.site_subdivisions\.site_id = \$1.*/),
+        );
+        expect(countQuery).toEqual(expect.stringMatching(/.*COUNT.*/));
+      });
+
+      it('Does not sort the count query.', () => {
+        const [_query, _queryParams, countQuery, _countQueryParams] =
+          getInternalUserQueries(
+            siteId,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(countQuery).not.toEqual(
+          expect.stringMatching(/.*ORDER BY parcel_descriptions\.id DESC.*/),
+        );
+      });
+
+      it('Does not page the count query.', () => {
+        const [_query, _queryParams, countQuery, _countQueryParams] =
+          getInternalUserQueries(
+            siteId,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(countQuery).not.toEqual(expect.stringMatching(/.*OFFSET.*/));
+        expect(countQuery).not.toEqual(expect.stringMatching(/.*LIMIT.*/));
+      });
+
+      it('Returns the correct query parameters for the count query', () => {
+        const [_query, _queryParams, _countQuery, countQueryParams] =
+          getInternalUserQueries(
+            siteId,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(countQueryParams).toEqual(
+          expect.arrayContaining([String(siteId)]),
+        );
+        expect(countQueryParams).toEqual(expect.arrayContaining([filterTerm]));
+      });
+    });
+
+    describe('when the orderBy is invalid', () => {
+      it('defaults to ordering by id', () => {
+        let orderBy = 'blunderbuss';
+        const [query, _queryParams, _countQuery, _countQueryParams] =
+          getInternalUserQueries(
+            siteId,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(query).not.toEqual(expect.stringMatching(/blunderbuss/));
+        expect(query).toEqual(
+          expect.stringMatching(/.*ORDER BY parcel_descriptions\.id DESC.*/),
+        );
+      });
+    });
+
+    describe('when the sortDir is invalid', () => {
+      it('defaults to ascending', () => {
+        let orderByDir = 'turnwise';
+        const [query, _queryParams, _countQuery, _countQueryParams] =
+          getInternalUserQueries(
+            siteId,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(query).not.toEqual(expect.stringMatching(/turnwuse/));
+        expect(query).toEqual(
+          expect.stringMatching(/.*ORDER BY parcel_descriptions\.id ASC.*/),
+        );
+      });
+    });
+  });
+});

--- a/backend/sites/src/app/services/parcelDescriptions/parcelDescriptions.queryBuilder.ts
+++ b/backend/sites/src/app/services/parcelDescriptions/parcelDescriptions.queryBuilder.ts
@@ -1,0 +1,108 @@
+// The Parcel Descriptions table (front end) is constructed from some
+// conditional values on the subdivisions table (database). TypeORM doesn't
+// allow us to be this expressive so we've elected to write a raw SQL query.
+// Based on briefly profiling this query this method is somewhat more
+// efficient than querying all the subdivisions for a site and performing
+// the sorting, filtering, and pagination in Node.
+const internalUserQuery = `
+  SELECT
+    parcel_descriptions.id,
+    parcel_descriptions.description_type,
+    parcel_descriptions.id_pin_number,
+    parcel_descriptions.date_noted,
+    parcel_descriptions.land_description
+  FROM (
+    SELECT
+      sites.subdivisions.id AS id,
+      CASE
+        WHEN sites.subdivisions.pid IS NOT NULL THEN 'Parcel ID'
+        WHEN sites.subdivisions.pin IS NOT NULL THEN 'Crown Land PIN'
+        WHEN sites.subdivisions.crown_lands_file_no IS NOT NULL THEN 'Crown Land File Number'
+        ELSE 'Unknown'
+      END AS description_type,
+      CASE
+        WHEN sites.subdivisions.pid IS NOT NULL THEN sites.subdivisions.pid
+        WHEN sites.subdivisions.pin IS NOT NULL THEN sites.subdivisions.pin
+        WHEN sites.subdivisions.crown_lands_file_no IS NOT NULL THEN sites.subdivisions.crown_lands_file_no
+        ELSE NULL
+      END AS id_pin_number,
+      sites.subdivisions.date_noted AS date_noted,
+      sites.subdivisions.legal_description AS land_description
+    FROM sites.site_subdivisions
+    LEFT JOIN sites.subdivisions 
+      ON sites.site_subdivisions.subdiv_id = sites.subdivisions.id
+    WHERE sites.site_subdivisions.site_id = $1
+  ) parcel_descriptions
+  WHERE (
+    LOWER(parcel_descriptions.description_type) ~* $2
+    OR LOWER(parcel_descriptions.id_pin_number) ~* $2
+    OR LOWER(CAST(parcel_descriptions.date_noted AS TEXT)) ~* $2
+    OR LOWER(parcel_descriptions.land_description) ~* $2
+  )
+`;
+
+const getSanitizedSiteId = (siteId: number) => {
+  return String(siteId);
+};
+
+const getSanitizedFilterTerm = (filterTerm: string) => {
+  return filterTerm ? filterTerm : '';
+};
+
+const getSanitizedOffset = (offset: number) => {
+  return String(offset);
+};
+
+const getSanitizedPageSize = (pageSize: number) => {
+  return String(pageSize);
+};
+
+const getSanitizedOrderBy = (orderBy: string) => {
+  return [
+    'id',
+    'description_type',
+    'id_pin_number',
+    'date_noted',
+    'land_description',
+  ].includes(orderBy)
+    ? `parcel_descriptions.${orderBy}`
+    : `parcel_descriptions.id`;
+};
+
+const getSanitizedOrderByDir = (orderByDir: string) => {
+  return orderByDir === 'DESC' ? 'DESC' : 'ASC';
+};
+
+export const getInternalUserQueries = (
+  siteId: number,
+  filterTerm: string,
+  limit: number,
+  pageSize: number,
+  orderBy: string,
+  orderByDir: string,
+): [string, string[], string, string[]] => {
+  const sanitizedSiteId = getSanitizedSiteId(siteId);
+  const sanitizedFilterTerm = getSanitizedFilterTerm(filterTerm);
+  const sanitizedOffset = getSanitizedOffset(limit);
+  const sanitizedPageSize = getSanitizedPageSize(pageSize);
+  const sanitizedOrderBy = getSanitizedOrderBy(orderBy);
+  const sanitizedOrderByDir = getSanitizedOrderByDir(orderByDir);
+
+  let query: string = internalUserQuery;
+  const countQuery: string = `SELECT COUNT(*) FROM ( ${query} ) AS subquery`;
+  // Add sorting and pagination. Including sorting here is a minor
+  // optimization so that it isn't included in the count query.
+  query += `
+    ORDER BY ${sanitizedOrderBy} ${sanitizedOrderByDir}
+    OFFSET $3
+    LIMIT $4 
+  `;
+  const queryParams: string[] = [
+    sanitizedSiteId,
+    sanitizedFilterTerm,
+    sanitizedOffset,
+    sanitizedPageSize,
+  ];
+  const countQueryParams: string[] = [sanitizedSiteId, sanitizedFilterTerm];
+  return [query, queryParams, countQuery, countQueryParams];
+};

--- a/backend/sites/src/app/services/parcelDescriptions/parcelDescriptions.service.ts
+++ b/backend/sites/src/app/services/parcelDescriptions/parcelDescriptions.service.ts
@@ -3,6 +3,7 @@ import { InjectEntityManager } from '@nestjs/typeorm';
 import { EntityManager } from 'typeorm';
 import { ParcelDescriptionDto } from '../../dto/parcelDescription.dto';
 import { GenericPagedResponse } from '../../dto/response/genericResponse';
+import { getInternalUserQueries } from './parcelDescriptions.queryBuilder';
 
 @Injectable()
 export class ParcelDescriptionsService {
@@ -29,77 +30,20 @@ export class ParcelDescriptionsService {
     sortDir: string,
   ): Promise<GenericPagedResponse<ParcelDescriptionDto[]>> {
     // Sanitize the query parameters.
-    const filterTerm = searchParam ? searchParam : '';
-    const orderBy = [
-      'id',
-      'description_type',
-      'id_pin_number',
-      'date_noted',
-      'land_description',
-    ].includes(sortParam)
-      ? `parcel_descriptions.${sortParam}`
-      : `parcel_descriptions.id`;
-    const orderByDir = sortDir == 'DESC' ? 'DESC' : 'ASC';
     const offset = (page - 1) * pageSize;
-    const countQueryParams: string[] = [String(siteId), filterTerm];
-    const queryParams: string[] = [
-      String(siteId),
-      filterTerm,
-      String(offset),
-      String(pageSize),
-    ];
+    let query: string;
+    let queryParams: string[];
+    let countQuery: string;
+    let countQueryParams: string[];
 
-    // The Parcel Descriptions table (front end) is constructed from some
-    // conditional values on the subdivisions table (database). TypeORM doesn't
-    // allow us to be this expressive so we've elected to write a raw SQL query.
-    // Based on briefly profiling this query this method is somewhat more
-    // efficient than querying all the subdivisions for a site and performing
-    // the sorting, filtering, and pagination in Node.
-    let query = `
-      SELECT
-        parcel_descriptions.id,
-        parcel_descriptions.description_type,
-        parcel_descriptions.id_pin_number,
-        parcel_descriptions.date_noted,
-        parcel_descriptions.land_description
-      FROM (
-        SELECT
-          sites.subdivisions.id AS id,
-          CASE
-            WHEN sites.subdivisions.pid IS NOT NULL THEN 'Parcel ID'
-            WHEN sites.subdivisions.pin IS NOT NULL THEN 'Crown Land PIN'
-            WHEN sites.subdivisions.crown_lands_file_no IS NOT NULL THEN 'Crown Land File Number'
-            ELSE 'Unknown'
-          END AS description_type,
-          CASE
-            WHEN sites.subdivisions.pid IS NOT NULL THEN sites.subdivisions.pid
-            WHEN sites.subdivisions.pin IS NOT NULL THEN sites.subdivisions.pin
-            WHEN sites.subdivisions.crown_lands_file_no IS NOT NULL THEN sites.subdivisions.crown_lands_file_no
-            ELSE NULL
-          END AS id_pin_number,
-          sites.subdivisions.date_noted AS date_noted,
-          sites.subdivisions.legal_description AS land_description
-        FROM sites.site_subdivisions
-        LEFT JOIN sites.subdivisions 
-          ON sites.site_subdivisions.subdiv_id = sites.subdivisions.id
-        WHERE sites.site_subdivisions.site_id = $1
-      ) parcel_descriptions
-      WHERE (
-        LOWER(parcel_descriptions.description_type) ~* $2
-        OR LOWER(parcel_descriptions.id_pin_number) ~* $2
-        OR LOWER(CAST(parcel_descriptions.date_noted AS TEXT)) ~* $2
-        OR LOWER(parcel_descriptions.land_description) ~* $2
-      )
-    `;
-    const countQuery = `SELECT COUNT(*) FROM ( ${query} ) AS subquery`;
-
-    // Add sorting and pagination. Including sorting here is a minor
-    // optimization so that it isn't included in the count query.
-    query += `
-      ORDER BY ${orderBy} ${orderByDir}
-      OFFSET $3
-      LIMIT $4 
-    `;
+    [query, queryParams, countQuery, countQueryParams] = getInternalUserQueries(
+      siteId,
+      searchParam,
+      offset,
+      pageSize,
+      sortParam,
+      sortDir,
+    );
 
     let countResult: any;
     let rawResults: any;


### PR DESCRIPTION
When implementing snapshot support, which requires a different SQL query, I became unhappy with managing the two different queries in the same file as the logic to execute the queries. This PR separates that logic into two different files. The Parcel Description Service is responsible for executing the query and constructing the results. The new query builder is responsible to generating the SQL queries and sanitizing the parameters use to make the query.