### PR TITLE
Update parcel description querybuilder to expose user_action and sr_action

### DIFF
--- a/backend/sites/src/app/services/parcelDescriptions/parcelDescriptions.queryBuilder.spec.ts
+++ b/backend/sites/src/app/services/parcelDescriptions/parcelDescriptions.queryBuilder.spec.ts
@@ -31,6 +31,40 @@ describe('ParcelDescriptionsQueryBuilder', () => {
         expect(query).not.toEqual(expect.stringMatching(/.*COUNT.*/));
       });
 
+      it('Queries all of the expected values.', () => {
+        const [query, _queryParams, _countQuery, _countQueryParams] =
+          getInternalUserQueries(
+            siteId,
+            filterTerm,
+            offset,
+            limit,
+            orderBy,
+            orderByDir,
+            showPending,
+          );
+        expect(query).toEqual(
+          expect.stringMatching(/.*parcel_descriptions\.id*/),
+        );
+        expect(query).toEqual(
+          expect.stringMatching(/.*parcel_descriptions\.description_type*/),
+        );
+        expect(query).toEqual(
+          expect.stringMatching(/.*parcel_descriptions\.id_pin_number*/),
+        );
+        expect(query).toEqual(
+          expect.stringMatching(/.*parcel_descriptions\.date_noted*/),
+        );
+        expect(query).toEqual(
+          expect.stringMatching(/.*parcel_descriptions\.land_description*/),
+        );
+        expect(query).toEqual(
+          expect.stringMatching(/.*parcel_descriptions\.user_action*/),
+        );
+        expect(query).toEqual(
+          expect.stringMatching(/.*parcel_descriptions\.sr_action*/),
+        );
+      });
+
       it('Sorts the main query', () => {
         const [query, _queryParams, _countQuery, _countQueryParams] =
           getInternalUserQueries(

--- a/backend/sites/src/app/services/parcelDescriptions/parcelDescriptions.queryBuilder.ts
+++ b/backend/sites/src/app/services/parcelDescriptions/parcelDescriptions.queryBuilder.ts
@@ -10,7 +10,9 @@ const parcelDescriptionQueryHead = `
     parcel_descriptions.description_type,
     parcel_descriptions.id_pin_number,
     parcel_descriptions.date_noted,
-    parcel_descriptions.land_description
+    parcel_descriptions.land_description,
+    parcel_descriptions.user_action,
+    parcel_descriptions.sr_action
   FROM (
     SELECT
       sites.subdivisions.id AS id,
@@ -27,7 +29,9 @@ const parcelDescriptionQueryHead = `
         ELSE NULL
       END AS id_pin_number,
       sites.subdivisions.date_noted AS date_noted,
-      sites.subdivisions.legal_description AS land_description
+      sites.subdivisions.legal_description AS land_description,
+      sites.site_subdivisions.user_action AS user_action,
+      sites.site_subdivisions.sr_action AS sr_action
     FROM sites.site_subdivisions
     LEFT JOIN sites.subdivisions 
       ON sites.site_subdivisions.subdiv_id = sites.subdivisions.id


### PR DESCRIPTION
This PR queries the `user_action` and `sr_action` properties from the `site_subdivision` data model in order to add these fields to the Parcel Description view model. I will follow up this PR with another that modifies the `ParcelDescriptionDTO` and GraphQL endpoint for parcel descriptions to add the `srAction` and `userAction` fields.