### PR TITLE
fix: SRS-361 implement autoincrementing ids for subdivision tables

### DIFF
--- a/backend/sites/src/app/entities/siteSubdivisions.entity.ts
+++ b/backend/sites/src/app/entities/siteSubdivisions.entity.ts
@@ -1,5 +1,12 @@
 import { Field, ObjectType } from '@nestjs/graphql';
-import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { Sites } from './sites.entity';
 import { Subdivisions } from './subdivisions.entity';
 import { ChangeAuditEntity } from './changeAuditEntity';
@@ -63,7 +70,7 @@ export class SiteSubdivisions extends ChangeAuditEntity {
   sprofDateCompleted: Date | null;
 
   @Field()
-  @Column('bigint', { primary: true, name: 'site_subdiv_id' })
+  @PrimaryGeneratedColumn('increment')
   siteSubdivId: string;
 
   @Field()

--- a/backend/sites/src/app/entities/subdivisions.entity.ts
+++ b/backend/sites/src/app/entities/subdivisions.entity.ts
@@ -1,5 +1,11 @@
 import { Field, ObjectType } from '@nestjs/graphql';
-import { Column, Entity, Index, OneToMany } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { SiteSubdivisions } from './siteSubdivisions.entity';
 import { ChangeAuditEntity } from './changeAuditEntity';
 
@@ -9,7 +15,7 @@ import { ChangeAuditEntity } from './changeAuditEntity';
 @Entity('subdivisions')
 export class Subdivisions extends ChangeAuditEntity {
   @Field()
-  @Column('bigint', { primary: true, name: 'id' })
+  @PrimaryGeneratedColumn('increment')
   id: string;
 
   @Field()

--- a/backend/sites/src/migrations/1729275924909-master-script.ts
+++ b/backend/sites/src/migrations/1729275924909-master-script.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MasterScript1729275924909 implements MigrationInterface {
+  name = 'MasterScript1729275924909';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE SEQUENCE "sites"."subdivision_id_seq" OWNED BY "sites"."subdivisions"."id"`,
+    );
+    await queryRunner.query(
+      `SELECT setval('sites.subdivision_id_seq', (SELECT MAX(id) FROM "sites"."subdivisions"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."subdivisions" ALTER COLUMN "id" SET DEFAULT nextval('sites.subdivision_id_seq')`,
+    );
+    await queryRunner.query(
+      `CREATE SEQUENCE "sites"."site_subdivision_site_subdiv_id_seq" OWNED BY "sites"."site_subdivisions"."site_subdiv_id"`,
+    );
+    await queryRunner.query(
+      `SELECT setval('sites.site_subdivision_site_subdiv_id_seq', (SELECT MAX(site_subdiv_id) FROM "sites"."site_subdivisions"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."site_subdivisions" ALTER COLUMN "site_subdiv_id" SET DEFAULT nextval('sites.site_subdivision_site_subdiv_id_seq')`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "sites"."site_subdivisions" ALTER COLUMN "site_subdiv_id" SET DEFAULT null`,
+    );
+    await queryRunner.query(
+      `DROP SEQUENCE "sites"."site_subdivision_site_subdiv_id_seq"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "sites"."subdivisions" ALTER COLUMN "id" SET DEFAULT null`,
+    );
+    await queryRunner.query(`DROP SEQUENCE "sites"."subdivision_id_seq"`);
+  }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

So the reason I wasn't able to insert new rows into the database for `subdivisions` and `site_subdivisions` I mentioned in standup is because TypeORM was inserting using `DEFAULT`. The problem is that when we imported the oracle db ddl, it didn't define any sort of auto incrementing ids for these tables.

This PR fixes this problem by:
1. using TypeORM's `@PrimaryGeneratedColumn` decorator on the relevant primary key columns so that TypeORM will not attempt to set the id of a new row.
2. migrating the database to create new sequences for the tables primary keys, altering those tables to use the new sequences, and setting the sequences current values to the maximum value that is already in the database (to avoid breaking existing databases).

Fixes # SRS-361 (partially)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Migrated my exisiting database and verified that I was able to insert a new row with the default id value in both tables.
- [x] Migrated a fresh database and verified that I was able to insert a new row with the default id value in both tables.
- [x] Inserted new rows into the database to ensure that the ids properly increment.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

Our migrations and decorators are not testable so I have not added any new tests.

## Further comments

@nikhila-aot I'm not sure how this change will impact our oracle data import. We may need to run the following code on the postgresql database to set the sequences correctly after import:

```
SELECT setval('sites.subdivision_id_seq', (SELECT MAX(id) FROM "sites"."subdivisions"));
SELECT setval('sites.site_subdivision_site_subdiv_id_seq', (SELECT MAX(site_subdiv_id) FROM "sites"."site_subdivisions"));
```

Alternatively: if this will impact data import, I can write a sequence generator in the backend to handle setting ids in code rather than on the database. Please let me know.

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-120-backend-sites.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-120-frontend-site-registry.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-120-backend-sites.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-120-frontend-site-registry.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-120-backend-sites.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-120-frontend-site-registry.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)