### PR TITLE
feat: SRS-550: Map Search – Selected Site Drawer

### DIFF
--- a/frontend/src/app/components/common/icon.ts
+++ b/frontend/src/app/components/common/icon.ts
@@ -27,6 +27,7 @@ import {
   FaAngleRight,
   FaChevronDown,
   FaChevronUp,
+  FaChevronRight,
   FaFloppyDisk,
   FaUserMinus,
   FaUserPlus,
@@ -50,6 +51,7 @@ import {
   BsEyeFill,
   BsExclamationCircle,
   BsExclamationTriangle,
+  BsXLg,
 } from 'react-icons/bs';
 import { BiSolidFilePdf } from 'react-icons/bi';
 
@@ -77,10 +79,12 @@ export const DropdownUpIcon = FaCaretUp;
 export const DropdownIcon = FaCaretDown;
 export const CalendarIcon = FaCalendar;
 export const XmarkIcon = FaXmark;
+export const XmarkIcon2 = BsXLg;
 export const AngleLeft = FaAngleLeft;
 export const AngleRight = FaAngleRight;
 export const ChevronDown = FaChevronDown;
 export const ChevronUp = FaChevronUp;
+export const ChevronRight = FaChevronRight;
 export const FloppyDisk = FaFloppyDisk;
 export const UserPlus = FaUserPlus;
 export const UserMinus = FaUserMinus;

--- a/frontend/src/app/features/map/MapView.css
+++ b/frontend/src/app/features/map/MapView.css
@@ -1,6 +1,6 @@
 .map-view {
   width: 100%;
-  height: 100vh;
+  height: calc(100vh - 65px);
 
   position: relative;
   display: flex;
@@ -12,10 +12,10 @@
 
 /* No footer on small screens - so use full height */
 .map-view.map-view--small {
-  height: 100vh; /* for old browser */
+  height: calc(100vh - 65px); /* for old browser */
   /* Use dvh instead of vh otherwise on Chrome the address bar pushes map down */
   /* https://stackoverflow.com/questions/52848856/100vh-height-when-address-bar-is-shown-chrome-mobile#70048720 */
-  height: 100dvh;
+  height: calc(100dvh - 65px);
 }
 
 .map-view > .map-container {

--- a/frontend/src/app/features/map/MapView.tsx
+++ b/frontend/src/app/features/map/MapView.tsx
@@ -13,6 +13,7 @@ import './MapView.css';
 import { MapSearch } from './MapSearch';
 import { useMapSearchQuery } from '../../../graphql/generated';
 import { SiteMarkers } from './siteMarkers/SiteMarkers';
+import { SiteDetailsDrawer } from './siteDrawer/SiteDetailsDrawer';
 
 // Set the position of the marker for center of BC
 const CENTER_OF_BC: LatLngTuple = [53.7267, -127.6476];
@@ -52,6 +53,7 @@ function MapView() {
         <SiteMarkers sites={data?.searchSites.sites || []} />
       </MapContainer>
       <MapSearch />
+      <SiteDetailsDrawer />
     </div>
   );
 }

--- a/frontend/src/app/features/map/siteDrawer/SiteDetailsDrawer.css
+++ b/frontend/src/app/features/map/siteDrawer/SiteDetailsDrawer.css
@@ -1,0 +1,38 @@
+.site-drawer-container.MuiDrawer-root > .MuiPaper-root {
+  transition:
+    max-height 225ms,
+    height 225ms,
+    transform 225ms cubic-bezier(0, 0, 0.2, 1);
+
+  border-top: none;
+  position: absolute;
+  background-color: var(--surface-color-background-light);
+  box-shadow: var(--surface-shadow-medium);
+}
+
+.site-drawer-header {
+  display: flex;
+  height: 69px;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--layout-margin-large);
+  border-bottom: 1px solid var(--surface-color-border-light);
+
+  font-size: var(--typography-font-size-body);
+  font-weight: var(--typography-font-weights-bold);
+}
+
+.site-drawer-header .resize-handle {
+  width: 40px;
+  height: 4px;
+  border-radius: 8px;
+  background-color: var(--surface-color-brand-gray-60);
+  position: absolute;
+  top: 6px;
+  left: calc(50% - 20px);
+  cursor: grab;
+}
+
+.site-drawer-body {
+  padding: var(--layout-margin-large);
+}

--- a/frontend/src/app/features/map/siteDrawer/SiteDetailsDrawer.tsx
+++ b/frontend/src/app/features/map/siteDrawer/SiteDetailsDrawer.tsx
@@ -1,0 +1,205 @@
+import { Drawer, SxProps, Theme } from '@mui/material';
+
+import { FC, useCallback, useEffect, useRef, useState } from 'react';
+
+import './SiteDetailsDrawer.css';
+import { StringParam, useQueryParam } from 'use-query-params';
+import {
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  XmarkIcon2,
+} from '../../../components/common/icon';
+
+enum ExpansionState {
+  Default,
+  Expanded,
+  Hidden,
+}
+
+const getExpandIcon = (state: ExpansionState) => {
+  switch (state) {
+    case ExpansionState.Expanded:
+      return <ChevronDown />;
+    case ExpansionState.Hidden:
+      return <ChevronUp />;
+    case ExpansionState.Default:
+      return <ChevronRight />;
+    default:
+      return <ChevronRight />;
+  }
+};
+
+const getNextExpansionStateFromCurrentState = (
+  currentState: ExpansionState,
+) => {
+  switch (currentState) {
+    case ExpansionState.Expanded:
+      return ExpansionState.Default;
+    case ExpansionState.Hidden:
+      return ExpansionState.Default;
+    case ExpansionState.Default:
+      return ExpansionState.Expanded;
+    default:
+      return ExpansionState.Default;
+  }
+};
+
+const getNextExpansionStateFromResizeRatio = (ratio: number) => {
+  switch (true) {
+    case ratio <= 60 && ratio > 30:
+      return ExpansionState.Default;
+    case ratio > 60:
+      return ExpansionState.Expanded;
+    default:
+      return ExpansionState.Hidden;
+  }
+};
+
+export const SiteDetailsDrawer: FC = () => {
+  const [open, setOpen] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+  const [expansion, setExpansion] = useState<ExpansionState>(
+    ExpansionState.Default,
+  );
+
+  const [selectedSiteId, setSelectedSiteId] = useQueryParam(
+    'site',
+    StringParam,
+  );
+
+  useEffect(() => {
+    if (selectedSiteId) {
+      setOpen(true);
+      setIsVisible(true);
+    }
+  }, [selectedSiteId]);
+
+  const [drawerResizeHeight, setDrawerResizeHeight] = useState<number | null>(
+    null,
+  );
+  const drawerHeightRef = useRef(drawerResizeHeight);
+  drawerHeightRef.current = drawerResizeHeight;
+
+  const enterResizeMode = () => {
+    document.addEventListener('mouseup', exitResizeMode, true);
+    document.addEventListener('mousemove', resizeDrawer, true);
+  };
+
+  const handleDrawerClose = () => {
+    setSelectedSiteId(null);
+    setOpen(false);
+    setExpansion(ExpansionState.Default);
+
+    // Listen for the transition end to set visibility
+    // Visibility change has to happen once the translateY() off screen has completed
+    const drawerElement = document.querySelector('.site-drawer-container');
+    const onTransitionEnd = () => {
+      setIsVisible(false);
+      drawerElement?.removeEventListener('transitionend', onTransitionEnd);
+    };
+    drawerElement?.addEventListener('transitionend', onTransitionEnd);
+  };
+
+  const exitResizeMode = () => {
+    document.removeEventListener('mouseup', exitResizeMode, true);
+    document.removeEventListener('mousemove', resizeDrawer, true);
+    setDrawerResizeHeight(null);
+
+    if (!drawerHeightRef.current) {
+      return;
+    }
+
+    const drawerHeightRatio =
+      (drawerHeightRef.current / document.body.clientHeight) * 100;
+
+    setExpansion(getNextExpansionStateFromResizeRatio(drawerHeightRatio));
+  };
+
+  const resizeDrawer = useCallback((e: MouseEvent) => {
+    const newHeight = document.body.offsetHeight - e.clientY;
+    setDrawerResizeHeight(newHeight);
+  }, []);
+
+  const buildDrawerStyles = () => {
+    let styles: SxProps<Theme> = {};
+
+    if (expansion === ExpansionState.Default) {
+      styles = {
+        ...styles,
+        height: `${Math.floor(document.body.clientHeight / 2)}px`,
+        maxHeight: '480px',
+      };
+    }
+    if (expansion === ExpansionState.Expanded) {
+      styles = {
+        ...styles,
+        height: '100%',
+        maxHeight: '100%',
+      };
+    }
+    if (expansion === ExpansionState.Hidden) {
+      styles = {
+        ...styles,
+        height: '70px',
+        maxHeight: '70px',
+        overflowY: 'hidden',
+      };
+    }
+    if (drawerResizeHeight !== null) {
+      styles = {
+        ...styles,
+        height: `${drawerResizeHeight}px`,
+        maxHeight: '100%',
+        transition: '0s !important',
+      };
+    }
+    if (!open) {
+      styles = {
+        ...styles,
+        transform: `translateY(${Math.floor(document.body.clientHeight / 2)}px)`,
+        height: `${Math.floor(document.body.clientHeight / 2)}px`,
+        maxHeight: '480px',
+        visibility: isVisible ? 'visible' : 'hidden',
+      };
+    }
+
+    return styles;
+  };
+
+  return (
+    <Drawer
+      open
+      anchor="bottom"
+      variant="persistent"
+      aria-hidden={!open}
+      className="site-drawer-container"
+      PaperProps={{
+        sx: buildDrawerStyles(),
+      }}
+    >
+      <div className="site-drawer-header">
+        <div className="resize-handle" onMouseDown={enterResizeMode}></div>
+
+        <button
+          className="border-0 bg-transparent"
+          onClick={() => {
+            setExpansion(getNextExpansionStateFromCurrentState(expansion));
+          }}
+        >
+          {getExpandIcon(expansion)}
+        </button>
+        <span>Selected Site</span>
+        <button className="border-0 bg-transparent" onClick={handleDrawerClose}>
+          <XmarkIcon2 size={20} />
+        </button>
+      </div>
+
+      <div className="site-drawer-body">
+        <span>
+          <span className="fw-bold">Site ID:</span> {selectedSiteId}
+        </span>
+      </div>
+    </Drawer>
+  );
+};

--- a/frontend/src/app/features/map/siteDrawer/SiteDetailsDrawer.tsx
+++ b/frontend/src/app/features/map/siteDrawer/SiteDetailsDrawer.tsx
@@ -127,7 +127,7 @@ export const SiteDetailsDrawer: FC = () => {
     if (expansion === ExpansionState.Default) {
       styles = {
         ...styles,
-        height: `${Math.floor(document.body.clientHeight / 2)}px`,
+        height: `50%`,
         maxHeight: '480px',
       };
     }
@@ -158,7 +158,7 @@ export const SiteDetailsDrawer: FC = () => {
       styles = {
         ...styles,
         transform: `translateY(${Math.floor(document.body.clientHeight / 2)}px)`,
-        height: `${Math.floor(document.body.clientHeight / 2)}px`,
+        height: `50%`,
         maxHeight: '480px',
         visibility: isVisible ? 'visible' : 'hidden',
       };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This PR adds adds a drawer for viewing details of the selected site on map search view.

The focus of this PR is the state management and the styling of this component. Fetching and displaying actual site data will be tackled in the next PR

Demo:


https://github.com/user-attachments/assets/1103721e-d363-48f5-b7f9-4064c867255c



Fixes [SRS-550](https://env-epd.atlassian.net/browse/SRS-550)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Go to map view, click around the site markers, change the expansion type of the drawer
- [x] If you have a site selected (you should have `site=SITE_ID` in the query params), refreshing the page should preserve the selection and the drawer should remain open


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-152-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-152-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)