### PR TITLE
feat: SRS-550: show site data in the selected site drawer

### DIFF
--- a/backend/src/app/dto/siteSummary.dto.ts
+++ b/backend/src/app/dto/siteSummary.dto.ts
@@ -85,7 +85,7 @@ export class SiteSummaryDTO extends ChangeAuditEntityDTO {
   longMinutes: number | null;
 
   @Field({ nullable: true })
-  longSeconds: string | null;
+  longSeconds: number | null;
 
   @Field({ nullable: true })
   latDegrees: number | null;
@@ -94,7 +94,7 @@ export class SiteSummaryDTO extends ChangeAuditEntityDTO {
   latMinutes: number | null;
 
   @Field({ nullable: true })
-  latSeconds: string | null;
+  latSeconds: number | null;
 
   @Field({ nullable: true })
   srStatus: string;

--- a/backend/src/app/entities/sites.entity.ts
+++ b/backend/src/app/entities/sites.entity.ts
@@ -199,7 +199,7 @@ export class Sites extends ChangeAuditEntity {
     precision: 4,
     scale: 2,
   })
-  longSeconds: string | null;
+  longSeconds: number | null;
 
   @Field({ nullable: true })
   @Column('smallint', { name: 'lat_degrees', nullable: true })
@@ -216,7 +216,7 @@ export class Sites extends ChangeAuditEntity {
     precision: 4,
     scale: 2,
   })
