### PR TITLE
update getBannerType to work for internal users

### DIFF
--- a/backend/sites/src/app/resolvers/snapshot/snapshot.resolver.ts
+++ b/backend/sites/src/app/resolvers/snapshot/snapshot.resolver.ts
@@ -235,7 +235,11 @@ export class SnapshotsResolver {
   }
 
   @Roles({
-    roles: [CustomRoles.External],
+    roles: [
+      CustomRoles.External,
+      CustomRoles.Internal,
+      CustomRoles.SiteRegistrar,
+    ],
     mode: RoleMatchingMode.ANY,
   })
   @Query(() => BannerTypeResponse, { name: 'getBannerType' })


### PR DESCRIPTION
Restricting this endpoint to only external users causes me to get an error about an invalid banner type response whenever I try to view a site as an internal user. @nupurdixit13 I would appreciate it if you could let me know if this is an appropriate solution or if I should modify the front end to not make the request if the logged in user is internal.