### PR TITLE
Remove the request to getBannerType for external users.

### DIFF
--- a/frontend/site-registry/src/app/features/details/SiteDetails.tsx
+++ b/frontend/site-registry/src/app/features/details/SiteDetails.tsx
@@ -261,56 +261,32 @@ const SiteDetails = () => {
     if (id) {
       dispatch(resetSaveSiteDetails(null));
       dispatch(setupSiteIdForSaving(id));
-      if (userType === UserType.External) {
-        Promise.all([
-          dispatch(fetchSnapshots(id ?? '')),
-          dispatch(getBannerType(id ?? '')),
-          dispatch(fetchMinistryContact('EMP')),
-          dispatch(fetchNotationClassCd()),
-          dispatch(fetchNotationTypeCd()),
-          dispatch(fetchNotationParticipantRoleCd()),
-          dispatch(fetchParticipantRoleCd()),
-          dispatch(
-            fetchSiteParticipants({ siteId: id ?? '', showPending: false }),
-          ),
-          dispatch(
-            fetchNotationParticipants({ siteId: id ?? '', showPending: false }),
-          ),
-          // should be based on condition for External and Internal User.
-          dispatch(fetchSitesDetails({ siteId: id ?? '', showPending: false })),
-          // dispatch(fetchNotationParticipants({ siteId: id ?? '', showPending: false})),
-        ])
-          .then(() => {
-            setIsLoading(false); // Set loading state to false after all API calls are resolved
-          })
-          .catch((error) => {
-            console.error('Error fetching data:', error);
-          });
-      } else {
-        Promise.all([
-          dispatch(fetchSnapshots(id ?? '')),
-          dispatch(fetchMinistryContact('EMP')),
-          dispatch(fetchNotationClassCd()),
-          dispatch(fetchNotationTypeCd()),
-          dispatch(fetchNotationParticipantRoleCd()),
-          dispatch(fetchParticipantRoleCd()),
-          dispatch(
-            fetchSiteParticipants({ siteId: id ?? '', showPending: false }),
-          ),
-          dispatch(
-            fetchNotationParticipants({ siteId: id ?? '', showPending: false }),
-          ),
-          // should be based on condition for External and Internal User.
-          dispatch(fetchSitesDetails({ siteId: id ?? '', showPending: false })),
-          // dispatch(fetchNotationParticipants({ siteId: id ?? '', showPending: false})),
-        ])
-          .then(() => {
-            setIsLoading(false); // Set loading state to false after all API calls are resolved
-          })
-          .catch((error) => {
-            console.error('Error fetching data:', error);
-          });
-      }
+      Promise.all([
+        dispatch(fetchSnapshots(id ?? '')),
+        userType === UserType.External
+          ? dispatch(getBannerType(id ?? ''))
+          : Promise.resolve(),
+        dispatch(fetchMinistryContact('EMP')),
+        dispatch(fetchNotationClassCd()),
+        dispatch(fetchNotationTypeCd()),
+        dispatch(fetchNotationParticipantRoleCd()),
+        dispatch(fetchParticipantRoleCd()),
+        dispatch(
+          fetchSiteParticipants({ siteId: id ?? '', showPending: false }),
+        ),
+        dispatch(
+          fetchNotationParticipants({ siteId: id ?? '', showPending: false }),
+        ),
+        // should be based on condition for External and Internal User.
+        dispatch(fetchSitesDetails({ siteId: id ?? '', showPending: false })),
+        // dispatch(fetchNotationParticipants({ siteId: id ?? '', showPending: false})),
+      ])
+        .then(() => {
+          setIsLoading(false); // Set loading state to false after all API calls are resolved
+        })
+        .catch((error) => {
+          console.error('Error fetching data:', error);
+        });
     }
   }, [id]);
 

