### PR TITLE
fix: Set Default page to search page instead of dashboard

### DIFF
--- a/frontend/src/app/routes/Routes.tsx
+++ b/frontend/src/app/routes/Routes.tsx
@@ -22,7 +22,7 @@ import SRUpdatesTables from '../features/details/srUpdates/srUpdatesTables';
 
 const roleBasedRoutes: any = {
   client: [
-    { path: '/', element: <Dashboard /> },
+    { path: '/', element: <Search /> },
     { path: '/dashboard', element: <Dashboard /> },
     { path: '/search', element: <Search /> },
     { path: '/site/details/:id', element: <SiteDetails /> },
@@ -37,7 +37,7 @@ const roleBasedRoutes: any = {
     { path: '/site/cart/site/details/:id', element: <SiteDetails /> },
   ],
   internal: [
-    { path: '/', element: <Dashboard /> },
+    { path: '/', element: <Search /> },
     { path: '/dashboard', element: <Dashboard /> },
     { path: '/search', element: <Search /> },
     { path: '/site/details/:id', element: <SiteDetails /> },
@@ -50,7 +50,7 @@ const roleBasedRoutes: any = {
     { path: '/review', element: <SRUpdatesTables /> },
   ],
   sr: [
-    { path: '/', element: <Dashboard /> },
+    { path: '/', element: <Search /> },
     { path: '/search', element: <Search /> },
     { path: '/site/details/:id', element: <SiteDetails /> },
     { path: '/search/site/details/:id', element: <SiteDetails /> },
@@ -59,7 +59,7 @@ const roleBasedRoutes: any = {
     { path: '/review', element: <SRUpdatesTables /> },
   ],
   public: [
-    { path: '/', element: <Dashboard /> },
+    { path: '/', element: <Search /> },
     { path: '/search', element: <Search /> },
     { path: '/site/details/:id', element: <SiteDetails /> },
     { path: '/search/site/details/:id', element: <SiteDetails /> },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Set Default page to search page instead of dashboard

![image](https://github.com/user-attachments/assets/5be5d437-01a0-4831-95ab-8e9869fceff2)


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-156-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-156-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)