### PR TITLE
Add user_action and sr_action to parcel description graphql endpoint

### DIFF
--- a/backend/sites/src/app/dto/parcelDescription.dto.ts
+++ b/backend/sites/src/app/dto/parcelDescription.dto.ts
@@ -16,12 +16,16 @@ export class ParcelDescriptionDto {
     idPinNumber: string | null,
     dateNoted: Date | null,
     landDescription: string | null,
+    userAction: string | null,
+    srAction: string | null,
   ) {
     this.id = id ? id : 0;
     this.descriptionType = descriptionType ? descriptionType : 'Unknown';
     this.idPinNumber = idPinNumber ? idPinNumber : 'Unknown';
     this.dateNoted = dateNoted;
     this.landDescription = landDescription ? landDescription : '';
+    this.userAction = userAction ? userAction : '';
+    this.srAction = srAction ? srAction : '';
   }
   @Field()
   @IsInt()
@@ -42,4 +46,12 @@ export class ParcelDescriptionDto {
   @Field()
   @IsString()
   landDescription: string;
+
+  @Field()
+  @IsString()
+  userAction: string;
+
+  @Field()
+  @IsString()
+  srAction: string;
 }

--- a/backend/sites/src/app/services/parcelDescriptions/parcelDescriptions.service.spec.ts
+++ b/backend/sites/src/app/services/parcelDescriptions/parcelDescriptions.service.spec.ts
@@ -43,6 +43,8 @@ describe('SiteSubdivisionsService', () => {
   let returnIdPinNumber: string;
   let returnDateNoted: string;
   let returnLandDescription: string;
+  let returnUserAction: string;
+  let returnSrAction: string;
 
   let returnSuccess: boolean;
 
@@ -69,6 +71,8 @@ describe('SiteSubdivisionsService', () => {
     returnIdPinNumber = '123456';
     returnDateNoted = '2024-08-07T00:00:00.000Z';
     returnLandDescription = 'A parcel of land';
+    returnUserAction = 'updated';
+    returnSrAction = 'approved'; // I don't actually know if this is a real-world value it could assume.
 
     returnSuccess = true;
 
@@ -131,6 +135,8 @@ describe('SiteSubdivisionsService', () => {
           id_pin_number: returnIdPinNumber,
           date_noted: returnDateNoted,
           land_description: returnLandDescription,
+          user_action: returnUserAction,
+          sr_action: returnSrAction,
         },
       ]);
     entityManager.query = queryMock;
@@ -239,6 +245,8 @@ describe('SiteSubdivisionsService', () => {
                 idPinNumber: returnIdPinNumber,
                 dateNoted: new Date(returnDateNoted),
                 landDescription: returnLandDescription,
+                userAction: returnUserAction,
+                srAction: returnSrAction,
               }),
             ]),
             count: returnCount,
@@ -340,6 +348,8 @@ describe('SiteSubdivisionsService', () => {
                 idPinNumber: returnIdPinNumber,
                 dateNoted: new Date(returnDateNoted),
                 landDescription: returnLandDescription,
+                userAction: returnUserAction,
+                srAction: returnSrAction,
               }),
             ]),
             count: returnCount,

--- a/backend/sites/src/app/services/parcelDescriptions/parcelDescriptions.service.ts
+++ b/backend/sites/src/app/services/parcelDescriptions/parcelDescriptions.service.ts
@@ -148,6 +148,8 @@ export class ParcelDescriptionsService {
         rawResult.id_pin_number,
         new Date(rawResult.date_noted),
         rawResult.land_description,
+        rawResult.user_action,
+        rawResult.sr_action,
       );
     });
 


### PR DESCRIPTION
This PR implements returning `user_action` and `sr_action` as part of the `getParcelDescriptionBySiteId` GraphQL endpoint