--- a/frontend/site-registry/src/app/features/details/SiteDetails.tsx
+++ b/frontend/site-registry/src/app/features/details/SiteDetails.tsx
@@ -261,30 +261,56 @@ const SiteDetails = () => {
     if (id) {
       dispatch(resetSaveSiteDetails(null));
       dispatch(setupSiteIdForSaving(id));
-      Promise.all([
-        dispatch(fetchSnapshots(id ?? '')),
-        dispatch(getBannerType(id ?? '')),
-        dispatch(fetchMinistryContact('EMP')),
-        dispatch(fetchNotationClassCd()),
-        dispatch(fetchNotationTypeCd()),
-        dispatch(fetchNotationParticipantRoleCd()),
-        dispatch(fetchParticipantRoleCd()),
-        dispatch(
-          fetchSiteParticipants({ siteId: id ?? '', showPending: false }),
-        ),
-        dispatch(
-          fetchNotationParticipants({ siteId: id ?? '', showPending: false }),
-        ),
-        // should be based on condition for External and Internal User.
-        dispatch(fetchSitesDetails({ siteId: id ?? '', showPending: false })),
-        // dispatch(fetchNotationParticipants({ siteId: id ?? '', showPending: false})),
-      ])
-        .then(() => {
-          setIsLoading(false); // Set loading state to false after all API calls are resolved
-        })
-        .catch((error) => {
-          console.error('Error fetching data:', error);
-        });
+      if (userType === UserType.External) {
+        Promise.all([
+          dispatch(fetchSnapshots(id ?? '')),
+          dispatch(getBannerType(id ?? '')),
+          dispatch(fetchMinistryContact('EMP')),
+          dispatch(fetchNotationClassCd()),
+          dispatch(fetchNotationTypeCd()),
+          dispatch(fetchNotationParticipantRoleCd()),
+          dispatch(fetchParticipantRoleCd()),
+          dispatch(
+            fetchSiteParticipants({ siteId: id ?? '', showPending: false }),
+          ),
+          dispatch(
+            fetchNotationParticipants({ siteId: id ?? '', showPending: false }),
+          ),
+          // should be based on condition for External and Internal User.
+          dispatch(fetchSitesDetails({ siteId: id ?? '', showPending: false })),
+          // dispatch(fetchNotationParticipants({ siteId: id ?? '', showPending: false})),
+        ])
+          .then(() => {
+            setIsLoading(false); // Set loading state to false after all API calls are resolved
+          })
+          .catch((error) => {
+            console.error('Error fetching data:', error);
+          });
+      } else {
+        Promise.all([
+          dispatch(fetchSnapshots(id ?? '')),
+          dispatch(fetchMinistryContact('EMP')),
+          dispatch(fetchNotationClassCd()),
+          dispatch(fetchNotationTypeCd()),
+          dispatch(fetchNotationParticipantRoleCd()),
+          dispatch(fetchParticipantRoleCd()),
+          dispatch(
+            fetchSiteParticipants({ siteId: id ?? '', showPending: false }),
+          ),
+          dispatch(
+            fetchNotationParticipants({ siteId: id ?? '', showPending: false }),
+          ),
+          // should be based on condition for External and Internal User.
+          dispatch(fetchSitesDetails({ siteId: id ?? '', showPending: false })),
+          // dispatch(fetchNotationParticipants({ siteId: id ?? '', showPending: false})),
+        ])
+          .then(() => {
+            setIsLoading(false); // Set loading state to false after all API calls are resolved
+          })
+          .catch((error) => {
+            console.error('Error fetching data:', error);
+          });
+      }
     }
   }, [id]);
 


### PR DESCRIPTION
Whenever browsing a site as an internal user, the site details page makes a call to the `getBannerType` endpoint, which is restricted to external users. This causes an invalid response error which renders the page unusable. After speaking with @nupurdixit13, we decided that it would be more appropriate to modify the front end to not make this call rather than open the endpoint to all users.

This PR splits the logic that hits all the site related endpoints into two branches, one for internal users and one for external users. There are some comments about only running some of the queries for internal/external users, but the only one I am confident in right now is that `getBannerType` should not be run for internal users.