### PR TITLE
Convert imports to relative file paths.

### DIFF
--- a/backend/sites/src/app/resolvers/document/document.resolver.ts
+++ b/backend/sites/src/app/resolvers/document/document.resolver.ts
@@ -7,9 +7,7 @@ import { GenericValidationPipe } from '../../utils/validations/genericValidation
 import { UsePipes } from '@nestjs/common';
 import { DocumentDto, DocumentResponse } from '../../dto/document.dto';
 import { CustomRoles } from '../../common/role';
-import { LoggerService } from 'src/app/logger/logger.service';
-
-
+import { LoggerService } from '../../logger/logger.service';
 
 @Resolver(() => SiteDocs)
 export class DocumentResolver {
@@ -18,7 +16,7 @@ export class DocumentResolver {
     private readonly genericResponseProvider: GenericResponseProvider<
       DocumentDto[]
     >,
-    private readonly sitesLogger: LoggerService
+    private readonly sitesLogger: LoggerService,
   ) {}
 
   @Roles({
@@ -36,11 +34,13 @@ export class DocumentResolver {
     @Args('pending', { type: () => Boolean, nullable: true })
     showPending: boolean,
   ) {
-
     this.sitesLogger.log(
       'DocumentResolver.getSiteDocumentsBySiteId() start siteId:' +
         ' ' +
-        siteId  +' showPending = '+ showPending );
+        siteId +
+        ' showPending = ' +
+        showPending,
+    );
 
     const response = await this.documentService.getSiteDocumentsBySiteId(
       siteId,

--- a/backend/sites/src/app/resolvers/folio/folio.resolver.ts
+++ b/backend/sites/src/app/resolvers/folio/folio.resolver.ts
@@ -7,14 +7,14 @@ import {
 } from 'nest-keycloak-connect';
 import { GenericResponseProvider } from '../../dto/response/genericResponseProvider';
 import { GenericValidationPipe } from '../../utils/validations/genericValidationPipe';
-import { Folio } from 'src/app/entities/folio.entity';
+import { Folio } from '../../entities/folio.entity';
 import { FolioService } from '../../services/folio/folio.service';
-import { FolioDTO, FolioMinDTO, FolioResponse } from 'src/app/dto/folio.dto';
+import { FolioDTO, FolioMinDTO, FolioResponse } from '../../dto/folio.dto';
 import {
   FolioContentDTO,
   FolioContentResponse,
-} from 'src/app/dto/folioContent.dto';
-import { FolioContents } from 'src/app/entities/folioContents.entity';
+} from '../../dto/folioContent.dto';
+import { FolioContents } from '../../entities/folioContents.entity';
 import { CustomRoles } from '../../common/role';
 import { LoggerService } from '../../logger/logger.service';
 

--- a/backend/sites/src/app/resolvers/landUseCode/landUseCode.resolver.ts
+++ b/backend/sites/src/app/resolvers/landUseCode/landUseCode.resolver.ts
@@ -1,9 +1,9 @@
 import { Query, Resolver } from '@nestjs/graphql';
 import { RoleMatchingMode, Roles } from 'nest-keycloak-connect';
 import { GenericResponseProvider } from '../../dto/response/genericResponseProvider';
-import { LandUseCd } from 'src/app/entities/landUseCd.entity';
-import { LandUseCodeService } from 'src/app/services/landUseCode/landUseCode.service';
-import { LandUseCodeResponse } from 'src/app/dto/landUseCodeResponse.dto';
+import { LandUseCd } from '../../entities/landUseCd.entity';
+import { LandUseCodeService } from '../../services/landUseCode/landUseCode.service';
+import { LandUseCodeResponse } from '../../dto/landUseCodeResponse.dto';
 import { LoggerService } from '../../logger/logger.service';
 
 @Resolver(() => LandUseCd)

--- a/backend/sites/src/app/resolvers/snapshot/snapshot.resolver.spec.ts
+++ b/backend/sites/src/app/resolvers/snapshot/snapshot.resolver.spec.ts
@@ -5,7 +5,7 @@ import { CreateSnapshotDto, SnapshotResponse } from '../../dto/snapshot.dto';
 import { Snapshots } from '../../entities/snapshots.entity';
 import { sampleSites } from '../../mockData/site.mockData';
 import { GenericResponseProvider } from '../../dto/response/genericResponseProvider';
-import { BannerTypeResponse } from 'src/app/dto/response/bannerTypeResponse';
+import { BannerTypeResponse } from '../../dto/response/bannerTypeResponse';
 
 describe('SnapshotResolver', () => {
   let resolver: SnapshotsResolver;

--- a/backend/sites/src/app/services/associatedSite/associatedSite.service.ts
+++ b/backend/sites/src/app/services/associatedSite/associatedSite.service.ts
@@ -7,7 +7,7 @@ import { SiteAssocs } from '../../entities/siteAssocs.entity';
 import { AssociatedSiteDto } from '../../dto/associatedSite.dto';
 import { LoggerService } from '../../logger/logger.service';
 
-import { UserActionEnum } from 'src/app/common/userActionEnum';
+import { UserActionEnum } from '../../common/userActionEnum';
 
 @Injectable()
 export class AssociatedSiteService {
@@ -17,7 +17,7 @@ export class AssociatedSiteService {
     private readonly sitesLogger: LoggerService,
   ) {}
 
-    /**
+  /**
    * Retrieves associated sites for a given site ID and transforms the data into DTOs.
    *
    * @param siteId - The ID of the site for which associated sites are to be fetched.
@@ -37,7 +37,7 @@ export class AssociatedSiteService {
 
       if (showPending) {
         result = await this.assocSiteRepository.find({
-          where: { siteId , userAction: UserActionEnum.UPDATED  },
+          where: { siteId, userAction: UserActionEnum.UPDATED },
         });
       } else {
         result = await this.assocSiteRepository.find({

--- a/backend/sites/src/app/services/cart/cart.service.ts
+++ b/backend/sites/src/app/services/cart/cart.service.ts
@@ -8,7 +8,7 @@ import {
   CartDeleteDTOWithSiteID,
   CartDTO,
 } from '../../dto/cart.dto';
-import { LoggerService } from 'src/app/logger/logger.service';
+import { LoggerService } from '../../logger/logger.service';
 
 @Injectable()
 export class CartService {

--- a/backend/sites/src/app/services/dashboard/dashboard.service.ts
+++ b/backend/sites/src/app/services/dashboard/dashboard.service.ts
@@ -4,7 +4,7 @@ import { Repository } from 'typeorm';
 import { plainToInstance } from 'class-transformer';
 import { RecentViews } from '../../entities/recentViews.entity';
 import { RecentViewDto } from '../../dto/recentView.dto';
-import { LoggerService } from 'src/app/logger/logger.service';
+import { LoggerService } from '../../logger/logger.service';
 
 @Injectable()
 export class DashboardService {

--- a/backend/sites/src/app/services/disclosure/disclosure.service.ts
+++ b/backend/sites/src/app/services/disclosure/disclosure.service.ts
@@ -2,9 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { SiteProfiles } from '../../entities/siteProfiles.entity';
-import { LoggerService } from 'src/app/logger/logger.service';
-import { UserActionEnum } from 'src/app/common/userActionEnum';
-
+import { LoggerService } from '../../logger/logger.service';
+import { UserActionEnum } from '../../common/userActionEnum';
 
 @Injectable()
 export class DisclosureService {
@@ -14,17 +13,21 @@ export class DisclosureService {
     private readonly sitesLogger: LoggerService,
   ) {}
 
-    /**
+  /**
    * Retrieves site profiles for a given site ID.
    *
    * @param siteId - The ID of the site whose profiles are to be fetched.
    * @returns A promise that resolves to an array of SiteProfiles entities.
    * @throws Error if there is an issue retrieving the data.
    */
-  async getSiteDisclosureBySiteId(siteId: string, showPending: boolean): Promise<SiteProfiles[]> {
-
+  async getSiteDisclosureBySiteId(
+    siteId: string,
+    showPending: boolean,
+  ): Promise<SiteProfiles[]> {
     try {
-      this.sitesLogger.log('DisclosureService.getSiteDisclosureBySiteId() start');
+      this.sitesLogger.log(
+        'DisclosureService.getSiteDisclosureBySiteId() start',
+      );
       this.sitesLogger.debug(
         'DisclosureService.getSiteDisclosureBySiteId() start',
       );

--- a/backend/sites/src/app/services/document/document.service.ts
+++ b/backend/sites/src/app/services/document/document.service.ts
@@ -4,8 +4,8 @@ import { SiteDocs } from '../../entities/siteDocs.entity';
 import { Repository } from 'typeorm';
 import { plainToInstance } from 'class-transformer';
 import { DocumentDto } from '../../dto/document.dto';
-import { UserActionEnum } from 'src/app/common/userActionEnum';
-import { LoggerService } from 'src/app/logger/logger.service';
+import { UserActionEnum } from '../../common/userActionEnum';
+import { LoggerService } from '../../logger/logger.service';
 
 @Injectable()
 export class DocumentService {
@@ -15,61 +15,62 @@ export class DocumentService {
     private readonly sitesLogger: LoggerService,
   ) {}
 
-   /**
+  /**
    * Retrieves site documents by site ID and transforms the data into a specific format.
    * @param siteId - The ID of the site to retrieve documents for.
    * @returns A promise that resolves to an array of DocumentDto objects.
    * @throws Error if there is an issue retrieving the data.
    */
-  async getSiteDocumentsBySiteId(siteId: string,showPending : boolean) {
-    
+  async getSiteDocumentsBySiteId(siteId: string, showPending: boolean) {
     try {
       this.sitesLogger.log('DocumentService.getSiteDocumentsBySiteId() start');
-      this.sitesLogger.debug('DocumentService.getSiteDocumentsBySiteId() start');
+      this.sitesLogger.debug(
+        'DocumentService.getSiteDocumentsBySiteId() start',
+      );
       let result: SiteDocs[] = [];
-      if(showPending)
-      {
-        result = await this.siteDocsRepository.find({ where: { siteId , userAction: UserActionEnum.UPDATED  },
-          relations: ['siteDocPartics', 'siteDocPartics.psnorg'],  });
-      }
-      else
-      {
-        result = await this.siteDocsRepository.find({ where: { siteId } ,
-          relations: ['siteDocPartics', 'siteDocPartics.psnorg']}
-        );
-      }      
-     
-    // Process and format the documents
-    const response = result.flatMap((res) => {
-      // Base document structure
-      const document = {
-        id: res.id,
-        siteId: res.siteId,
-        title: res.title,
-        submissionDate: res.submissionDate.toISOString(),
-        documentDate: res.documentDate
-          ? res.documentDate.toISOString()
-          : null,
-      };
-
-      // If there are associated siteDocPartics, map them
-      if (res.siteDocPartics.length > 0) {
-        return res.siteDocPartics.map((sdp) => ({
-          ...document,
-          psnorgId: sdp.psnorgId,
-          displayName: sdp.psnorg.displayName,
-        }));
+      if (showPending) {
+        result = await this.siteDocsRepository.find({
+          where: { siteId, userAction: UserActionEnum.UPDATED },
+          relations: ['siteDocPartics', 'siteDocPartics.psnorg'],
+        });
+      } else {
+        result = await this.siteDocsRepository.find({
+          where: { siteId },
+          relations: ['siteDocPartics', 'siteDocPartics.psnorg'],
+        });
       }
 
-      // If no siteDocPartics, return a single document with default values
-      return [
-        {
-          ...document,
-          psnorgId: '',
-          displayName: '',
-        },
-      ];
-    });
+      // Process and format the documents
+      const response = result.flatMap((res) => {
+        // Base document structure
+        const document = {
+          id: res.id,
+          siteId: res.siteId,
+          title: res.title,
+          submissionDate: res.submissionDate.toISOString(),
+          documentDate: res.documentDate
+            ? res.documentDate.toISOString()
+            : null,
+        };
+
+        // If there are associated siteDocPartics, map them
+        if (res.siteDocPartics.length > 0) {
+          return res.siteDocPartics.map((sdp) => ({
+            ...document,
+            psnorgId: sdp.psnorgId,
+            displayName: sdp.psnorg.displayName,
+          }));
+        }
+
+        // If no siteDocPartics, return a single document with default values
+        return [
+          {
+            ...document,
+            psnorgId: '',
+            displayName: '',
+          },
+        ];
+      });
 
       // Convert plain objects to DocumentDto instances
       this.sitesLogger.log('DocumentService.getSiteDocumentsBySiteId() end');

--- a/backend/sites/src/app/services/folio/folio.service.ts
+++ b/backend/sites/src/app/services/folio/folio.service.ts
@@ -7,7 +7,7 @@ import { plainToInstance } from 'class-transformer';
 import { FolioContentsService } from './folioContents.service';
 import { FolioContentDTO } from '../../dto/folioContent.dto';
 import { FolioContents } from '../../entities/folioContents.entity';
-import { LoggerService } from 'src/app/logger/logger.service';
+import { LoggerService } from '../../logger/logger.service';
 
 @Injectable()
 export class FolioService {

--- a/backend/sites/src/app/services/folio/folioContents.service.ts
+++ b/backend/sites/src/app/services/folio/folioContents.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { FolioContents } from '../../entities/folioContents.entity';
 import { Repository } from 'typeorm';
 import { FolioContentDTO } from '../../dto/folioContent.dto';
-import { LoggerService } from 'src/app/logger/logger.service';
+import { LoggerService } from '../../logger/logger.service';
 
 @Injectable()
 export class FolioContentsService {

--- a/backend/sites/src/app/services/landHistory/landHistory.service.spec.ts
+++ b/backend/sites/src/app/services/landHistory/landHistory.service.spec.ts
@@ -3,7 +3,7 @@ import { LandHistoryService } from './landHistory.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { LandHistories } from '../../entities/landHistories.entity';
 import { In } from 'typeorm';
-import { LandHistoriesInputDTO } from 'src/app/dto/landHistoriesInput.dto';
+import { LandHistoriesInputDTO } from '../../dto/landHistoriesInput.dto';
 import { TransactionManagerService } from '../transactionManager/transactionManager.service';
 import { REQUEST } from '@nestjs/core';
 

--- a/backend/sites/src/app/services/landHistory/landHistory.service.ts
+++ b/backend/sites/src/app/services/landHistory/landHistory.service.ts
@@ -2,12 +2,12 @@ import { v4 } from 'uuid';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, Brackets, In } from 'typeorm';
 import { LandHistories } from '../../entities/landHistories.entity';
-import { LandHistoriesInputDTO } from 'src/app/dto/landHistoriesInput.dto';
+import { LandHistoriesInputDTO } from '../../dto/landHistoriesInput.dto';
 import { TransactionManagerService } from '../transactionManager/transactionManager.service';
-import { LoggerService } from 'src/app/logger/logger.service';
+import { LoggerService } from '../../logger/logger.service';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 
-import { UserActionEnum } from 'src/app/common/userActionEnum';
+import { UserActionEnum } from '../../common/userActionEnum';
 
 export class LandHistoryService {
   constructor(
@@ -21,7 +21,7 @@ export class LandHistoryService {
     siteId: string,
     searchTerm: string,
     sortDirection: 'ASC' | 'DESC',
-    showPending: boolean
+    showPending: boolean,
   ): Promise<LandHistories[]> {
     this.sitesLogger.log('LandHistoryService.getLandHistoriesForSite() start');
     this.sitesLogger.debug(
@@ -49,13 +49,12 @@ export class LandHistoryService {
         );
       }
 
-      if(showPending)
-      {
+      if (showPending) {
         query.andWhere(
           new Brackets((qb) => {
             qb.where('landHistory.user_action = :status', {
               status: `${UserActionEnum.UPDATED}`,
-            })
+            });
           }),
         );
       }
@@ -101,9 +100,9 @@ export class LandHistoryService {
           whoCreated: curentUser.name,
           whenCreated: new Date(),
           rwmFlag: 0,
-          rwmNoteFlag: 0,   
+          rwmNoteFlag: 0,
           userAction: arg.userAction,
-          srAction: arg.srAction      
+          srAction: arg.srAction,
         };
       });
 
@@ -117,7 +116,7 @@ export class LandHistoryService {
           whoUpdated: curentUser.name,
           whenUpdated: new Date(),
           userAction: arg.userAction,
-          srAction: arg.srAction      
+          srAction: arg.srAction,
         };
 
         return [whereClause, data];

--- a/backend/sites/src/app/services/landUseCode/landUseCode.service.ts
+++ b/backend/sites/src/app/services/landUseCode/landUseCode.service.ts
@@ -1,7 +1,7 @@
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { LandUseCd } from '../../entities/landUseCd.entity';
-import { LoggerService } from 'src/app/logger/logger.service';
+import { LoggerService } from '../../logger/logger.service';
 
 export class LandUseCodeService {
   constructor(

--- a/backend/sites/src/app/services/notation/notation.service.ts
+++ b/backend/sites/src/app/services/notation/notation.service.ts
@@ -7,7 +7,7 @@ import { plainToInstance } from 'class-transformer';
 import { UserActionEnum } from '../../common/userActionEnum';
 import { SRApprovalStatusEnum } from '../../common/srApprovalStatusEnum';
 import { EventPartics } from '../../entities/eventPartics.entity';
-import { LoggerService } from 'src/app/logger/logger.service';
+import { LoggerService } from '../../logger/logger.service';
 
 @Injectable()
 export class NotationService {
@@ -19,29 +19,27 @@ export class NotationService {
     private readonly sitesLogger: LoggerService,
   ) {}
 
-    /**
+  /**
    * Fetches notations for a given site ID, including related participants.
    *
    * @param siteId - The ID of the site for which notations are to be fetched.
    * @returns An array of NotationDto objects, each containing event and participant details.
    * @throws Error if there's an issue retrieving the data.
    */
-  async getSiteNotationBySiteId(siteId: string,showPending: boolean) {
-
+  async getSiteNotationBySiteId(siteId: string, showPending: boolean) {
     this.sitesLogger.log('NotationService.getSiteNotationBySiteId() start');
     this.sitesLogger.debug('NotationService.getSiteNotationBySiteId() start');
 
     try {
       // Retrieve events associated with the given siteId
-      let events:Events[] = [];
-      
-      if(showPending)
-      {
-        events =  await this.notationRepository.find({ where: { siteId , userAction: UserActionEnum.UPDATED } });
-      }
-      else
-      {
-        events =  await this.notationRepository.find({ where: { siteId } });
+      let events: Events[] = [];
+
+      if (showPending) {
+        events = await this.notationRepository.find({
+          where: { siteId, userAction: UserActionEnum.UPDATED },
+        });
+      } else {
+        events = await this.notationRepository.find({ where: { siteId } });
       }
 
       // If no events are found, return an empty array

--- a/backend/sites/src/app/services/participant/participant.service.ts
+++ b/backend/sites/src/app/services/participant/participant.service.ts
@@ -5,10 +5,9 @@ import { SiteParticsDto } from '../../dto/sitePartics.dto';
 import { SitePartics } from '../../entities/sitePartics.entity';
 import { Repository } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid'; // Import uuid function for generating unique IDs
-import { LoggerService } from 'src/app/logger/logger.service';
-import { UserActionEnum } from 'src/app/common/userActionEnum';
+import { LoggerService } from '../../logger/logger.service';
+import { UserActionEnum } from '../../common/userActionEnum';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-
 
 @Injectable()
 export class ParticipantService {
@@ -18,17 +17,18 @@ export class ParticipantService {
     private readonly sitesLogger: LoggerService,
   ) {}
 
-   /**
+  /**
    * Retrieves site participants for a given site ID and transforms the data into DTOs.
    *
    * @param siteId - The ID of the site for which participants are to be fetched.
    * @returns An array of SiteParticsDto objects containing participant details.
    * @throws Error if there is an issue retrieving the data.
    */
-  async getSiteParticipantsBySiteId(siteId: string, showPending: boolean): Promise<SiteParticsDto[]> {
-
+  async getSiteParticipantsBySiteId(
+    siteId: string,
+    showPending: boolean,
+  ): Promise<SiteParticsDto[]> {
     try {
-
       this.sitesLogger.log(
         'ParticipantService.getSiteParticipantsBySiteId() start',
       );
@@ -39,17 +39,17 @@ export class ParticipantService {
       // Fetch site participants based on the given siteId
       let result = [];
 
-      if(showPending)
-      result = await this.siteParticsRepository.find({
-        where: { siteId, userAction: UserActionEnum.UPDATED },
-        relations: ['psnorg', 'siteParticRoles', 'siteParticRoles.prCode2'],
-      });
+      if (showPending)
+        result = await this.siteParticsRepository.find({
+          where: { siteId, userAction: UserActionEnum.UPDATED },
+          relations: ['psnorg', 'siteParticRoles', 'siteParticRoles.prCode2'],
+        });
       else
-      result = await this.siteParticsRepository.find({
-        where: { siteId },
-        relations: ['psnorg', 'siteParticRoles', 'siteParticRoles.prCode2'],
-      });
-      
+        result = await this.siteParticsRepository.find({
+          where: { siteId },
+          relations: ['psnorg', 'siteParticRoles', 'siteParticRoles.prCode2'],
+        });
+
       if (!result.length) {
         return [];
       }
@@ -79,7 +79,6 @@ export class ParticipantService {
         'ParticipantService.getSiteParticipantsBySiteId() end',
       );
       return sitePartics;
-      
     } catch (error) {
       this.sitesLogger.error(
         'Exception occured in ParticipantService.getSiteParticipantsBySiteId() end',

--- a/backend/sites/src/app/services/site/site.service.spec.ts
+++ b/backend/sites/src/app/services/site/site.service.spec.ts
@@ -14,7 +14,7 @@ import { SiteProfiles } from '../../entities/siteProfiles.entity';
 import { HistoryLog } from '../../entities/siteHistoryLog.entity';
 import { Events } from '../../entities/events.entity';
 import { SiteDocs } from '../../entities/siteDocs.entity';
-import { SaveSiteDetailsDTO } from 'src/app/dto/saveSiteDetails.dto';
+import { SaveSiteDetailsDTO } from '../../dto/saveSiteDetails.dto';
 import { LandHistoryService } from '../landHistory/landHistory.service';
 import { TransactionManagerService } from '../transactionManager/transactionManager.service';
 

--- a/backend/sites/src/app/services/site/site.service.ts
+++ b/backend/sites/src/app/services/site/site.service.ts
@@ -22,8 +22,8 @@ import { HistoryLog } from '../../entities/siteHistoryLog.entity';
 import { LandHistoryService } from '../landHistory/landHistory.service';
 import { TransactionManagerService } from '../transactionManager/transactionManager.service';
 import { UserActionEnum } from '../../common/userActionEnum';
-import { LoggerService } from 'src/app/logger/logger.service';
-import { SRApprovalStatusEnum } from 'src/app/common/srApprovalStatusEnum';
+import { LoggerService } from '../../logger/logger.service';
+import { SRApprovalStatusEnum } from '../../common/srApprovalStatusEnum';
 
 /**
  * Nestjs Service For Region Entity
@@ -254,29 +254,26 @@ export class SiteService {
    * @param siteId site Id
    * @returns a single site matching the site ID
    */
-  async findSiteBySiteId(siteId: string, pending:boolean) {
+  async findSiteBySiteId(siteId: string, pending: boolean) {
     this.sitesLogger.log('SiteService.findSiteBySiteId() start');
     this.sitesLogger.debug('SiteService.findSiteBySiteId() start');
     const response = new FetchSiteDetail();
 
     response.httpStatusCode = 200;
 
-    if(pending)
-    {
+    if (pending) {
       const result = await this.siteRepository.findOne({
-        where: { id: siteId , userAction: UserActionEnum.UPDATED },
-      });
-      
-      response.data = result ? result : null;
-    }
-    else
-    {
-      const result = await this.siteRepository.findOne({
-        where: { id: siteId  },
+        where: { id: siteId, userAction: UserActionEnum.UPDATED },
       });
 
       response.data = result ? result : null;
-    }    
+    } else {
+      const result = await this.siteRepository.findOne({
+        where: { id: siteId },
+      });
+
+      response.data = result ? result : null;
+    }
     this.sitesLogger.log('SiteService.findSiteBySiteId() end');
     this.sitesLogger.debug('SiteService.findSiteBySiteId() end');
     return response;
@@ -483,7 +480,11 @@ export class SiteService {
                 changes: {
                   ...existingPartic,
                   ...particData,
-                  userAction: (partic.srAction === SRApprovalStatusEnum.PUBLIC || partic.srAction === SRApprovalStatusEnum.PRIVATE) ? UserActionEnum.DEFAULT : UserActionEnum.UPDATED,
+                  userAction:
+                    partic.srAction === SRApprovalStatusEnum.PUBLIC ||
+                    partic.srAction === SRApprovalStatusEnum.PRIVATE
+                      ? UserActionEnum.DEFAULT
+                      : UserActionEnum.UPDATED,
                   whenUpdated: new Date(),
                   whoUpdated: userInfo ? userInfo.givenName : '',
                 },
@@ -554,7 +555,11 @@ export class SiteService {
                 ...new Events(),
                 ...existingEvent,
                 ...event,
-                userAction: (notation.srAction === SRApprovalStatusEnum.PUBLIC || notation.srAction === SRApprovalStatusEnum.PRIVATE) ? UserActionEnum.DEFAULT : UserActionEnum.UPDATED,
+                userAction:
+                  notation.srAction === SRApprovalStatusEnum.PUBLIC ||
+                  notation.srAction === SRApprovalStatusEnum.PRIVATE
+                    ? UserActionEnum.DEFAULT
+                    : UserActionEnum.UPDATED,
                 whenUpdated: new Date(),
                 whoUpdated: userInfo ? userInfo.givenName : '',
               },

--- a/backend/sites/src/app/services/snapshot/snapshot.service.ts
+++ b/backend/sites/src/app/services/snapshot/snapshot.service.ts
@@ -13,7 +13,7 @@ import { SiteSubdivisions } from '../../entities/siteSubdivisions.entity';
 import { SiteProfiles } from '../../entities/siteProfiles.entity';
 import { SnapshotSiteContent } from '../../dto/snapshotSiteContent';
 import { Events } from '../../entities/events.entity';
-import { LoggerService } from 'src/app/logger/logger.service';
+import { LoggerService } from '../../logger/logger.service';
 
 @Injectable()
 export class SnapshotsService {

--- a/backend/sites/src/app/services/user/user.service.ts
+++ b/backend/sites/src/app/services/user/user.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from '../../entities/user.entity';
 import { Repository } from 'typeorm';
-import { LoggerService } from 'src/app/logger/logger.service';
+import { LoggerService } from '../../logger/logger.service';
 
 @Injectable()
 export class UserService {


### PR DESCRIPTION
Using absolute file paths in imports causes specs to fail on my machine. I'm not sure if this is a configuration issue with me or not, but in any case they should be consistent now. There were also some prettier changes automatically applied in the files that I touched.