### PR TITLE
Implement external user/snapshot support for parcel descriptions

### DIFF
--- a/backend/sites/src/app/resolvers/parcelDescription/parcelDescription.resolver.ts
+++ b/backend/sites/src/app/resolvers/parcelDescription/parcelDescription.resolver.ts
@@ -1,5 +1,10 @@
 import { Args, Int, Query, Resolver } from '@nestjs/graphql';
-import { Resource, RoleMatchingMode, Roles } from 'nest-keycloak-connect';
+import {
+  AuthenticatedUser,
+  Resource,
+  RoleMatchingMode,
+  Roles,
+} from 'nest-keycloak-connect';
 import { Subdivisions } from '../../entities/subdivisions.entity';
 import { ParcelDescriptionsService } from '../../services/parcelDescriptions/parcelDescriptions.service';
 import { CustomRoles } from '../../common/role';
@@ -26,7 +31,11 @@ export class ParcelDescriptionResolver {
    * @returns parcel descriptions (subdivisions) belonging to the given site.
    */
   @Roles({
-    roles: [CustomRoles.Internal, CustomRoles.SiteRegistrar],
+    roles: [
+      CustomRoles.Internal,
+      CustomRoles.SiteRegistrar,
+      CustomRoles.External,
+    ],
     mode: RoleMatchingMode.ANY,
   })
   @Query(() => ParcelDescriptionsResponse, {
@@ -39,6 +48,7 @@ export class ParcelDescriptionResolver {
     @Args('searchParam', { type: () => String }) searchParam: string,
     @Args('sortBy', { type: () => String }) sortBy: string,
     @Args('sortByDir', { type: () => String }) sortByDir: string,
+    @AuthenticatedUser() user: any,
   ) {
     const response =
       await this.parcelDescriptionService.getParcelDescriptionsBySiteId(
@@ -48,6 +58,7 @@ export class ParcelDescriptionResolver {
         searchParam,
         sortBy,
         sortByDir,
+        user,
       );
 
     return response;

--- a/backend/sites/src/app/services/parcelDescriptions/parcelDescriptions.queryBuilder.spec.ts
+++ b/backend/sites/src/app/services/parcelDescriptions/parcelDescriptions.queryBuilder.spec.ts
@@ -1,4 +1,7 @@
-import { getInternalUserQueries } from './parcelDescriptions.queryBuilder';
+import {
+  getExternalUserQueries,
+  getInternalUserQueries,
+} from './parcelDescriptions.queryBuilder';
 
 describe('ParcelDescriptionsQueryBuilder', () => {
   describe('getInternalUserQueries', () => {
@@ -158,6 +161,183 @@ describe('ParcelDescriptionsQueryBuilder', () => {
         const [query, _queryParams, _countQuery, _countQueryParams] =
           getInternalUserQueries(
             siteId,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(query).not.toEqual(expect.stringMatching(/turnwuse/));
+        expect(query).toEqual(
+          expect.stringMatching(/.*ORDER BY parcel_descriptions\.id ASC.*/),
+        );
+      });
+    });
+  });
+
+  describe('getExternalUserQueries', () => {
+    let siteSubdivisionIds: string[] = ['1', '2', '3'];
+    let filterTerm: string = 'filterTerm';
+    let offset: number = 0;
+    let limit: number = 5;
+    let orderBy: string = 'id';
+    let orderByDir: string = 'DESC';
+
+    describe('when everything is correct.', () => {
+      it('Returns the main query', () => {
+        const [query, _queryParams, _countQuery, _countQueryParams] =
+          getExternalUserQueries(
+            siteSubdivisionIds,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(query).toEqual(
+          expect.stringMatching(
+            /.*sites\.site_subdivisions\.site_subdiv_id = ANY \(\$1\).*/,
+          ),
+        );
+        expect(query).not.toEqual(expect.stringMatching(/.*COUNT.*/));
+      });
+
+      it('Sorts the main query', () => {
+        const [query, _queryParams, _countQuery, _countQueryParams] =
+          getExternalUserQueries(
+            siteSubdivisionIds,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(query).toEqual(
+          expect.stringMatching(/.*ORDER BY parcel_descriptions\.id DESC.*/),
+        );
+      });
+
+      it('Pages the main query', () => {
+        const [query, _queryParams, _countQuery, _countQueryParams] =
+          getExternalUserQueries(
+            siteSubdivisionIds,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(query).toEqual(expect.stringMatching(/.*OFFSET.*/));
+        expect(query).toEqual(expect.stringMatching(/.*LIMIT.*/));
+      });
+
+      it('Returns the expected main query parameters', () => {
+        const [_query, queryParams, _countQuery, _countQueryParams] =
+          getExternalUserQueries(
+            siteSubdivisionIds,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(queryParams).toEqual(
+          expect.arrayContaining([`{${String(siteSubdivisionIds)}}`]),
+        );
+        expect(queryParams).toEqual(expect.arrayContaining([filterTerm]));
+        expect(queryParams).toEqual(expect.arrayContaining([String(offset)]));
+        expect(queryParams).toEqual(expect.arrayContaining([String(limit)]));
+      });
+
+      it('Returns a count query.', () => {
+        const [_query, _queryParams, countQuery, _countQueryParams] =
+          getExternalUserQueries(
+            siteSubdivisionIds,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(countQuery).toEqual(
+          expect.stringMatching(
+            /.*sites\.site_subdivisions\.site_subdiv_id = ANY \(\$1\).*/,
+          ),
+        );
+        expect(countQuery).toEqual(expect.stringMatching(/.*COUNT.*/));
+      });
+
+      it('Does not sort the count query.', () => {
+        const [_query, _queryParams, countQuery, _countQueryParams] =
+          getExternalUserQueries(
+            siteSubdivisionIds,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(countQuery).not.toEqual(
+          expect.stringMatching(/.*ORDER BY parcel_descriptions\.id DESC.*/),
+        );
+      });
+
+      it('Does not page the count query.', () => {
+        const [_query, _queryParams, countQuery, _countQueryParams] =
+          getExternalUserQueries(
+            siteSubdivisionIds,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(countQuery).not.toEqual(expect.stringMatching(/.*OFFSET.*/));
+        expect(countQuery).not.toEqual(expect.stringMatching(/.*LIMIT.*/));
+      });
+
+      it('Returns the correct query parameters for the count query', () => {
+        const [_query, _queryParams, _countQuery, countQueryParams] =
+          getExternalUserQueries(
+            siteSubdivisionIds,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(countQueryParams).toEqual(
+          expect.arrayContaining([`{${String(siteSubdivisionIds)}}`]),
+        );
+        expect(countQueryParams).toEqual(expect.arrayContaining([filterTerm]));
+      });
+    });
+
+    describe('when the orderBy is invalid', () => {
+      it('defaults to ordering by id', () => {
+        let orderBy = 'blunderbuss';
+        const [query, _queryParams, _countQuery, _countQueryParams] =
+          getExternalUserQueries(
+            siteSubdivisionIds,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+          );
+        expect(query).not.toEqual(expect.stringMatching(/blunderbuss/));
+        expect(query).toEqual(
+          expect.stringMatching(/.*ORDER BY parcel_descriptions\.id DESC.*/),
+        );
+      });
+    });
+
+    describe('when the sortDir is invalid', () => {
+      it('defaults to ascending', () => {
+        let orderByDir = 'turnwise';
+        const [query, _queryParams, _countQuery, _countQueryParams] =
+          getExternalUserQueries(
+            siteSubdivisionIds,
             filterTerm,
             offset,
             limit,


### PR DESCRIPTION
# SRS-373 External - Parcel Description Page Purchased - Site Details

This is the final (YAY) PR for SRS-373. It implements external user (snapshot) support for parcel descriptions. Edit mode will be up next and handled in SRS-361

Due to the size and complexity of this feature I'll be making a number of pull requests:

- [x] Database Migration
- [x] Backend functionality for internal users
- [x] Shared component updates
- [x] Front end functionality for internal users
- [x] External user (snapshot) support for both front end and back end.