### PR TITLE
SRS-577: replace custom `useUser` hook with `react-oidc-context`'s  `useAuth`

### DIFF
--- a/frontend/site-registry/src/app/components/navigation/SideBar.tsx
+++ b/frontend/site-registry/src/app/components/navigation/SideBar.tsx
@@ -5,6 +5,7 @@ import { AnglesLeftIcon } from '../common/icon';
 import { AnglesRightIcon } from '../common/icon';
 import { Link, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
+import { useAuth } from 'react-oidc-context';
 import {
   cartItems,
   addCartItemRequestStatus,
@@ -12,11 +13,7 @@ import {
   fetchCartItems,
 } from '../../features/cart/CartSlice';
 import { AppDispatch } from '../../Store';
-import {
-  getLoggedInUserType,
-  showNotification,
-  useUser,
-} from '../../helpers/utility';
+import { getLoggedInUserType, showNotification } from '../../helpers/utility';
 
 function SideBar() {
   let userCartItems = useSelector(cartItems);
@@ -27,16 +24,11 @@ function SideBar() {
   let cartItemAdded = useSelector(addCartItemRequestStatus);
   let cartItemDeleted = useSelector(deleteRequestStatus);
 
-  const user = useUser();
-
-  // useEffect(() => {
-  //   console.log('user updated');
-  //   SetNavList(getSideBarNavList(getLoggedInUserType()));
-  // }, [user]);
+  const { user } = useAuth();
 
   useEffect(() => {
     SetNavList(getSideBarNavList(getLoggedInUserType()));
-  }, []);
+  }, [user]);
 
   const cartItemsArr = useSelector(cartItems);
 

--- a/frontend/site-registry/src/app/features/details/SiteDetails.tsx
+++ b/frontend/site-registry/src/app/features/details/SiteDetails.tsx
@@ -43,7 +43,6 @@ import {
   formatDateWithNoTimzoneName,
   getUser,
   showNotification,
-  useUser,
 } from '../../helpers/utility';
 import { addRecentView } from '../dashboard/DashboardSlice';
 import { fetchSiteParticipants } from './participants/ParticipantSlice';
@@ -98,13 +97,13 @@ const SiteDetails = () => {
   const [dropDownNavItems, SetDropDownNavItems] =
     useState<{ label: string; value: string }[]>();
 
-  const user = useUser();
+  const auth = useAuth();
 
   useEffect(() => {
     SetNavComponents(getNavComponents());
     SetNavItems(getNavItems());
     SetDropDownNavItems(getDropDownNavItems());
-  }, [user]);
+  }, [auth.user]);
 
   const [folioSearchTerm, SetFolioSearchTeam] = useState('');
 
@@ -156,8 +155,6 @@ const SiteDetails = () => {
   const arr: IFormField[] = [folioDropdown];
 
   const arr2: IFormField[][] = [arr];
-
-  const auth = useAuth();
 
   const [addToFolioVisible, SetAddToFolioVisible] = useState(false);
 

--- a/frontend/site-registry/src/app/helpers/utility.ts
+++ b/frontend/site-registry/src/app/helpers/utility.ts
@@ -10,7 +10,6 @@ import {
 } from '../components/input-controls/IFormField';
 import { RequestStatus } from './requests/status';
 import { notifyError, notifySuccess } from '../components/alert/Alert';
-import { useEffect, useState } from 'react';
 import { TableColumn } from '../components/table/TableColumn';
 import { UserActionEnum } from '../common/userActionEnum';
 
@@ -84,26 +83,6 @@ export function getUser() {
   }
 
   return User.fromStorageString(oidcStorage);
-}
-
-export function useUser() {
-  const [user, setUser] = useState<User | null>(null);
-
-  const handleStorageChange = () => {
-    setUser(getUser());
-  };
-
-  useEffect(() => {
-    handleStorageChange();
-
-    window.addEventListener('storage', handleStorageChange);
-
-    return () => {
-      window.removeEventListener('storage', handleStorageChange);
-    };
-  }, []);
-
-  return user;
 }
 
 export const consoleLog = (identifier: string, message: any) => {
@@ -189,7 +168,7 @@ export enum UserRoleType {
 
 export const isUserOfType = (roleType: UserRoleType) => {
   const user = getUser();
- 
+
   if (user !== null) {
     const userRoles: any = user.profile?.role;
     switch (roleType) {
@@ -219,10 +198,10 @@ export const isUserOfType = (roleType: UserRoleType) => {
         }
       case 'sr':
         const srUserRole =
-        //  process.env?.REACT_APP_SITE_REGISTRAR_USER_ROLE 
-        // ?? ((window as any)?._env_?.REACT_APP_SITE_REGISTRAR_USER_ROLE) ?? 
-        'site-site-registrar';
-    
+          //  process.env?.REACT_APP_SITE_REGISTRAR_USER_ROLE
+          // ?? ((window as any)?._env_?.REACT_APP_SITE_REGISTRAR_USER_ROLE) ??
+          'site-site-registrar';
+
         if (userRoles.includes(srUserRole)) {
           return true;
         } else {


### PR DESCRIPTION
[JIRA ticket](https://env-epd.atlassian.net/browse/SRS-577)

There was a bug in the `useUser` hook implementation where the `user` state field wouldn't get populated after the successful login redirect until the page was refreshed.

Initially, I tried to modify this hook to more reliably read values from the session storage or from oidc's `UserManager`, but it turns out we're already using `react-oidc-context` library that already provides a very similar hook that seems to work as intended.