-  latSeconds: string | null;
+  latSeconds: number | null;
 
   @Field()
   @Column('character varying', {

--- a/backend/src/app/mockData/site.mockData.ts
+++ b/backend/src/app/mockData/site.mockData.ts
@@ -202,10 +202,10 @@ sampleSites = [
     consultantSubmitted: 'Consultant Submitted',
     longDegrees: 0, // Example long degrees
     longMinutes: 0, // Example long minutes
-    longSeconds: '0', // Example long seconds
+    longSeconds: 0, // Example long seconds
     latDegrees: 0, // Example lat degrees
     latMinutes: 0, // Example lat minutes
-    latSeconds: '0', // Example lat seconds
+    latSeconds: 0, // Example lat seconds
     srStatus: 'SR Status',
     latlongReliabilityFlag: 'LatLong Reliability Flag',
     siteRiskCode: 'Site Risk Code',
@@ -259,10 +259,10 @@ sampleSites = [
     consultantSubmitted: 'Consultant Submitted',
     longDegrees: 0, // Example long degrees
     longMinutes: 0, // Example long minutes
-    longSeconds: '0', // Example long seconds
+    longSeconds: 0, // Example long seconds
     latDegrees: 0, // Example lat degrees
     latMinutes: 0, // Example lat minutes
-    latSeconds: '0', // Example lat seconds
+    latSeconds: 0, // Example lat seconds
     srStatus: 'SR Status',
     latlongReliabilityFlag: 'LatLong Reliability Flag',
     siteRiskCode: 'Site Risk Code',

--- a/backend/src/app/services/snapshot/snapshot.service.spec.ts
+++ b/backend/src/app/services/snapshot/snapshot.service.spec.ts
@@ -183,8 +183,8 @@ describe('SnapshotService', () => {
   ];
 
   const sampleSite: Sites = {
-    userAction:"",
-    srAction: "",
+    userAction: '',
+    srAction: '',
     id: '1',
     bcerCode: 'BC1234',
     sstCode: 'SST56',
@@ -202,8 +202,7 @@ describe('SnapshotService', () => {
     victoriaFileNo: 'VF-001',
     regionalFileNo: 'RF-002',
     classCode: 'CC01',
-    generalDescription:
-      'This site is an example for demonstration purposes.',
+    generalDescription: 'This site is an example for demonstration purposes.',
     whoCreated: 'admin',
     whoUpdated: 'editor',
     whenCreated: new Date('2024-01-01T00:00:00Z'),
@@ -213,10 +212,10 @@ describe('SnapshotService', () => {
     consultantSubmitted: 'Y',
     longDegrees: 118,
     longMinutes: 14,
-    longSeconds: '14.34',
+    longSeconds: 14.34,
     latDegrees: 34,
     latMinutes: 3,
-    latSeconds: '7.92',
+    latSeconds: 7.92,
     srStatus: 'Y',
     latlongReliabilityFlag: 'High',
     siteRiskCode: 'UNC',
@@ -238,10 +237,10 @@ describe('SnapshotService', () => {
     recentViewedSites: [],
     cart: [],
     folioContents: [],
-    snapshots: [],                
+    snapshots: [],
   };
 
-  const sampleSitePartics : SitePartics = {                
+  const sampleSitePartics: SitePartics = {
     id: '1',
     siteId: 'site_001',
     psnorgId: 'org_123',
@@ -259,10 +258,9 @@ describe('SnapshotService', () => {
     userAction: 'created',
     srAction: 'reviewed',
     site: sampleSite,
-  }
+  };
 
-
-  const samplePSORG :PeopleOrgs = {
+  const samplePSORG: PeopleOrgs = {
     id: '1',
     organizationName: 'Example Organization',
     displayName: 'Example Org',
@@ -287,124 +285,128 @@ describe('SnapshotService', () => {
     siteDocPartics: [],
     sitePartics: [],
     siteStaffs: [],
-  }
+  };
 
-
-  const sampleSiteSubDivions:SiteSubdivisions[] = [{
-    site: sampleSite,
-    subdivision: null,
-    userAction:"",
-    srAction: "public",
-    "siteId": "101",
-    "subdivId": "202",
-    "dateNoted": new Date("2024-10-01T10:00:00Z"),
-    "initialIndicator": "Y",
-    "whoCreated": "admin_user",
-    "whoUpdated": "editor_user",
-    "whenCreated": new Date("2024-10-01T09:30:00Z"),
-    "whenUpdated": new Date("2024-10-15T14:00:00Z"),
-    "sprofDateCompleted": new Date("2024-10-10T12:00:00Z"),
-    "siteSubdivId": "303",
-    "sendToSr": "N"
-  }
-  ]
+  const sampleSiteSubDivions: SiteSubdivisions[] = [
+    {
+      site: sampleSite,
+      subdivision: null,
+      userAction: '',
+      srAction: 'public',
+      siteId: '101',
+      subdivId: '202',
+      dateNoted: new Date('2024-10-01T10:00:00Z'),
+      initialIndicator: 'Y',
+      whoCreated: 'admin_user',
+      whoUpdated: 'editor_user',
+      whenCreated: new Date('2024-10-01T09:30:00Z'),
+      whenUpdated: new Date('2024-10-15T14:00:00Z'),
+      sprofDateCompleted: new Date('2024-10-10T12:00:00Z'),
+      siteSubdivId: '303',
+      sendToSr: 'N',
+    },
+  ];
 
   const sampleSiteAssociations: SiteAssocs[] = [
     {
-      site:sampleSite,
-      siteIdAssociatedWith2:sampleSite,
-      userAction:"",
-      srAction: "public",
-      "id": "f8c2d6e9-3e10-4e6b-b123-2f0a1eeb9e0c",
-      "siteId": "101",
-      "siteIdAssociatedWith": "202",
-      "effectiveDate": new Date('2024-01-01T12:00:00Z'),
-      "note": "This site is associated with Site 202 for monitoring purposes.",
-      "whoCreated": "admin_user",
-      "whoUpdated": "editor_user",
-      "whenCreated": new Date('2024-01-01T12:00:00Z'),
-      "whenUpdated": new Date('2024-01-01T12:00:00Z'),
-      "rwmFlag": null,
-      "rwmNoteFlag": null,
-      "commonPid": "Y"
-    }
-  ]
-
-  const sampleProfiles: SiteProfiles[] = [{
-    site: sampleSite,
-    userAction:"",
-    srAction: "public",
-    "id": "a2c3e5c6-4f7b-49e6-97d6-1e1b7f45e890",
-    "siteId": "101",
-    "dateCompleted": new Date("2024-01-15T10:30:00Z"),
-    "localAuthDateRecd": new Date("2024-01-15T10:30:00Z"),
-    "localAuthName": "John Doe",
-    "localAuthAgency": "Environmental Agency",
-    "localAuthAddress1": "123 Main St",
-    "localAuthAddress2": "Suite 200",
-    "localAuthPhoneAreaCode": "555",
-    "localAuthPhoneNo": "1234567",
-    "localAuthFaxAreaCode": "555",
-    "localAuthFaxNo": "7654321",
-    "localAuthDateSubmitted": new Date("2024-01-15T10:30:00Z"),
-    "localAuthDateForwarded": new Date("2024-01-15T10:30:00Z"),
-    "rwmDateReceived": new Date("2024-01-15T10:30:00Z"),
-    "rwmParticId": "2001",
-    "rwmPhoneAreaCode": "555",
-    "rwmPhoneNo": "7654321",
-    "rwmFaxAreaCode": "555",
-    "rwmFaxNo": "1234567",
-    "investigationRequired": "Y",
-    "rwmDateDecision": new Date("2024-01-15T10:30:00Z"),
-    "siteRegDateRecd": new Date("2024-01-15T10:30:00Z"),
-    "siteRegDateEntered": new Date("2024-01-15T10:30:00Z"),
-    "siteRegParticId": "3001",
-    "ownerParticId": "4001",
-    "siteAddress": "456 Elm St",
-    "siteCity": "Anytown",
-    "sitePostalCode": "12345",
-    "numberOfPids": 5,
-    "numberOfPins": 10,
-    "latDegrees": 34,
-    "latMinutes": 12,
-    "latSeconds": "34.56",
-    "longDegrees": -118,
-    "longMinutes": 15,
-    "longSeconds": "45.67",
-    "comments": "Site requires further investigation.",
-    "whoCreated": "admin_user",
-    "whoUpdated": "editor_user",
-    "whenCreated": new Date("2024-01-15T10:30:00Z"),
-    "whenUpdated": new Date("2024-01-15T10:30:00Z"),
-    "localAuthEmail": "johndoe@example.com",
-    "plannedActivityComment": "Planning for site assessment.",
-    "siteDisclosureComment": "Disclosure of previous activities.",
-    "govDocumentsComment": "Pending government document approvals."
-  }]  ;
-  
-  const sampleLandHistories: LandHistories[] = [{
-    userAction:"",
-    srAction:"public",
-    "siteId": "1",
-    "guid": "d7f8c6e3-7b9b-4f5e-8b92-e5b9b1d34567",
-    "lutCode": "LU1234",
-    "note": "Initial land use assessment completed.",
-    "whoCreated": "admin_user",
-    "whoUpdated": "editor_user",
-    "whenCreated": new Date("2024-01-15T10:30:00Z"),
-    "whenUpdated": new Date("2024-01-15T10:30:00Z"),
-    "rwmFlag": 1,
-    "rwmNoteFlag": 0,
-    "siteProfile": "Y",
-    "profileDateReceived": new Date("2024-01-15T10:30:00Z"),
-    "landUse": {
-      "code": "LU1234",
-      "description": "Residential Development",
-      "landHistories":  [],
-      siteProfileLandUses: []
+      site: sampleSite,
+      siteIdAssociatedWith2: sampleSite,
+      userAction: '',
+      srAction: 'public',
+      id: 'f8c2d6e9-3e10-4e6b-b123-2f0a1eeb9e0c',
+      siteId: '101',
+      siteIdAssociatedWith: '202',
+      effectiveDate: new Date('2024-01-01T12:00:00Z'),
+      note: 'This site is associated with Site 202 for monitoring purposes.',
+      whoCreated: 'admin_user',
+      whoUpdated: 'editor_user',
+      whenCreated: new Date('2024-01-01T12:00:00Z'),
+      whenUpdated: new Date('2024-01-01T12:00:00Z'),
+      rwmFlag: null,
+      rwmNoteFlag: null,
+      commonPid: 'Y',
     },
-    "site": sampleSite
-  }]
+  ];
+
+  const sampleProfiles: SiteProfiles[] = [
+    {
+      site: sampleSite,
+      userAction: '',
+      srAction: 'public',
+      id: 'a2c3e5c6-4f7b-49e6-97d6-1e1b7f45e890',
+      siteId: '101',
+      dateCompleted: new Date('2024-01-15T10:30:00Z'),
+      localAuthDateRecd: new Date('2024-01-15T10:30:00Z'),
+      localAuthName: 'John Doe',
+      localAuthAgency: 'Environmental Agency',
+      localAuthAddress1: '123 Main St',
+      localAuthAddress2: 'Suite 200',
+      localAuthPhoneAreaCode: '555',
+      localAuthPhoneNo: '1234567',
+      localAuthFaxAreaCode: '555',
+      localAuthFaxNo: '7654321',
+      localAuthDateSubmitted: new Date('2024-01-15T10:30:00Z'),
+      localAuthDateForwarded: new Date('2024-01-15T10:30:00Z'),
+      rwmDateReceived: new Date('2024-01-15T10:30:00Z'),
+      rwmParticId: '2001',
+      rwmPhoneAreaCode: '555',
+      rwmPhoneNo: '7654321',
+      rwmFaxAreaCode: '555',
+      rwmFaxNo: '1234567',
+      investigationRequired: 'Y',
+      rwmDateDecision: new Date('2024-01-15T10:30:00Z'),
+      siteRegDateRecd: new Date('2024-01-15T10:30:00Z'),
+      siteRegDateEntered: new Date('2024-01-15T10:30:00Z'),
+      siteRegParticId: '3001',
+      ownerParticId: '4001',
+      siteAddress: '456 Elm St',
+      siteCity: 'Anytown',
+      sitePostalCode: '12345',
+      numberOfPids: 5,
+      numberOfPins: 10,
+      latDegrees: 34,
+      latMinutes: 12,
+      latSeconds: '34.56',
+      longDegrees: -118,
+      longMinutes: 15,
+      longSeconds: '45.67',
+      comments: 'Site requires further investigation.',
+      whoCreated: 'admin_user',
+      whoUpdated: 'editor_user',
+      whenCreated: new Date('2024-01-15T10:30:00Z'),
+      whenUpdated: new Date('2024-01-15T10:30:00Z'),
+      localAuthEmail: 'johndoe@example.com',
+      plannedActivityComment: 'Planning for site assessment.',
+      siteDisclosureComment: 'Disclosure of previous activities.',
+      govDocumentsComment: 'Pending government document approvals.',
+    },
+  ];
+
+  const sampleLandHistories: LandHistories[] = [
+    {
+      userAction: '',
+      srAction: 'public',
+      siteId: '1',
+      guid: 'd7f8c6e3-7b9b-4f5e-8b92-e5b9b1d34567',
+      lutCode: 'LU1234',
+      note: 'Initial land use assessment completed.',
+      whoCreated: 'admin_user',
+      whoUpdated: 'editor_user',
+      whenCreated: new Date('2024-01-15T10:30:00Z'),
+      whenUpdated: new Date('2024-01-15T10:30:00Z'),
+      rwmFlag: 1,
+      rwmNoteFlag: 0,
+      siteProfile: 'Y',
+      profileDateReceived: new Date('2024-01-15T10:30:00Z'),
+      landUse: {
+        code: 'LU1234',
+        description: 'Residential Development',
+        landHistories: [],
+        siteProfileLandUses: [],
+      },
+      site: sampleSite,
+    },
+  ];
 
   const sampleSiteParticipants: SitePartics[] = [
     {
@@ -415,19 +417,24 @@ describe('SnapshotService', () => {
       endDate: null,
       note: 'Note 1',
       psnorg: samplePSORG,
-      whoCreated: "",
+      whoCreated: '',
       rwmFlag: 1,
-      rwmNoteFlag : 1,
+      rwmNoteFlag: 1,
       site: sampleSite,
       whoUpdated: 'admin',
       whenCreated: new Date('2024-01-01T12:00:00Z'),
       whenUpdated: new Date('2024-10-01T12:00:00Z'),
-      userAction:"",
-      srAction: "",   
+      userAction: '',
+      srAction: '',
       siteParticRoles: [
-        { rwmFlag:1, sp:sampleSitePartics
-          , userAction:"", srAction:"",
-          id:"", spId:"",  whoCreated: 'admin',
+        {
+          rwmFlag: 1,
+          sp: sampleSitePartics,
+          userAction: '',
+          srAction: '',
+          id: '',
+          spId: '',
+          whoCreated: 'admin',
           whoUpdated: 'admin',
           whenCreated: new Date('2024-01-01T12:00:00Z'),
           whenUpdated: new Date('2024-10-01T12:00:00Z'),
@@ -436,9 +443,9 @@ describe('SnapshotService', () => {
             description: 'Role 1 Description',
             code: '',
             siteParticRoles: [
-              {              
-                userAction:"",
-                srAction: "",              
+              {
+                userAction: '',
+                srAction: '',
                 id: 'b8a7c6f3-d29b-4f91-9b16-e21e8b63e4f5',
                 prCode: 'ROLE1',
                 spId: '12345',
@@ -1325,7 +1332,6 @@ describe('SnapshotService', () => {
       ).rejects.toThrow(mockError);
     });
 
-
     it('Should Only Return Land Histories with Pending Status', async () => {
       jest
         .spyOn(landHistoriesRepository, 'find')
@@ -1350,7 +1356,6 @@ describe('SnapshotService', () => {
         service.getLandHisotoriesForSnapshotCreation(''),
       ).rejects.toThrow(mockError);
     });
-
 
     it('Should Only Return Disclosure with Pending Status', async () => {
       jest
@@ -1377,7 +1382,6 @@ describe('SnapshotService', () => {
       ).rejects.toThrow(mockError);
     });
 
-
     it('Should Only Return Site Associations with Pending Status', async () => {
       jest
         .spyOn(siteAssocsRepository, 'find')
@@ -1403,7 +1407,6 @@ describe('SnapshotService', () => {
       ).rejects.toThrow(mockError);
     });
 
-
     it('Should Only Return Site SubDivisions with Pending Status', async () => {
       jest
         .spyOn(siteSubdivisionsRepository, 'find')
@@ -1428,7 +1431,5 @@ describe('SnapshotService', () => {
         service.getSubDivisionsForSnapshotCreation(''),
       ).rejects.toThrow(mockError);
     });
-
-    
   });
 });

--- a/frontend/src/app/features/map/MapSearch.graphql
+++ b/frontend/src/app/features/map/MapSearch.graphql
@@ -8,3 +8,24 @@ query mapSearch($searchParam: String!) {
         }
     }
 }
+
+query MapSearch_findSiteBySiteId($siteId: String!) {
+    findSiteBySiteId(siteId: $siteId) {
+        data {
+            id
+            addrLine_1
+            addrLine_2
+            addrLine_3
+            addrLine_4
+            city
+            latDegrees
+            latMinutes
+            latSeconds
+            longDegrees
+            longMinutes
+            longSeconds
+            generalDescription
+            siteRiskCode
+        }
+    }
+}

--- a/frontend/src/app/features/map/siteDrawer/SiteDetailsDrawer.css
+++ b/frontend/src/app/features/map/siteDrawer/SiteDetailsDrawer.css
@@ -8,6 +8,7 @@
   position: absolute;
   background-color: var(--surface-color-background-light);
   box-shadow: var(--surface-shadow-medium);
+  overflow-y: hidden;
 }
 
 .site-drawer-header {
@@ -15,7 +16,7 @@
   height: 69px;
   justify-content: space-between;
   align-items: center;
-  padding: var(--layout-margin-large);
+  padding: var(--layout-padding-large);
   border-bottom: 1px solid var(--surface-color-border-light);
 
   font-size: var(--typography-font-size-body);
@@ -34,5 +35,33 @@
 }
 
 .site-drawer-body {
-  padding: var(--layout-margin-large);
+  padding: var(--layout-padding-large);
+  overflow-y: auto;
+}
+
+.site-drawer-info-summary {
+  padding: var(--layout-padding-medium) var(--layout-padding-large);
+  border: 1px solid var(--support-border-color-info);
+  background-color: var(--support-surface-color-info);
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: var(--layout-margin-large);
+}
+
+@media screen and (max-width: 576px) {
+  .site-drawer-info-summary {
+    grid-template-columns: auto;
+  }
+}
+
+.site-drawer-info-summary > .summary-item {
+  display: flex;
+  flex-direction: row;
+  gap: var(--layout-margin-small);
+}
+
+@media screen and (max-width: 768px) {
+  .site-drawer-info-summary > .summary-item {
+    flex-direction: column;
+  }
 }

--- a/frontend/src/app/features/map/siteDrawer/SiteDetailsDrawer.tsx
+++ b/frontend/src/app/features/map/siteDrawer/SiteDetailsDrawer.tsx
@@ -8,8 +8,13 @@ import {
   ChevronDown,
   ChevronRight,
   ChevronUp,
+  SpinnerIcon,
   XmarkIcon2,
 } from '../../../components/common/icon';
+import {
+  useMapSearch_FindSiteBySiteIdQuery,
+  MapSearch_FindSiteBySiteIdQuery,
+} from '../../../../graphql/generated';
 
 enum ExpansionState {
   Default,
@@ -56,6 +61,41 @@ const getNextExpansionStateFromResizeRatio = (ratio: number) => {
   }
 };
 
+const SummaryItem = ({
+  label,
+  value,
+}: {
+  label: string;
+  value?: number | string | null;
+}) => {
+  return (
+    <div className="summary-item">
+      <div className="fw-bold">{label}</div>
+      <div>{value || ''}</div>
+    </div>
+  );
+};
+
+type Site = MapSearch_FindSiteBySiteIdQuery['findSiteBySiteId']['data'];
+const formatAddress = (site: Site) => {
+  const addressLines = [
+    site?.addrLine_1,
+    site?.addrLine_2,
+    site?.addrLine_3,
+    site?.addrLine_4,
+  ];
+  return addressLines.filter(Boolean).join(', ');
+};
+
+const formatCoordinates = (coords: Array<number | undefined | null>) => {
+  const [d, m, s] = coords;
+  let result = '';
+  if (d) result += `${d}d`;
+  if (m) result += `, ${m}m`;
+  if (s) result += `, ${s}s`;
+  return result;
+};
+
 export const SiteDetailsDrawer: FC = () => {
   const [open, setOpen] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
@@ -67,6 +107,13 @@ export const SiteDetailsDrawer: FC = () => {
     'site',
     StringParam,
   );
+
+  const { data, loading } = useMapSearch_FindSiteBySiteIdQuery({
+    variables: { siteId: selectedSiteId || '' },
+    skip: !selectedSiteId,
+  });
+
+  const siteData = data?.findSiteBySiteId.data;
 
   useEffect(() => {
     if (selectedSiteId) {
@@ -196,9 +243,42 @@ export const SiteDetailsDrawer: FC = () => {
       </div>
 
       <div className="site-drawer-body">
-        <span>
-          <span className="fw-bold">Site ID:</span> {selectedSiteId}
-        </span>
+        <div className="mb-2">
+          <span className="fw-bold mb-2">Site ID:</span> {selectedSiteId}
+        </div>
+        {loading && <SpinnerIcon size={20} className="site-fa-spin" />}
+        {!loading && (
+          <div className="d-grid gap-3">
+            <h4 className="fw-bold">{formatAddress(siteData)}</h4>
+            <div className="site-drawer-info-summary">
+              <SummaryItem
+                label="Latitude"
+                value={formatCoordinates([
+                  siteData?.latDegrees,
+                  siteData?.latMinutes,
+                  siteData?.latSeconds,
+                ])}
+              />
+              <SummaryItem
+                label="Site Risk Classification"
+                value={siteData?.siteRiskCode || 'N/A'}
+              />
+              <SummaryItem
+                label="Longitude"
+                value={formatCoordinates([
+                  siteData?.longDegrees,
+                  siteData?.longMinutes,
+                  siteData?.longSeconds,
+                ])}
+              />
+              <SummaryItem label="Region" value={siteData?.city} />
+            </div>
+            <div>
+              <div className="fw-bold mb-2">Location Description</div>
+              <div>{siteData?.generalDescription}</div>
+            </div>
+          </div>
+        )}
       </div>
     </Drawer>
   );

--- a/frontend/src/graphql/generated.ts
+++ b/frontend/src/graphql/generated.ts
@@ -1200,12 +1200,12 @@ export type SiteSummaryDto = {
   id: Scalars['String']['input'];
   latDegrees?: InputMaybe<Scalars['Float']['input']>;
   latMinutes?: InputMaybe<Scalars['Float']['input']>;
-  latSeconds?: InputMaybe<Scalars['String']['input']>;
+  latSeconds?: InputMaybe<Scalars['Float']['input']>;
   latdeg?: InputMaybe<Scalars['Float']['input']>;
   latlongReliabilityFlag?: InputMaybe<Scalars['String']['input']>;
   longDegrees?: InputMaybe<Scalars['Float']['input']>;
   longMinutes?: InputMaybe<Scalars['Float']['input']>;
-  longSeconds?: InputMaybe<Scalars['String']['input']>;
+  longSeconds?: InputMaybe<Scalars['Float']['input']>;
   longdeg?: InputMaybe<Scalars['Float']['input']>;
   postalCode?: InputMaybe<Scalars['String']['input']>;
   provState?: InputMaybe<Scalars['String']['input']>;
@@ -1247,12 +1247,12 @@ export type Sites = {
   landHistories: Array<LandHistories>;
   latDegrees?: Maybe<Scalars['Float']['output']>;
   latMinutes?: Maybe<Scalars['Float']['output']>;
-  latSeconds?: Maybe<Scalars['String']['output']>;
+  latSeconds?: Maybe<Scalars['Float']['output']>;
   latdeg?: Maybe<Scalars['Float']['output']>;
   latlongReliabilityFlag: Scalars['String']['output'];
   longDegrees?: Maybe<Scalars['Float']['output']>;
   longMinutes?: Maybe<Scalars['Float']['output']>;
-  longSeconds?: Maybe<Scalars['String']['output']>;
+  longSeconds?: Maybe<Scalars['Float']['output']>;
   longdeg?: Maybe<Scalars['Float']['output']>;
   mailouts: Array<Mailout>;
   postalCode?: Maybe<Scalars['String']['output']>;
@@ -1268,7 +1268,7 @@ export type Sites = {
   sitePartics: Array<SitePartics>;
   siteProfiles: Array<SiteProfiles>;
   siteRiskCode: Scalars['String']['output'];
-  siteRiskCode2: SiteRiskCd;
+  siteRiskCode2?: Maybe<SiteRiskCd>;
   siteSubdivisions: SiteSubdivisions;
   srAction: Scalars['String']['output'];
   srStatus: Scalars['String']['output'];
@@ -1322,6 +1322,13 @@ export type MapSearchQueryVariables = Exact<{
 
 export type MapSearchQuery = { __typename?: 'Query', searchSites: { __typename?: 'SearchSiteResponse', sites: Array<{ __typename?: 'Sites', id: string, addrLine_1: string, latdeg?: number | null, longdeg?: number | null }> } };
 
+export type MapSearch_FindSiteBySiteIdQueryVariables = Exact<{
+  siteId: Scalars['String']['input'];
+}>;
+
+
+export type MapSearch_FindSiteBySiteIdQuery = { __typename?: 'Query', findSiteBySiteId: { __typename?: 'FetchSiteDetail', data?: { __typename?: 'Sites', id: string, addrLine_1: string, addrLine_2?: string | null, addrLine_3?: string | null, addrLine_4?: string | null, city: string, latDegrees?: number | null, latMinutes?: number | null, latSeconds?: number | null, longDegrees?: number | null, longMinutes?: number | null, longSeconds?: number | null, generalDescription?: string | null, siteRiskCode: string } | null } };
+
 
 export const MapSearchDocument = gql`
     query mapSearch($searchParam: String!) {
@@ -1368,3 +1375,58 @@ export type MapSearchQueryHookResult = ReturnType<typeof useMapSearchQuery>;
 export type MapSearchLazyQueryHookResult = ReturnType<typeof useMapSearchLazyQuery>;
 export type MapSearchSuspenseQueryHookResult = ReturnType<typeof useMapSearchSuspenseQuery>;
 export type MapSearchQueryResult = Apollo.QueryResult<MapSearchQuery, MapSearchQueryVariables>;
+export const MapSearch_FindSiteBySiteIdDocument = gql`
+    query MapSearch_findSiteBySiteId($siteId: String!) {
+  findSiteBySiteId(siteId: $siteId) {
+    data {
+      id
+      addrLine_1
+      addrLine_2
+      addrLine_3
+      addrLine_4
+      city
+      latDegrees
+      latMinutes
+      latSeconds
+      longDegrees
+      longMinutes
+      longSeconds
+      generalDescription
+      siteRiskCode
+    }
+  }
+}
+    `;
+
+/**
+ * __useMapSearch_FindSiteBySiteIdQuery__
+ *
+ * To run a query within a React component, call `useMapSearch_FindSiteBySiteIdQuery` and pass it any options that fit your needs.
+ * When your component renders, `useMapSearch_FindSiteBySiteIdQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useMapSearch_FindSiteBySiteIdQuery({
+ *   variables: {
+ *      siteId: // value for 'siteId'
+ *   },
+ * });
+ */
+export function useMapSearch_FindSiteBySiteIdQuery(baseOptions: Apollo.QueryHookOptions<MapSearch_FindSiteBySiteIdQuery, MapSearch_FindSiteBySiteIdQueryVariables> & ({ variables: MapSearch_FindSiteBySiteIdQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<MapSearch_FindSiteBySiteIdQuery, MapSearch_FindSiteBySiteIdQueryVariables>(MapSearch_FindSiteBySiteIdDocument, options);
+      }
+export function useMapSearch_FindSiteBySiteIdLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MapSearch_FindSiteBySiteIdQuery, MapSearch_FindSiteBySiteIdQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<MapSearch_FindSiteBySiteIdQuery, MapSearch_FindSiteBySiteIdQueryVariables>(MapSearch_FindSiteBySiteIdDocument, options);
+        }
+export function useMapSearch_FindSiteBySiteIdSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<MapSearch_FindSiteBySiteIdQuery, MapSearch_FindSiteBySiteIdQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<MapSearch_FindSiteBySiteIdQuery, MapSearch_FindSiteBySiteIdQueryVariables>(MapSearch_FindSiteBySiteIdDocument, options);
+        }
+export type MapSearch_FindSiteBySiteIdQueryHookResult = ReturnType<typeof useMapSearch_FindSiteBySiteIdQuery>;
+export type MapSearch_FindSiteBySiteIdLazyQueryHookResult = ReturnType<typeof useMapSearch_FindSiteBySiteIdLazyQuery>;
+export type MapSearch_FindSiteBySiteIdSuspenseQueryHookResult = ReturnType<typeof useMapSearch_FindSiteBySiteIdSuspenseQuery>;
+export type MapSearch_FindSiteBySiteIdQueryResult = Apollo.QueryResult<MapSearch_FindSiteBySiteIdQuery, MapSearch_FindSiteBySiteIdQueryVariables>;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This PR adds fetching and displaying of data in the selected site drawer of the map search view

Fixes [SRS-550](https://env-epd.atlassian.net/browse/SRS-550)

**Note**: This change does not include Parcel IDs section of the drawer and will be added later.

L screen (width > 786px)

<img width="1741" alt="Screenshot 2024-11-01 at 7 15 46 PM" src="https://github.com/user-attachments/assets/11522df9-9ab6-466a-a19a-cc94444d1494">

M screen (576px < width <= 786px)

<img width="757" alt="Screenshot 2024-11-01 at 7 16 03 PM" src="https://github.com/user-attachments/assets/7a80328e-8b30-4a56-808c-3c5cadc1ff17">

S screen (width <= 576px)

<img width="521" alt="Screenshot 2024-11-01 at 7 16 19 PM" src="https://github.com/user-attachments/assets/cb33a500-83d6-4b81-8eab-dc4218a5218f">

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Navigate to `/map` route and click around the sites on the map to view the data


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

N/A


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-166-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-166-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)