### PR TITLE
feat: SRS 361 Implement delete parcel descriptions for site

### DIFF
--- a/backend/src/app/services/parcelDescriptions/parcelDescriptions.service.spec.ts
+++ b/backend/src/app/services/parcelDescriptions/parcelDescriptions.service.spec.ts
@@ -1227,4 +1227,127 @@ describe('SiteSubdivisionsService', () => {
       });
     });
   });
+
+  describe('deleteParcelDescriptionsForSite', () => {
+    let today: Date;
+    let subdivId: string;
+    let siteSubdivId: string;
+
+    let inputParcelDescriptions: ParcelDescriptionInputDTO[];
+    let siteId: string;
+
+    let databaseSiteSubdivision: SiteSubdivisions;
+
+    let siteSubdivisionFindByResult: SiteSubdivisions[] = [];
+    let siteSubdivisionRemoveResult: SiteSubdivisions[] = [];
+
+    let siteSubdivisionFindByMock: jest.Mock;
+    let siteSubdivisionRemoveMock: jest.Mock;
+
+    beforeEach(() => {
+      today = new Date();
+      subdivId = '1';
+      siteSubdivId = '100';
+
+      siteId = '10';
+      inputParcelDescriptions = [
+        {
+          id: subdivId,
+          descriptionType: 'Crown Land PIN',
+          idPinNumber: '123456',
+          dateNoted: today,
+          landDescription: 'should be ignored',
+          srAction: 'approved',
+          userAction: 'approved',
+          apiAction: 'deleted',
+        },
+      ];
+
+      databaseSiteSubdivision = {
+        srAction: 'pending',
+        userAction: 'pending',
+        siteId: siteId,
+        subdivId: subdivId,
+        dateNoted: today,
+        initialIndicator: 'N',
+        whoCreated: 'employee of the month',
+        whoUpdated: 'employee of the month',
+        whenCreated: today,
+        whenUpdated: today,
+        sprofDateCompleted: null,
+        siteSubdivId: siteSubdivId,
+        sendToSr: 'Y',
+        site: null,
+        subdivision: null,
+      };
+
+      siteSubdivisionFindByResult = [databaseSiteSubdivision];
+      // This value is disregarded.
+      siteSubdivisionRemoveResult = [];
+
+      siteSubdivisionFindByMock = jest
+        .fn()
+        .mockResolvedValue(siteSubdivisionFindByResult);
+      siteSubdivisionRemoveMock = jest
+        .fn()
+        .mockResolvedValue(siteSubdivisionRemoveResult);
+
+      siteSubdivisionsRepository.remove = siteSubdivisionRemoveMock;
+      siteSubdivisionsRepository.findBy = siteSubdivisionFindByMock;
+    });
+    it('logs the call to deleteParcelDescriptionsForSite', async () => {
+      await parcelDescriptionsService.deleteParcelDescriptionsForSite(
+        siteId,
+        inputParcelDescriptions,
+      );
+
+      expect(logMock).toHaveBeenCalledWith(
+        'parcelDescriptionService.deleteParcelDescriptionsForSite(): Entering method.',
+      );
+      expect(logMock).toHaveBeenCalledWith(
+        'parcelDescriptionService.deleteParcelDescriptionsForSite(): Complete.',
+      );
+    });
+
+    it('removes the expected site subdivision from the database', async () => {
+      await parcelDescriptionsService.deleteParcelDescriptionsForSite(
+        siteId,
+        inputParcelDescriptions,
+      );
+
+      expect(logMock).toHaveBeenCalledWith(
+        'parcelDescriptionService.deleteParcelDescriptionsForSite(): Entering method.',
+      );
+      expect(logMock).toHaveBeenCalledWith(
+        'parcelDescriptionService.deleteParcelDescriptionsForSite(): Complete.',
+      );
+    });
+
+    describe('when the site subdivision fails to remove', () => {
+      beforeEach(() => {
+        siteSubdivisionRemoveMock = jest.fn().mockImplementation(() => {
+          throw new Error('A bad thing happened!');
+        });
+        siteSubdivisionsRepository.remove = siteSubdivisionRemoveMock;
+      });
+
+      it('logs and throws the error', async () => {
+        expect(async () => {
+          await parcelDescriptionsService.deleteParcelDescriptionsForSite(
+            siteId,
+            inputParcelDescriptions,
+          );
+        }).rejects.toThrow('A bad thing happened!');
+
+        // Need to wait for the above block to reject before testing the logging
+        // mock.
+        await jest.runAllTimersAsync();
+        expect(errorMock).toHaveBeenCalledTimes(1);
+        expect(errorMock).toHaveBeenCalledWith(
+          'parcelDescriptionService.deleteParcelDescriptionsForSite(): Failed deleting siteSubdivisions.',
+          expect.anything(),
+        );
+      });
+    });
+  });
 });

--- a/backend/src/app/services/parcelDescriptions/parcelDescriptions.service.ts
+++ b/backend/src/app/services/parcelDescriptions/parcelDescriptions.service.ts
@@ -443,6 +443,31 @@ export class ParcelDescriptionsService {
     siteId: string,
     parcelDescriptions: ParcelDescriptionInputDTO[],
   ) {
-    // TODO: Implementation to come in another pull request
+    this.sitesLogger.log(
+      'parcelDescriptionService.deleteParcelDescriptionsForSite(): Entering method.',
+    );
+
+    // Only the relation between subdivisions and sites, the site subdivision,
+    // can be removed. Subdivisions exist independently of sites.
+    const subdivIds = parcelDescriptions.map((parcelDescription) => {
+      return parcelDescription.id;
+    });
+    let siteSubdivisions = await this.siteSubdivisionsRepository.findBy({
+      subdivId: In(subdivIds),
+      siteId: siteId,
+    });
+    try {
+      await this.siteSubdivisionsRepository.remove(siteSubdivisions);
+    } catch (error) {
+      this.sitesLogger.error(
+        'parcelDescriptionService.deleteParcelDescriptionsForSite(): Failed deleting siteSubdivisions.',
+        JSON.stringify(error),
+      );
+      throw error;
+    }
+
+    this.sitesLogger.log(
+      'parcelDescriptionService.deleteParcelDescriptionsForSite(): Complete.',
+    );
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Implement the method to delete Parcel Description entities from the database

Fixes # SRS-361 (Partially)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Manual GraphQL test.
```graphql
mutation updateSiteDetails($siteDetailsDTO: SaveSiteDetailsDTO!) {
    updateSiteDetails(siteDetailsDTO: $siteDetailsDTO) {
        message
        httpStatusCode
        success
    }
}
```
with variables:
```json
{
    "siteDetailsDTO": {
    "siteId": "997",
    "parcelDescriptions": [
      {
        "id": "",
        "descriptionType": "Parcel ID",
        "idPinNumber": "123456",
        "dateNoted": "2024-10-17T00:00:00Z",
        "landDescription": "should be disregarded",
        "userAction": "pending",
        "srAction": "pending",
        "apiAction": "deleted"
      }
    ]
  }  
}
```
(after adding the parcel description)

- [x] Unit tests

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
