### PR TITLE
fix: SRS-621 - Changes to hide purchase section at the bottom if site already purchased

### DIFF
--- a/frontend/src/app/features/details/SiteDetails.css
+++ b/frontend/src/app/features/details/SiteDetails.css
@@ -120,6 +120,10 @@
   color: var(--typography-color-primary, #2d2d2d);
 }
 
+.btn-icon-color-white {
+  color: var(--typography-color-primary-invert, #2d2d2d);
+}
+
 .btn-folio-icon {
   font-size: 16px;
   font-weight: 900;

--- a/frontend/src/app/features/details/snapshot/SnapshotSlice.ts
+++ b/frontend/src/app/features/details/snapshot/SnapshotSlice.ts
@@ -154,6 +154,10 @@ export const getFirstSnapshotCreatedDate = (state: any) => {
   return state.snapshots.firstSnapshotCreatedDate;
 };
 
+export const isUserPurchasedSnapshot = (state: any) => {
+  return state.snapshots.firstSnapshotCreatedDate !== null;
+};
+
 export const createSnapshotForSitesStatus = (state: any) =>
   state.snapshots.createSnapshotRequest;
 

--- a/frontend/src/app/features/details/summary/Summary.css
+++ b/frontend/src/app/features/details/summary/Summary.css
@@ -41,3 +41,10 @@
   gap: var(--layout-margin-small);
   justify-content: center;
 }
+
+@media (max-width: 576px) {
+  .external-purchase-buttons {
+      flex-direction: column; /* Change to column layout */
+      align-items: center;    /* Center items */
+  }
+}

--- a/frontend/src/app/features/details/summary/Summary.tsx
+++ b/frontend/src/app/features/details/summary/Summary.tsx
@@ -43,9 +43,12 @@ import { SRApprovalStatusEnum } from '../../../common/srApprovalStatusEnum';
 
 import { useParams } from 'react-router-dom';
 import SummaryInfo from './SummaryInfo';
+import { isUserPurchasedSnapshot } from '../snapshot/SnapshotSlice';
 
 const Summary = () => {
   const auth = useAuth();
+
+  const isUserPurchasedSite = useSelector(isUserPurchasedSnapshot);
 
   const user = getUser();
   const addCartItemStatus = useSelector(addCartItemRequestStatus);
@@ -191,24 +194,12 @@ const Summary = () => {
     setParcelIds(parcelIdsLocal);
   };
 
-  const data = [
-    {
-      notation: 1,
-      participants: 3,
-      associatedSites: 1,
-      documents: 1,
-      landUses: 5,
-      parcelDescription: 10,
-    },
+  const data:any = [
+    
   ];
 
-  const activityData = [
-    {
-      id: 1,
-      activity: 'some activity',
-      user: 'Midhun',
-      timeStamp: '23-04-1989 00:11:11',
-    },
+  const activityData:any = [
+    
   ];
 
   const columns: TableColumn[] = [
@@ -517,9 +508,9 @@ const Summary = () => {
               Summary of details types
             </span>
           </div>
-          <div className="col-12">
+          <div className="col-12 overflow-auto w-100">
             <Table
-              label="Search Results"
+              label="Summary Details"
               isLoading={RequestStatus.success}
               columns={columns}
               data={data}
@@ -534,12 +525,12 @@ const Summary = () => {
         </div>
       }
 
-      {false && (
+      {isUserPurchasedSite && (
         <div className="summary-details-border">
           <span className="summary-details-header">Activity Log</span>
-          <div className="col-12">
+          <div className="col-12 overflow-auto w-100">
             <Table
-              label="Search Results"
+              label="Activity Log"
               isLoading={RequestStatus.success}
               columns={activityColumns}
               data={activityData}
@@ -554,7 +545,7 @@ const Summary = () => {
         </div>
       )}
 
-      {
+      { !isUserPurchasedSite && 
         <div className="external-purchase-section">
           <div className="external-purchase-info">
             <span>
@@ -564,10 +555,10 @@ const Summary = () => {
           </div>
           <div className="external-purchase-buttons">
             <button className="d-flex btn-cart align-items-center">
-              <ShoppingCartIcon className="btn-icon" />
+              <ShoppingCartIcon className="btn-icon btn-icon-color-white"  />
               <span className="btn-cart-lbl" onClick={() => handleAddToCart()}>
                 {' '}
-                Add to Cart
+                Purchase Site Details
               </span>
             </button>
             <button className="d-flex btn-folio align-items-center">


### PR DESCRIPTION
- Changes to hide purchase section at the bottom if site already purchased
- Update icon color to white
- Delete dummy data 
- Show activity table if site purchased
- Set tables for overflow scroll

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-148-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-148-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)