### PR TITLE
fix: SRS-617 - Prevent showing banner related error message for internal users

### DIFF
--- a/frontend/src/app/features/details/SiteDetails.tsx
+++ b/frontend/src/app/features/details/SiteDetails.tsx
@@ -166,7 +166,7 @@ const SiteDetails = () => {
   const [showLocationDetails, SetShowLocationDetails] = useState(false);
   const [showParcelDetails, SetShowParcelDetails] = useState(false);
   const [save, setSave] = useState(false);
-  const [userType, setUserType] = useState<UserType>(UserType.External);
+  const [userType, setUserType] = useState<UserType | null>(null);
   const [viewMode, setViewMode] = useState(SiteDetailsMode.ViewOnlyMode);
   const [isLoading, setIsLoading] = useState(true);
   const dispatch = useDispatch<AppDispatch>();
@@ -241,7 +241,7 @@ const SiteDetails = () => {
       setUserType(UserType.External);
     }
     dispatch(fetchFolioItems(loggedInUser?.profile.sub ?? ''));
-  }, []);
+  }, [loggedInUser]);
 
   const savedChanges = useSelector(trackedChanges);
   const mode = useSelector(siteDetailsMode);
@@ -291,7 +291,7 @@ const SiteDetails = () => {
           console.error('Error fetching data:', error);
         });
     }
-  }, [id]);
+  }, [id, userType]);
 
   useEffect(() => {
     if (srUpdateRequestStatus === RequestStatus.success) {


### PR DESCRIPTION
This fix is to make sure we don't get any error when trying to fetch the bannerType. Currently the error was coming due to two reasons:
1. The default state for userType was set to "External" thus the two useEffects using the userType were picking two different values intermittently.
2. The dependency array for the useEffects was not using the loggedInuser and userType which is necessary to maintain consistent values throughout. 


Key Changes:
1. Dependency Array in First useEffect: Added loggedInUser to the dependency array to ensure it re-runs when loggedInUser changes.
2. Dependency Array in Second useEffect: Added userType to the dependency array to ensure it re-runs when userType changes.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-145-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-145-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)