### PR TITLE
fix: Changes For internal user

### DIFF
--- a/backend/src/app/services/document/document.service.ts
+++ b/backend/src/app/services/document/document.service.ts
@@ -31,7 +31,7 @@ export class DocumentService {
       let result: SiteDocs[] = [];
       if (showPending) {
         result = await this.siteDocsRepository.find({
-          where: { siteId, userAction: UserActionEnum.UPDATED },
+          where: { siteId, srAction: SRApprovalStatusEnum.PENDING },
           relations: ['siteDocPartics', 'siteDocPartics.psnorg'],
         });
       } else {

--- a/frontend/src/app/features/details/srUpdates/srUpdates.tsx
+++ b/frontend/src/app/features/details/srUpdates/srUpdates.tsx
@@ -676,7 +676,11 @@ const [notationColumnInternalLocal, SetNotationColumnInternalLocal] =
   return (
     <div data-testid="srreviewtab-component">
       {siteSummaryData && (
-        <ApproveReject name="Summary" testId="site-summary-component" link="?summary">
+        <ApproveReject
+          name="Summary"
+          testId="site-summary-component"
+          link="?summary"
+        >
           <SummaryInfo
             siteData={siteSummaryData}
             location={location}
@@ -692,7 +696,11 @@ const [notationColumnInternalLocal, SetNotationColumnInternalLocal] =
       {notationData &&
         notationData.map((notation: any, index: number) => {
           return (
-            <ApproveReject name="Notations" testId="srupdates-notation-component" link="?notations">
+            <ApproveReject
+              name="Notations"
+              testId="srupdates-notation-component"
+              link="?notations"
+            >
               <Notation
                 index={index}
                 notation={notation}
@@ -726,7 +734,11 @@ const [notationColumnInternalLocal, SetNotationColumnInternalLocal] =
         })}
 
       {siteParticipantData && siteParticipantData.length > 0 && (
-        <ApproveReject name="Participants" testId="srupdates-participant-component" link="?participants">
+        <ApproveReject
+          name="Participants"
+          testId="srupdates-participant-component"
+          link="?participants"
+        >
           <ParticipantTable
             handleTableChange={handleParticipantsApproveRejectHandler}
             handleWidgetCheckBox={handleChange}
@@ -751,7 +763,11 @@ const [notationColumnInternalLocal, SetNotationColumnInternalLocal] =
       {documentsData &&
         documentsData.map((document: any, index: number) => {
           return (
-            <ApproveReject name="Documents" testId="srupdates-documents-component" link="?documents">
+            <ApproveReject
+              name="Documents"
+              testId="srupdates-documents-component"
+              link="?documents"
+            >
               <Document
                 index={index}
                 userType={UserType.Internal}
@@ -778,7 +794,11 @@ const [notationColumnInternalLocal, SetNotationColumnInternalLocal] =
         })}
 
       {associatedSitesData && associatedSitesData.length > 0 && (
-        <ApproveReject name="Site Associations"  testId="srupdates-siteassociations-component"  link="?associated">
+        <ApproveReject
+          name="Site Associations"
+          testId="srupdates-siteassociations-component"
+          link="?associated"
+        >
           <AssociateSiteComponent
             handleTableChange={handleAssociatedSiteApproveRejectHandler}
             handleWidgetCheckBox={handleChange}
@@ -804,7 +824,11 @@ const [notationColumnInternalLocal, SetNotationColumnInternalLocal] =
       )}
 
       {landUsesData && (
-        <ApproveReject name="LandUses"  testId="srupdates-landuses-component" link="?landuses">
+        <ApproveReject
+          name="LandUses"
+          testId="srupdates-landuses-component"
+          link="?landuses"
+        >
           <LandUseTable
             onTableChange={approveRejectHandlerForLandUses}
             tableColumns={landUseTableColumn}
@@ -820,23 +844,28 @@ const [notationColumnInternalLocal, SetNotationColumnInternalLocal] =
         </ApproveReject>
       )}
 
-      {parcelDescriptionData?.data.length > 0 && parcelDescriptionData?.data && (
-        <ApproveReject name="Parcel Description"  testId="srupdates-parceldesc-component" link="?parceldesc">
-          <ParcelDescriptionTable
-            tableChangeHandler={handleParcelDescriptionApproveRejectHandler}
-            showPageOptions={false}
-            requestStatus={RequestStatus.success}
-            columns={parcelDescriptionColumn}
-            data={parcelDescriptionData.data}
-            totalResults={[].length}
-            handleSelectPage={handleChange}
-            handleChangeResultsPerPage={handleChange}
-            currentPage={1}
-            resultsPerPage={undefined}
-            handleTableSortChange={handleChange}
-          />
-        </ApproveReject>
-      )}
+      {parcelDescriptionData?.data.length > 0 &&
+        parcelDescriptionData?.data && (
+          <ApproveReject
+            name="Parcel Description"
+            testId="srupdates-parceldesc-component"
+            link="?parceldesc"
+          >
+            <ParcelDescriptionTable
+              tableChangeHandler={handleParcelDescriptionApproveRejectHandler}
+              showPageOptions={false}
+              requestStatus={RequestStatus.success}
+              columns={parcelDescriptionColumn}
+              data={parcelDescriptionData.data}
+              totalResults={[].length}
+              handleSelectPage={handleChange}
+              handleChangeResultsPerPage={handleChange}
+              currentPage={1}
+              resultsPerPage={undefined}
+              handleTableSortChange={handleChange}
+            />
+          </ApproveReject>
+        )}
 
       {disclosureData && (
         <ApproveReject name="Disclosure" link="?disclosure">
@@ -871,6 +900,19 @@ const [notationColumnInternalLocal, SetNotationColumnInternalLocal] =
           />
         </ApproveReject>
       )}
+      {!disclosureData &&
+        (!parcelDescriptionData || parcelDescriptionData.data.length === 0) &&
+        (!landUsesData || landUsesData.length === 0) &&
+        (!associatedSitesData || associatedSitesData.length === 0) &&
+        (!documentsData || documentsData.length === 0) && 
+        (!siteParticipantData || siteParticipantData.length === 0) && 
+        (!notationData || notationData.length === 0) && 
+        (!siteSummaryData) &&
+        (
+          <div>
+            <span> No updates to review</span>
+          </div>
+        )}
     </div>
   );
 };

--- a/frontend/src/app/features/site/Search.tsx
+++ b/frontend/src/app/features/site/Search.tsx
@@ -34,11 +34,12 @@ import { TableColumn } from '../../components/table/TableColumn';
 import { getSiteSearchResultsColumns } from './dto/Columns';
 import SiteFilterForm from './filters/SiteFilterForm';
 import PageContainer from '../../components/simple/PageContainer';
-import { getUser } from '../../helpers/utility';
+import { getUser, isUserOfType, UserRoleType } from '../../helpers/utility';
 import { useAuth } from 'react-oidc-context';
 import { addCartItem, resetCartItemAddedStatus } from '../cart/CartSlice';
 import AddToFolio from '../folios/AddToFolio';
 import { downloadCSV } from '../../helpers/csvExport/csvExport';
+import { UserType } from '../../helpers/requests/userType';
 
 const Search = () => {
   const auth = useAuth();
@@ -391,14 +392,14 @@ const Search = () => {
               </div>
             ) : null}
             <div className="search-result-actions">
-              <div
+              {!isUserOfType(UserRoleType.INTERNAL) && <div
                 className="search-result-actions-btn"
                 onClick={() => handleAddToShoppingCart()}
               >
                 <ShoppingCartIcon />
                 <span>Add Selected To Cart</span>
-              </div>
-              <div
+              </div>}
+              {!isUserOfType(UserRoleType.INTERNAL) && <div
                 className="search-result-actions-btn"
                 onClick={() => {
                   let loggedInUser = getUser();
@@ -413,7 +414,7 @@ const Search = () => {
               >
                 <FolderPlusIcon />
                 <span>Add Selected To Folio</span>
-              </div>
+              </div>}
               {showAddToFolio && (
                 <AddToFolio
                   className="pos-absolute-search"


### PR DESCRIPTION
- Hiding Add to Cart and Folio For internal users
- Adding no update text in SR updates tab when no changes for reviewing
- changing where clause for Document Service in show pending records

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-160-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-160-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)