### PR TITLE
feat: Updates Tab For Site Registrar

### DIFF
--- a/backend/src/app/dto/sitesPendingReview.dto.ts
+++ b/backend/src/app/dto/sitesPendingReview.dto.ts
@@ -111,6 +111,10 @@ export class BulkApproveRejectChangesDTO {
   @IsNotEmpty()
   isApproved: boolean;
 
+  @Field(() => Boolean)
+  @IsBoolean() 
+  fromSiteDetails: boolean;
+
   @Field(() => [SiteRecordsForSRAction])
   @IsArray()
   @IsNotEmpty()

--- a/backend/src/app/services/site/site.service.spec.ts
+++ b/backend/src/app/services/site/site.service.spec.ts
@@ -636,6 +636,7 @@ describe('SiteService', () => {
       it('Bulk Approve/Reject ', async () => {
         const inputDTO: BulkApproveRejectChangesDTO = {
           isApproved: true,
+          fromSiteDetails: false,
           sites: [
             {
               id: '1',
@@ -683,6 +684,7 @@ describe('SiteService', () => {
           entityManager,
           site,
           true,
+          false,
           userInfo,
         );
 

--- a/backend/src/app/services/site/site.service.ts
+++ b/backend/src/app/services/site/site.service.ts
@@ -318,7 +318,7 @@ export class SiteService {
 
     if (pending) {
       const result = await this.siteRepository.findOne({
-        where: { id: siteId, userAction: UserActionEnum.UPDATED },
+        where: { id: siteId, srAction: SRApprovalStatusEnum.PENDING},
       });
 
       response.data = result ? result : null;
@@ -1536,9 +1536,11 @@ export class SiteService {
         );
         return false;
       } else {
-        const { isApproved, sites } = inputDTO;
+        const { isApproved, sites , fromSiteDetails } = inputDTO;
 
-        sites.forEach(async (site: SiteRecordsForSRAction) => {
+
+        for (const site of sites)
+        {
           await this.entityManager.transaction(
             async (transactionalEntityManager: EntityManager) => {
               if (
@@ -1551,12 +1553,13 @@ export class SiteService {
                 transactionalEntityManager,
                 site,
                 isApproved,
+                fromSiteDetails,
                 userInfo,
               );
             },
           );
-        });
-
+        }
+        
         return true;
       }
     } catch (error) {
@@ -1571,6 +1574,7 @@ export class SiteService {
     transactionalEntityManager: EntityManager,
     site: SiteRecordsForSRAction,
     isApproved: boolean,
+    fromSiteDetails: boolean,
     userInfo: any,
   ) {
     try {
@@ -1584,8 +1588,10 @@ export class SiteService {
       }
 
       if (site.changes.indexOf('summary') !== -1) {
-        const sitesForUpdates = await transactionalEntityManager.find(Sites, {
+        const sitesForUpdates = !fromSiteDetails? await transactionalEntityManager.find(Sites, {
           where: { id: site.siteId, whoUpdated: site.whoUpdated },
+        }):await transactionalEntityManager.find(Sites, {
+          where: { id: site.siteId },
         });
 
         if (sitesForUpdates?.length > 0) {
@@ -1601,8 +1607,10 @@ export class SiteService {
       }
 
       if (site.changes.indexOf('notation') !== -1) {
-        const events = await transactionalEntityManager.find(Events, {
+        const events = !fromSiteDetails?await transactionalEntityManager.find(Events, {
           where: { siteId: site.siteId, whoUpdated: site.whoUpdated },
+        }):await transactionalEntityManager.find(Events, {
+          where: { siteId: site.siteId},
         });
 
         if (events?.length > 0) {
@@ -1614,12 +1622,19 @@ export class SiteService {
 
           const eventIds = events.map((event) => event.id);
 
-          const eventsParticipants = await transactionalEntityManager.find(
+          const eventsParticipants = !fromSiteDetails?await transactionalEntityManager.find(
             EventPartics,
             {
               where: {
                 eventId: In(eventIds),
                 whoUpdated: site.whoUpdated,
+              },
+            },
+          ):await transactionalEntityManager.find(
+            EventPartics,
+            {
+              where: {
+                eventId: In(eventIds)              
               },
             },
           );
@@ -1646,12 +1661,19 @@ export class SiteService {
       }
 
       if (site.changes.indexOf('site participants') !== -1) {
-        const siteParticipants = await transactionalEntityManager.find(
+        const siteParticipants = !fromSiteDetails?await transactionalEntityManager.find(
           SitePartics,
           {
             where: {
               siteId: site.siteId,
               whoUpdated: site.whoUpdated,
+            },
+          },
+        ):await transactionalEntityManager.find(
+          SitePartics,
+          {
+            where: {
+              siteId: site.siteId,
             },
           },
         );
@@ -1670,10 +1692,14 @@ export class SiteService {
       }
 
       if (site.changes.indexOf('documents') !== -1) {
-        const siteDocs = await transactionalEntityManager.find(SiteDocs, {
+        const siteDocs = !fromSiteDetails?await transactionalEntityManager.find(SiteDocs, {
           where: {
             siteId: site.siteId,
             whoUpdated: site.whoUpdated,
+          },
+        }):await transactionalEntityManager.find(SiteDocs, {
+          where: {
+            siteId: site.siteId,
           },
         });
 
@@ -1691,12 +1717,19 @@ export class SiteService {
       }
 
       if (site.changes.indexOf('associated sites') !== -1) {
-        const siteAssociations = await transactionalEntityManager.find(
+        const siteAssociations = !fromSiteDetails?await transactionalEntityManager.find(
           SiteAssocs,
           {
             where: {
               siteId: site.siteId,
               whoUpdated: site.whoUpdated,
+            },
+          },
+        ):await transactionalEntityManager.find(
+          SiteAssocs,
+          {
+            where: {
+              siteId: site.siteId,
             },
           },
         );
@@ -1715,12 +1748,19 @@ export class SiteService {
       }
 
       if (site.changes.indexOf('land histories') !== -1) {
-        const landHistories = await transactionalEntityManager.find(
+        const landHistories = !fromSiteDetails?await transactionalEntityManager.find(
           LandHistories,
           {
             where: {
               siteId: site.siteId,
               whoUpdated: site.whoUpdated,
+            },
+          },
+        ):await transactionalEntityManager.find(
+          LandHistories,
+          {
+            where: {
+              siteId: site.siteId,             
             },
           },
         );
@@ -1739,10 +1779,14 @@ export class SiteService {
       }
 
       if (site.changes.indexOf('site profiles') !== -1) {
-        const profiles = await transactionalEntityManager.find(SiteProfiles, {
+        const profiles = !fromSiteDetails?await transactionalEntityManager.find(SiteProfiles, {
           where: {
             siteId: site.siteId,
             whoUpdated: site.whoUpdated,
+          },
+        }):await transactionalEntityManager.find(SiteProfiles, {
+          where: {
+            siteId: site.siteId,
           },
         });
 
@@ -1760,7 +1804,7 @@ export class SiteService {
       }
 
       if (site.changes.indexOf('parcel description') !== -1) {
-        const siteSubDivisions = await transactionalEntityManager.find(
+        const siteSubDivisions = !fromSiteDetails?await transactionalEntityManager.find(
           SiteSubdivisions,
           {
             where: {
@@ -1768,15 +1812,27 @@ export class SiteService {
               whoUpdated: site.whoUpdated,
             },
           },
+        ):await transactionalEntityManager.find(
+          SiteSubdivisions,
+          {
+            where: {
+              siteId: site.siteId,
+            },
+          },
         );
 
         if (siteSubDivisions?.length > 0) {
           const subDivIds = siteSubDivisions.map((x) => x.subdivId);
 
-          const subDivisions = await transactionalEntityManager.find(
+          const subDivisions = !fromSiteDetails?await transactionalEntityManager.find(
             Subdivisions,
             {
               where: { id: In(subDivIds), whoUpdated: site.whoUpdated },
+            },
+          ):await transactionalEntityManager.find(
+            Subdivisions,
+            {
+              where: { id: In(subDivIds)},
             },
           );
 

--- a/backend/src/app/services/site/site.service.ts
+++ b/backend/src/app/services/site/site.service.ts
@@ -628,8 +628,10 @@ export class SiteService {
                   changes: {
                     ...existingDocument,
                     ...siteDocument,
-                    userAction: UserActionEnum.UPDATED,
-                    srAction: SRApprovalStatusEnum.PENDING,
+                    userAction: document.srAction === SRApprovalStatusEnum.PUBLIC ||
+                    document.srAction === SRApprovalStatusEnum.PRIVATE
+                      ? UserActionEnum.DEFAULT
+                      : UserActionEnum.UPDATED,                   
                     whenUpdated: new Date(),
                     whoUpdated: userInfo ? userInfo.givenName : '',
                   },
@@ -646,8 +648,10 @@ export class SiteService {
                     changes: {
                       ...existingDocumentParticipant,
                       ...siteDocumentParticipant,
-                      userAction: UserActionEnum.UPDATED,
-                      srAction: SRApprovalStatusEnum.PENDING,
+                      userAction: document.srAction === SRApprovalStatusEnum.PUBLIC ||
+                      document.srAction === SRApprovalStatusEnum.PRIVATE
+                        ? UserActionEnum.DEFAULT
+                        : UserActionEnum.UPDATED,                     
                       whenUpdated: new Date(),
                       whoUpdated: userInfo ? userInfo.givenName : '',
                     },

--- a/backend/src/app/services/site/site.service.ts
+++ b/backend/src/app/services/site/site.service.ts
@@ -1558,8 +1558,7 @@ export class SiteService {
               );
             },
           );
-        }
-        
+        }        
         return true;
       }
     } catch (error) {
@@ -1589,9 +1588,9 @@ export class SiteService {
 
       if (site.changes.indexOf('summary') !== -1) {
         const sitesForUpdates = !fromSiteDetails? await transactionalEntityManager.find(Sites, {
-          where: { id: site.siteId, whoUpdated: site.whoUpdated },
+          where: { id: site.siteId, whoUpdated: site.whoUpdated, srAction: SRApprovalStatusEnum.PENDING },
         }):await transactionalEntityManager.find(Sites, {
-          where: { id: site.siteId },
+          where: { id: site.siteId, srAction: SRApprovalStatusEnum.PENDING },
         });
 
         if (sitesForUpdates?.length > 0) {
@@ -1608,9 +1607,9 @@ export class SiteService {
 
       if (site.changes.indexOf('notation') !== -1) {
         const events = !fromSiteDetails?await transactionalEntityManager.find(Events, {
-          where: { siteId: site.siteId, whoUpdated: site.whoUpdated },
+          where: { siteId: site.siteId, whoUpdated: site.whoUpdated, srAction: SRApprovalStatusEnum.PENDING },
         }):await transactionalEntityManager.find(Events, {
-          where: { siteId: site.siteId},
+          where: { siteId: site.siteId, srAction: SRApprovalStatusEnum.PENDING},
         });
 
         if (events?.length > 0) {
@@ -1628,13 +1627,15 @@ export class SiteService {
               where: {
                 eventId: In(eventIds),
                 whoUpdated: site.whoUpdated,
+                srAction: SRApprovalStatusEnum.PENDING
               },
             },
           ):await transactionalEntityManager.find(
             EventPartics,
             {
               where: {
-                eventId: In(eventIds)              
+                eventId: In(eventIds) ,
+                srAction: SRApprovalStatusEnum.PENDING            
               },
             },
           );
@@ -1666,14 +1667,14 @@ export class SiteService {
           {
             where: {
               siteId: site.siteId,
-              whoUpdated: site.whoUpdated,
+              whoUpdated: site.whoUpdated, srAction: SRApprovalStatusEnum.PENDING
             },
           },
         ):await transactionalEntityManager.find(
           SitePartics,
           {
             where: {
-              siteId: site.siteId,
+              siteId: site.siteId, srAction: SRApprovalStatusEnum.PENDING
             },
           },
         );
@@ -1695,11 +1696,11 @@ export class SiteService {
         const siteDocs = !fromSiteDetails?await transactionalEntityManager.find(SiteDocs, {
           where: {
             siteId: site.siteId,
-            whoUpdated: site.whoUpdated,
+            whoUpdated: site.whoUpdated, srAction: SRApprovalStatusEnum.PENDING
           },
         }):await transactionalEntityManager.find(SiteDocs, {
           where: {
-            siteId: site.siteId,
+            siteId: site.siteId, srAction: SRApprovalStatusEnum.PENDING
           },
         });
 
@@ -1722,14 +1723,14 @@ export class SiteService {
           {
             where: {
               siteId: site.siteId,
-              whoUpdated: site.whoUpdated,
+              whoUpdated: site.whoUpdated, srAction: SRApprovalStatusEnum.PENDING
             },
           },
         ):await transactionalEntityManager.find(
           SiteAssocs,
           {
             where: {
-              siteId: site.siteId,
+              siteId: site.siteId, srAction: SRApprovalStatusEnum.PENDING
             },
           },
         );
@@ -1753,14 +1754,14 @@ export class SiteService {
           {
             where: {
               siteId: site.siteId,
-              whoUpdated: site.whoUpdated,
+              whoUpdated: site.whoUpdated, srAction: SRApprovalStatusEnum.PENDING
             },
           },
         ):await transactionalEntityManager.find(
           LandHistories,
           {
             where: {
-              siteId: site.siteId,             
+              siteId: site.siteId, srAction: SRApprovalStatusEnum.PENDING             
             },
           },
         );
@@ -1782,11 +1783,11 @@ export class SiteService {
         const profiles = !fromSiteDetails?await transactionalEntityManager.find(SiteProfiles, {
           where: {
             siteId: site.siteId,
-            whoUpdated: site.whoUpdated,
+            whoUpdated: site.whoUpdated, srAction: SRApprovalStatusEnum.PENDING
           },
         }):await transactionalEntityManager.find(SiteProfiles, {
           where: {
-            siteId: site.siteId,
+            siteId: site.siteId, srAction: SRApprovalStatusEnum.PENDING
           },
         });
 
@@ -1809,14 +1810,14 @@ export class SiteService {
           {
             where: {
               siteId: site.siteId,
-              whoUpdated: site.whoUpdated,
+              whoUpdated: site.whoUpdated, srAction: SRApprovalStatusEnum.PENDING
             },
           },
         ):await transactionalEntityManager.find(
           SiteSubdivisions,
           {
             where: {
-              siteId: site.siteId,
+              siteId: site.siteId, srAction: SRApprovalStatusEnum.PENDING
             },
           },
         );
@@ -1827,12 +1828,12 @@ export class SiteService {
           const subDivisions = !fromSiteDetails?await transactionalEntityManager.find(
             Subdivisions,
             {
-              where: { id: In(subDivIds), whoUpdated: site.whoUpdated },
+              where: { id: In(subDivIds), whoUpdated: site.whoUpdated , srAction: SRApprovalStatusEnum.PENDING},
             },
           ):await transactionalEntityManager.find(
             Subdivisions,
             {
-              where: { id: In(subDivIds)},
+              where: { id: In(subDivIds), srAction: SRApprovalStatusEnum.PENDING}
             },
           );
 

--- a/frontend/src/app/components/action/ActionsConfig.ts
+++ b/frontend/src/app/components/action/ActionsConfig.ts
@@ -1,4 +1,4 @@
-import { SiteDetailsMode } from '../../features/details/dto/SiteDetailsMode';
+import { SiteActionBtn, SiteDetailsMode } from '../../features/details/dto/SiteDetailsMode';
 import { DropdownItem } from './IActions';
 
 export const ActionItems: DropdownItem[] = [
@@ -13,5 +13,27 @@ export const ActionItems: DropdownItem[] = [
   {
     label: 'Delete',
     value: SiteDetailsMode.ViewOnlyMode,
-  },
+  }
 ];
+
+
+export const getActionItems= (inlcudeSRApprovalOptions: boolean): DropdownItem[]  => {
+
+  console.log("inlcudeSRApprovalOptions",inlcudeSRApprovalOptions)
+  if(inlcudeSRApprovalOptions)
+  {
+    return [...ActionItems, {
+      label: 'Approval All Changes',
+      value: SiteActionBtn.ApproveAll
+    },
+    {
+      label: 'Not Public',
+      value: SiteActionBtn.RejectAll
+    }];
+  }
+  else
+  {
+    return ActionItems;
+  }
+
+}

--- a/frontend/src/app/components/action/ActionsConfig.ts
+++ b/frontend/src/app/components/action/ActionsConfig.ts
@@ -23,7 +23,7 @@ export const getActionItems= (inlcudeSRApprovalOptions: boolean): DropdownItem[]
   if(inlcudeSRApprovalOptions)
   {
     return [...ActionItems, {
-      label: 'Approval All Changes',
+      label: 'Approve All Changes',
       value: SiteActionBtn.ApproveAll
     },
     {

--- a/frontend/src/app/components/navigation/Header.tsx
+++ b/frontend/src/app/components/navigation/Header.tsx
@@ -42,7 +42,7 @@ const Header = () => {
   };
 
   return (
-    <header className="navbar position-sticky navbar-small-device">
+    <header className="navbar position-sticky navbar-for-small-device">
       <div className="banner" tabIndex={1} role="navigation">
         <a href="https://gov.bc.ca">
           <img src={logo} className="logo" alt="BC Government Logo" />

--- a/frontend/src/app/features/details/SiteDetails.tsx
+++ b/frontend/src/app/features/details/SiteDetails.tsx
@@ -34,10 +34,10 @@ import {
 import { IChangeType } from '../../components/common/IChangeType';
 
 import './SiteDetails.css'; // Ensure this import is correct
-import { SiteDetailsMode } from './dto/SiteDetailsMode';
+import { SiteActionBtn, SiteDetailsMode } from './dto/SiteDetailsMode';
 import { UserType } from '../../helpers/requests/userType';
 import Actions from '../../components/action/Actions';
-import { ActionItems } from '../../components/action/ActionsConfig';
+import { ActionItems, getActionItems } from '../../components/action/ActionsConfig';
 import {
   formatDate,
   formatDateWithNoTimzoneName,
@@ -91,9 +91,17 @@ import {
   setupSiteIdForSaving,
 } from './SaveSiteDetailsSlice';
 import { fetchAssociatedSites } from './associates/AssociateSlice';
-import { updateRequestStatus } from './srUpdates/srUpdatesSlice';
+import { fetchParcelDescriptionsForApproval, fetchPendingAssociatedSites, fetchPendingDocumentsForApproval, fetchPendingLandUses, fetchPendingSiteDisclosure, fetchPendingSiteNotationBySiteId, fetchPendingSiteParticipantsForApproval, fetchPendingSitesDetailsFprApproval, hasNoPendingUpdates, updateRequestStatus } from './srUpdates/srUpdatesSlice';
+import { fetchLandUseCodes } from './landUses/LandUsesSlice';
+import { IFetchParcelDescriptionParams } from './parcelDescriptions/parcelDescriptionsSlice';
+import { bulkAproveRejectChanges, bulkUpdateApproveRejectStatus, resetBulkUpdateStatus } from './srUpdates/state/srUpdatesTableSlice';
 
 const SiteDetails = () => {
+
+  const bulkApproveRejectStatus = useSelector(bulkUpdateApproveRejectStatus);
+  const hasNoPendingUpdatesFromState = useSelector(hasNoPendingUpdates);
+  console.log("hasNoPendingUpdatesFromState",hasNoPendingUpdatesFromState)
+
   const [navItems, SetNavItems] = useState<string[] | undefined>();
   const [navComponents, SetNavComponents] = useState<any[]>();
   const [dropDownNavItems, SetDropDownNavItems] =
@@ -102,9 +110,9 @@ const SiteDetails = () => {
   const auth = useAuth();
 
   useEffect(() => {
-    SetNavComponents(getNavComponents());
-    SetNavItems(getNavItems());
-    SetDropDownNavItems(getDropDownNavItems());
+    SetNavComponents(getNavComponents(false));
+    SetNavItems(getNavItems(false));
+    SetDropDownNavItems(getDropDownNavItems(false));
 
     if(isUserOfType(UserRoleType.CLIENT))
     {
@@ -112,6 +120,22 @@ const SiteDetails = () => {
     }
 
   }, [auth.user]);
+
+
+  useEffect(()=>{
+    if(isUserOfType(UserRoleType.SR) && !hasNoPendingUpdatesFromState)
+    {
+      SetNavComponents(getNavComponents(true));
+      SetNavItems(getNavItems(true));
+      SetDropDownNavItems(getDropDownNavItems(true));
+    }
+    else
+    {
+      SetNavComponents(getNavComponents(false));
+      SetNavItems(getNavItems(false));
+      SetDropDownNavItems(getDropDownNavItems(false));
+    }
+  },[hasNoPendingUpdatesFromState])
 
   const [folioSearchTerm, SetFolioSearchTeam] = useState('');
 
@@ -193,6 +217,8 @@ const SiteDetails = () => {
         dispatch(clearTrackChanges(null));
         dispatch(updateSiteDetailsMode(SiteDetailsMode.ViewOnlyMode));
         setEdit(false);
+        if(id)
+        checkForRecordsPendingReview(id);
       } else {
         // dont close edit mode
       }
@@ -207,6 +233,38 @@ const SiteDetails = () => {
       // do nothing
     }
   }, [saveSiteDetailsRequestStatus]);
+
+
+  useEffect(() => {
+    console.log("bulkApproveRejectStatus",bulkApproveRejectStatus);
+    if (
+      bulkApproveRejectStatus === RequestStatus.success ||
+      bulkApproveRejectStatus === RequestStatus.failed
+    ) {
+      if (bulkApproveRejectStatus === RequestStatus.success) {
+        dispatch(resetBulkUpdateStatus(null));      
+        dispatch(updateSiteDetailsMode(SiteDetailsMode.ViewOnlyMode));
+        setEdit(false);
+        if(id)
+        checkForRecordsPendingReview(id);
+      } else if (bulkApproveRejectStatus === RequestStatus.failed) {
+        // dont close edit mode
+        dispatch(resetBulkUpdateStatus(null));
+      }
+
+      showNotification(
+        bulkApproveRejectStatus,
+        'Successfully updated site review',
+        'Failed to update site review',
+      );
+    
+    } else {
+      // do nothing
+    }
+  }, [bulkApproveRejectStatus]);
+
+
+  
 
   const navigate = useNavigate();
   const onClickBackButton = () => {
@@ -317,6 +375,62 @@ const SiteDetails = () => {
     }
   }, [id, userType]);
 
+
+    useEffect(() => {
+      if (id && id !== '') {
+        checkForRecordsPendingReview(id);
+      }
+    }, [id]);
+
+
+  const checkForRecordsPendingReview = (siteId:string) => {
+
+    if(siteId && siteId !== '' && (isUserOfType(UserRoleType.SR)))
+    {
+
+    const params: IFetchParcelDescriptionParams = {
+      siteId: parseInt(siteId),
+      page: 1,
+      pageSize: 1000,
+      searchParam: '',
+      sortBy: '',
+      sortByDir: '',
+      showPending: true,
+    };
+
+     Promise.all([
+      
+      dispatch(
+        fetchPendingSitesDetailsFprApproval({ siteId, showPending: true }),
+      ),
+
+      dispatch(fetchPendingSiteNotationBySiteId({ siteId, showPending: true })),
+      dispatch(
+        fetchPendingSiteParticipantsForApproval({ siteId, showPending: true }),
+      ),
+
+      dispatch(
+        fetchPendingLandUses({
+          siteId,
+          searchTerm: '',
+          sortDirection: 'ASC',
+          showPending: true,
+        }),
+      ),
+
+      dispatch(fetchPendingDocumentsForApproval({ siteId, showPending: true })),
+
+      dispatch(fetchPendingSiteDisclosure({ siteId, showPending: true })),
+
+      dispatch(fetchPendingAssociatedSites({ siteId, showPending: true })),
+
+      dispatch(fetchLandUseCodes()),
+      
+      dispatch(fetchParcelDescriptionsForApproval(params))
+     ])
+    }
+  }
+
   useEffect(() => {
     if (srUpdateRequestStatus === RequestStatus.success) {
       if (id) {
@@ -355,6 +469,32 @@ const SiteDetails = () => {
         setEdit(false);
         setViewMode(SiteDetailsMode.ViewOnlyMode);
         dispatch(updateSiteDetailsMode(SiteDetailsMode.ViewOnlyMode));
+        break;
+      case SiteActionBtn.ApproveAll:
+        setEdit(false);
+        if(id)
+        dispatch(
+          bulkAproveRejectChanges({
+            sites: [{siteId: id, changes: 'summary, notation, notation participants, site participants, documents, associated sites, land histories, site profiles, parcel description', whoUpdated: auth.user?.profile?.given_name ?? '', whenUpdated: new Date(), address:'', id : '1' }],
+            isApproved: true,
+            fromSiteDetails: true
+          }),
+        );
+        // setViewMode(SiteDetailsMode.ViewOnlyMode);
+        // dispatch(updateSiteDetailsMode(SiteDetailsMode.ViewOnlyMode));
+        break;
+      case SiteActionBtn.RejectAll:
+        setEdit(false);
+        // setViewMode(SiteDetailsMode.ViewOnlyMode);
+        // dispatch(updateSiteDetailsMode(SiteDetailsMode.ViewOnlyMode));
+        if(id)
+          dispatch(
+            bulkAproveRejectChanges({
+              sites: [{siteId: id, changes: 'summary, notation, notation participants, site participants, documents, associated sites, land histories, site profiles, parcel description', whoUpdated: auth.user?.profile?.given_name ?? '', whenUpdated: new Date(), address:'', id : '1' }],
+              isApproved: false,
+              fromSiteDetails: true
+            }),
+          );
         break;
       default:
         break;
@@ -406,6 +546,13 @@ const SiteDetails = () => {
     }
   };
 
+
+  const getActionItemsToRender = ()=> {   
+    let userTypeSR :boolean= isUserOfType(UserRoleType.SR)??false;
+    let includeSRApprovalActions = userTypeSR && !hasNoPendingUpdatesFromState;
+    return getActionItems(includeSRApprovalActions);
+  }
+
   if (isLoading || snapshot.status === RequestStatus.loading) {
     return (
       <div className="loading-overlay">
@@ -448,7 +595,7 @@ const SiteDetails = () => {
               userType === UserType.Internal && (
                 <Actions
                   label="Actions"
-                  items={ActionItems}
+                  items={getActionItemsToRender()}
                   onItemClick={handleItemClick}
                 />
               )}
@@ -587,7 +734,7 @@ const SiteDetails = () => {
                 userType === UserType.Internal && (
                   <Actions
                     label="Actions"
-                    items={ActionItems}
+                    items={getActionItemsToRender()}
                     onItemClick={handleItemClick}
                   />
                 )}

--- a/frontend/src/app/features/details/SiteDetails.tsx
+++ b/frontend/src/app/features/details/SiteDetails.tsx
@@ -98,10 +98,9 @@ import { bulkAproveRejectChanges, bulkUpdateApproveRejectStatus, resetBulkUpdate
 
 const SiteDetails = () => {
 
+  const [confirmSiteReview,SetConfirmSiteReview] = useState<Boolean | null>(null);
   const bulkApproveRejectStatus = useSelector(bulkUpdateApproveRejectStatus);
   const hasNoPendingUpdatesFromState = useSelector(hasNoPendingUpdates);
-  console.log("hasNoPendingUpdatesFromState",hasNoPendingUpdatesFromState)
-
   const [navItems, SetNavItems] = useState<string[] | undefined>();
   const [navComponents, SetNavComponents] = useState<any[]>();
   const [dropDownNavItems, SetDropDownNavItems] =
@@ -235,8 +234,7 @@ const SiteDetails = () => {
   }, [saveSiteDetailsRequestStatus]);
 
 
-  useEffect(() => {
-    console.log("bulkApproveRejectStatus",bulkApproveRejectStatus);
+  useEffect(() => {    
     if (
       bulkApproveRejectStatus === RequestStatus.success ||
       bulkApproveRejectStatus === RequestStatus.failed
@@ -471,30 +469,28 @@ const SiteDetails = () => {
         dispatch(updateSiteDetailsMode(SiteDetailsMode.ViewOnlyMode));
         break;
       case SiteActionBtn.ApproveAll:
-        setEdit(false);
-        if(id)
-        dispatch(
-          bulkAproveRejectChanges({
-            sites: [{siteId: id, changes: 'summary, notation, notation participants, site participants, documents, associated sites, land histories, site profiles, parcel description', whoUpdated: auth.user?.profile?.given_name ?? '', whenUpdated: new Date(), address:'', id : '1' }],
-            isApproved: true,
-            fromSiteDetails: true
-          }),
-        );
-        // setViewMode(SiteDetailsMode.ViewOnlyMode);
-        // dispatch(updateSiteDetailsMode(SiteDetailsMode.ViewOnlyMode));
+        setEdit(false);    
+        SetConfirmSiteReview(true);  
+        // if(id)
+        // dispatch(
+        //   bulkAproveRejectChanges({
+        //     sites: [{siteId: id, changes: 'summary, notation, notation participants, site participants, documents, associated sites, land histories, site profiles, parcel description', whoUpdated: auth.user?.profile?.given_name ?? '', whenUpdated: new Date(), address:'', id : '1' }],
+        //     isApproved: true,
+        //     fromSiteDetails: true
+        //   }),
+        // );
         break;
       case SiteActionBtn.RejectAll:
-        setEdit(false);
-        // setViewMode(SiteDetailsMode.ViewOnlyMode);
-        // dispatch(updateSiteDetailsMode(SiteDetailsMode.ViewOnlyMode));
-        if(id)
-          dispatch(
-            bulkAproveRejectChanges({
-              sites: [{siteId: id, changes: 'summary, notation, notation participants, site participants, documents, associated sites, land histories, site profiles, parcel description', whoUpdated: auth.user?.profile?.given_name ?? '', whenUpdated: new Date(), address:'', id : '1' }],
-              isApproved: false,
-              fromSiteDetails: true
-            }),
-          );
+        setEdit(false);      
+        SetConfirmSiteReview(false);  
+        // if(id)
+        //   dispatch(
+        //     bulkAproveRejectChanges({
+        //       sites: [{siteId: id, changes: 'summary, notation, notation participants, site participants, documents, associated sites, land histories, site profiles, parcel description', whoUpdated: auth.user?.profile?.given_name ?? '', whenUpdated: new Date(), address:'', id : '1' }],
+        //       isApproved: false,
+        //       fromSiteDetails: true
+        //     }),
+        //   );
         break;
       default:
         break;
@@ -680,6 +676,21 @@ const SiteDetails = () => {
         </div>
       )}
       <PageContainer role="details">
+        {confirmSiteReview != null &&  (confirmSiteReview === false || confirmSiteReview === true) && (
+          <ModalDialog           
+            label={`Are you sure to proceed`}
+            closeHandler={(response) => {
+              if (response) {
+                alert(confirmSiteReview);
+                if (confirmSiteReview) {
+                  //handleRemoveAssociate(response);
+                 
+                }
+              }
+              SetConfirmSiteReview(null);
+            }}
+          />
+        )}
         {save && (
           <ModalDialog
             closeHandler={(response) => {

--- a/frontend/src/app/features/details/dto/SiteDetailsMode.ts
+++ b/frontend/src/app/features/details/dto/SiteDetailsMode.ts
@@ -6,6 +6,14 @@ export enum SiteDetailsMode {
   ViewOnlyMode = 'normal',
 }
 
+
+
+export enum SiteActionBtn {
+  ApproveAll = 'approve_all',
+  RejectAll = 'reject_all'
+}
+
+
 export interface SaveSiteDetails {
   saveRequestStatus: RequestStatus;
   notationData: any;

--- a/frontend/src/app/features/details/navigation/NavigationPillsConfig.tsx
+++ b/frontend/src/app/features/details/navigation/NavigationPillsConfig.tsx
@@ -25,8 +25,8 @@ export interface IComponentProps {
   showPending?: boolean;
 }
 
-export const getNavItems = () =>
-  isUserOfType(UserRoleType.SR) ? ['Updates', ...mainNavItems] : mainNavItems;
+export const getNavItems = (includeUpdatesTab:boolean) =>
+  isUserOfType(UserRoleType.SR) && includeUpdatesTab ? ['Updates', ...mainNavItems] : mainNavItems;
 
 const mainNavComponents = [
  { key:"summary", component:  <Summary />},
@@ -39,8 +39,8 @@ const mainNavComponents = [
  { key:"disclosure", component: <Disclosure /> },
 ];
 
-export const getNavComponents = () =>
-  isUserOfType(UserRoleType.SR)
+export const getNavComponents = (includeUpdatesTab:boolean) =>
+  isUserOfType(UserRoleType.SR) && includeUpdatesTab
     ? [{ key:"updates", component:  <SRUpdates />}, ...mainNavComponents]
     : mainNavComponents;
 
@@ -79,8 +79,8 @@ export const mainDropDownNavItems = [
   },
 ];
 
-export const getDropDownNavItems = () =>
-  isUserOfType(UserRoleType.SR)
+export const getDropDownNavItems = (includeUpdatesTab:boolean) =>
+  isUserOfType(UserRoleType.SR) && includeUpdatesTab
     ? [
         {
           label: 'Updated',

--- a/frontend/src/app/features/details/srUpdates/dto/srUpdateState.ts
+++ b/frontend/src/app/features/details/srUpdates/dto/srUpdateState.ts
@@ -18,9 +18,11 @@ export class SitePendingApprovalDTO {
   whoUpdated: string = '';
   whenUpdated: Date = new Date();
   address: string = '';
+  id: string = ''
 }
 
 export class BulkApproveRejectChangesDTO {
   isApproved: boolean = false;
+  fromSiteDetails: boolean = false;
   sites: SitePendingApprovalDTO[] = [];
 }

--- a/frontend/src/app/features/details/srUpdates/srUpdates.tsx
+++ b/frontend/src/app/features/details/srUpdates/srUpdates.tsx
@@ -172,6 +172,7 @@ const SRUpdates = () => {
   const notationTypeDropdownData = useSelector(notationTypeDrpdown);
   const notationClass = useSelector(notationClassDrpdown);
   const { landUseCodes } = useSelector(selectLandUseCodes);
+ 
 
 
   const { id } = useParams();
@@ -366,46 +367,46 @@ const [notationColumnInternalLocal, SetNotationColumnInternalLocal] =
     }
   }, [updateRequestStatusFromState]);
 
-  useEffect(() => {
-    if (siteId !== '') {
-      dispatch(
-        fetchPendingSitesDetailsFprApproval({ siteId, showPending: true }),
-      );
+  // useEffect(() => {
+  //   if (siteId !== '') {
+  //     dispatch(
+  //       fetchPendingSitesDetailsFprApproval({ siteId, showPending: true }),
+  //     );
 
-      dispatch(fetchPendingSiteNotationBySiteId({ siteId, showPending: true }));
-      dispatch(
-        fetchPendingSiteParticipantsForApproval({ siteId, showPending: true }),
-      );
+  //     dispatch(fetchPendingSiteNotationBySiteId({ siteId, showPending: true }));
+  //     dispatch(
+  //       fetchPendingSiteParticipantsForApproval({ siteId, showPending: true }),
+  //     );
 
-      dispatch(
-        fetchPendingLandUses({
-          siteId,
-          searchTerm: '',
-          sortDirection: 'ASC',
-          showPending: true,
-        }),
-      );
+  //     dispatch(
+  //       fetchPendingLandUses({
+  //         siteId,
+  //         searchTerm: '',
+  //         sortDirection: 'ASC',
+  //         showPending: true,
+  //       }),
+  //     );
 
-      dispatch(fetchPendingDocumentsForApproval({ siteId, showPending: true }));
+  //     dispatch(fetchPendingDocumentsForApproval({ siteId, showPending: true }));
 
-      dispatch(fetchPendingSiteDisclosure({ siteId, showPending: true }));
+  //     dispatch(fetchPendingSiteDisclosure({ siteId, showPending: true }));
 
-      dispatch(fetchPendingAssociatedSites({ siteId, showPending: true }));
+  //     dispatch(fetchPendingAssociatedSites({ siteId, showPending: true }));
 
-      dispatch(fetchLandUseCodes());
+  //     dispatch(fetchLandUseCodes());
 
-      const params: IFetchParcelDescriptionParams = {
-        siteId: parseInt(siteId),
-        page: 1,
-        pageSize: 1000,
-        searchParam: '',
-        sortBy: '',
-        sortByDir: '',
-        showPending: true,
-      };
-      dispatch(fetchParcelDescriptionsForApproval(params));
-    }
-  }, [siteId]);
+  //     const params: IFetchParcelDescriptionParams = {
+  //       siteId: parseInt(siteId),
+  //       page: 1,
+  //       pageSize: 1000,
+  //       searchParam: '',
+  //       sortBy: '',
+  //       sortByDir: '',
+  //       showPending: true,
+  //     };
+  //     dispatch(fetchParcelDescriptionsForApproval(params));
+  //   }
+  // }, [siteId]);
 
   const handleChange = (event: any) => {
     console.log('No Change Hanlder Required Here', event);

--- a/frontend/src/app/features/details/srUpdates/srUpdates.tsx
+++ b/frontend/src/app/features/details/srUpdates/srUpdates.tsx
@@ -367,48 +367,7 @@ const [notationColumnInternalLocal, SetNotationColumnInternalLocal] =
     }
   }, [updateRequestStatusFromState]);
 
-  // useEffect(() => {
-  //   if (siteId !== '') {
-  //     dispatch(
-  //       fetchPendingSitesDetailsFprApproval({ siteId, showPending: true }),
-  //     );
-
-  //     dispatch(fetchPendingSiteNotationBySiteId({ siteId, showPending: true }));
-  //     dispatch(
-  //       fetchPendingSiteParticipantsForApproval({ siteId, showPending: true }),
-  //     );
-
-  //     dispatch(
-  //       fetchPendingLandUses({
-  //         siteId,
-  //         searchTerm: '',
-  //         sortDirection: 'ASC',
-  //         showPending: true,
-  //       }),
-  //     );
-
-  //     dispatch(fetchPendingDocumentsForApproval({ siteId, showPending: true }));
-
-  //     dispatch(fetchPendingSiteDisclosure({ siteId, showPending: true }));
-
-  //     dispatch(fetchPendingAssociatedSites({ siteId, showPending: true }));
-
-  //     dispatch(fetchLandUseCodes());
-
-  //     const params: IFetchParcelDescriptionParams = {
-  //       siteId: parseInt(siteId),
-  //       page: 1,
-  //       pageSize: 1000,
-  //       searchParam: '',
-  //       sortBy: '',
-  //       sortByDir: '',
-  //       showPending: true,
-  //     };
-  //     dispatch(fetchParcelDescriptionsForApproval(params));
-  //   }
-  // }, [siteId]);
-
-  const handleChange = (event: any) => {
+   const handleChange = (event: any) => {
     console.log('No Change Hanlder Required Here', event);
   };
   const handleAndReturnBoolean = (event: any): boolean => {

--- a/frontend/src/app/features/details/srUpdates/srUpdatesSlice.ts
+++ b/frontend/src/app/features/details/srUpdates/srUpdatesSlice.ts
@@ -193,6 +193,7 @@ export const fetchPendingSitesDetailsFprApproval = createAsyncThunk(
           pending: args.showPending,
         },
       });
+      console.log("response.data.data.findSiteBySiteId;",response)
       return response.data.data.findSiteBySiteId;
     } catch (error) {
       throw error;
@@ -271,6 +272,7 @@ const srUpdatesSlice = createSlice({
           const newState = { ...state };
           if(action.payload.httpStatusCode === 200)
           {
+            console.log("new  newState.siteSummaryData",  action.payload.data)
             newState.siteSummaryData = action.payload.data
           }
           else
@@ -443,6 +445,17 @@ export const selectAssociatedSites = (state: any) =>
 export const selectParcelDescriptionData = (state:any) => state.srUpdates.parcelDescriptionData;
 export const updateRequestStatus = (state: any) =>
   state.srUpdates.updateRequestStatus;
+
+export const hasNoPendingUpdates = (state:any) => {
+   console.log("in hasNoPendingUpdates")
+  return (!state.srUpdates.disclosure &&
+(!state.srUpdates.parcelDescriptionData ||state.srUpdates.parcelDescriptionData.data.length === 0) &&
+(!state.srUpdates.landUsesData || state.srUpdates.landUsesData.length === 0) &&
+(! state.srUpdates.siteAssociations ||  state.srUpdates.siteAssociations.length === 0) &&
+(! state.srUpdates.documents ||  state.srUpdates.documents.length === 0) && 
+(! state.srUpdates.siteParticipants ||  state.srUpdates.siteParticipants.length === 0) && 
+(! state.srUpdates.notation ||  state.srUpdates.notation.length === 0) && 
+(!state.srUpdates.siteSummaryData))}
 
 export const { resetAllData, resetRequestStatus } = srUpdatesSlice.actions;
 

--- a/frontend/src/app/features/details/srUpdates/srUpdatesSlice.ts
+++ b/frontend/src/app/features/details/srUpdates/srUpdatesSlice.ts
@@ -192,8 +192,7 @@ export const fetchPendingSitesDetailsFprApproval = createAsyncThunk(
           siteId: args.siteId,
           pending: args.showPending,
         },
-      });
-      console.log("response.data.data.findSiteBySiteId;",response)
+      }); 
       return response.data.data.findSiteBySiteId;
     } catch (error) {
       throw error;
@@ -271,8 +270,7 @@ const srUpdatesSlice = createSlice({
         (state, action) => {
           const newState = { ...state };
           if(action.payload.httpStatusCode === 200)
-          {
-            console.log("new  newState.siteSummaryData",  action.payload.data)
+          {           
             newState.siteSummaryData = action.payload.data
           }
           else
@@ -447,7 +445,6 @@ export const updateRequestStatus = (state: any) =>
   state.srUpdates.updateRequestStatus;
 
 export const hasNoPendingUpdates = (state:any) => {
-   console.log("in hasNoPendingUpdates")
   return (!state.srUpdates.disclosure &&
 (!state.srUpdates.parcelDescriptionData ||state.srUpdates.parcelDescriptionData.data.length === 0) &&
 (!state.srUpdates.landUsesData || state.srUpdates.landUsesData.length === 0) &&

--- a/frontend/src/app/features/details/srUpdates/srUpdatesTables.tsx
+++ b/frontend/src/app/features/details/srUpdates/srUpdatesTables.tsx
@@ -16,7 +16,8 @@ import {
   getSearchParam,
   getTotalRecords,
   selectAllSites,
-  updateStatus,
+  bulkUpdateApproveRejectStatus,
+  resetBulkUpdateStatus,
 } from './state/srUpdatesTableSlice';
 import SRUpdatesTableFilter from './srUpdatesTableFilter';
 import Table from '../../../components/table/Table';
@@ -34,7 +35,7 @@ const SRUpdatesTables = () => {
   const [totalResults, SetTotalResults] = useState(1);
   const reviewPendingSites = useSelector(selectAllSites);
   const totalRecords = useSelector(getTotalRecords);
-  const updateRequestStatus = useSelector(updateStatus);
+  const updateRequestStatus = useSelector(bulkUpdateApproveRejectStatus);
   const searchParamRef = useSelector(getSearchParam);
   const [searchParam, SetSearchParam] = useState(searchParamRef);
   useEffect(() => {
@@ -94,6 +95,7 @@ const SRUpdatesTables = () => {
         bulkAproveRejectChanges({
           sites: selectedRows,
           isApproved: false,
+          fromSiteDetails: false
         }),
       );
     }
@@ -105,6 +107,7 @@ const SRUpdatesTables = () => {
         bulkAproveRejectChanges({
           sites: selectedRows,
           isApproved: true,
+          fromSiteDetails: false
         }),
       );
     }
@@ -129,10 +132,16 @@ const SRUpdatesTables = () => {
   };
 
   useEffect(() => {
+
+    if(updateRequestStatus === RequestStatus.success || updateRequestStatus === RequestStatus.failed)
+    {
+       dispatch(resetBulkUpdateStatus(null));
+    }
+
     showNotification(
       updateRequestStatus,
       'Successfully updated.',
-      'Unable updated',
+      'Failed to update',
     );
 
     dispatch(

--- a/frontend/src/app/features/details/srUpdates/state/srUpdatesTableSlice.ts
+++ b/frontend/src/app/features/details/srUpdates/state/srUpdatesTableSlice.ts
@@ -61,6 +61,13 @@ const srReviewSlice = createSlice({
   initialState,
 
   reducers: {
+    resetBulkUpdateStatus: (state, action) =>{
+      const newState = {
+        ...state,
+      };
+      newState.updateStatus = RequestStatus.idle;
+      return newState;
+    },
     setFetchLoadingState: (state, action) => {
       const newState = {
         ...state,
@@ -154,7 +161,7 @@ export const loadingState = (state: any) => state.srReview.fetchStatus;
 export const currentPageSelection = (state: any) => state.srReview.currentPage;
 export const currentPageSize = (state: any) => state.srReview.pageSize;
 export const getTotalRecords = (state: any) => state.srReview.resultsCount;
-export const updateStatus = (state: any) => state.srReview.updateStatus;
+export const bulkUpdateApproveRejectStatus = (state: any) => state.srReview.updateStatus;
 export const getSearchParam = (state: any) => state.srReview.searchParam;
 
 export const {
@@ -163,6 +170,7 @@ export const {
   updatePageSizeSetting,
   updateSearchQuery,
   updateSearchParam,
+  resetBulkUpdateStatus
 } = srReviewSlice.actions;
 
 export default srReviewSlice.reducer;


### PR DESCRIPTION
Implemented following features for Site Registrar
- Updates tab in Site Details will be only visible for Site Registrar when there are pending records to review
- Also they will have 'Approve All Changes' , 'Not Public' options in Actions Dropdown when records are pending for review

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-175-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-175-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)