### PR TITLE
update spec to correctly reflect parceldescription resolver behaviour

### DIFF
--- a/backend/sites/src/app/resolvers/parcelDescription/parcelDescription.resolver.spec.ts
+++ b/backend/sites/src/app/resolvers/parcelDescription/parcelDescription.resolver.spec.ts
@@ -72,7 +72,7 @@ describe('ParcelDescriptionResolver', () => {
       user,
     );
 
-    expect(logMock).toHaveBeenCalled();
+    expect(logMock).toHaveBeenCalledTimes(2);
   });
 
   it('calls the site subdivision service with the expected parameters.', async () => {


### PR DESCRIPTION
A quick one liner for the parcel description resolver spec. The LoggerService should be called twice.