### PR TITLE
feat: SRS-361 Implement updateParcelDescriptionsForSite

### DIFF
--- a/backend/src/app/services/parcelDescriptions/parcelDescriptions.service.spec.ts
+++ b/backend/src/app/services/parcelDescriptions/parcelDescriptions.service.spec.ts
@@ -953,4 +953,289 @@ describe('SiteSubdivisionsService', () => {
       });
     });
   });
+
+  describe('updateParcelDescriptionsForSite', () => {
+    let today: Date;
+    let yesterday: Date;
+
+    let inputParcelDescriptions: ParcelDescriptionInputDTO[];
+    let siteId: string;
+    let userInfo: any;
+
+    let subdivisionFindByResult: Subdivisions[];
+    let subdivisionSaveResult: Subdivisions[];
+
+    let siteSubdivisionFindByResult: SiteSubdivisions[];
+    let siteSubdivisionSaveResult: SiteSubdivisions[];
+
+    let databaseSubdivision: Subdivisions;
+    let databaseSiteSubdivision: SiteSubdivisions;
+
+    let updatedSubdivision: any;
+    let updatedSiteSubdivision: any;
+
+    let subdivisionFindByMock: jest.Mock;
+    let subdivisionSaveMock: jest.Mock;
+    let siteSubdivisionFindByMock: jest.Mock;
+    let siteSubdivisionSaveMock: jest.Mock;
+
+    beforeEach(() => {
+      today = new Date();
+      yesterday = new Date();
+      yesterday.setDate(today.getDate() - 1);
+
+      siteId = '10';
+      inputParcelDescriptions = [
+        {
+          id: '1',
+          descriptionType: ParcelDescriptionType.CrownLandPIN,
+          idPinNumber: '654321',
+          dateNoted: today,
+          landDescription: 'should be ignored',
+          srAction: 'approved',
+          userAction: 'approved',
+          apiAction: 'updated',
+        },
+      ];
+      userInfo = { givenName: 'test' };
+      databaseSubdivision = {
+        srAction: 'pending',
+        userAction: 'pending',
+        id: '1',
+        dateNoted: new Date(),
+        pin: null,
+        pid: '123456',
+        bcaaFolioNumber: null,
+        entityType: null,
+        addrLine_1: 'test addr',
+        addrLine_2: null,
+        addrLine_3: null,
+        addrLine_4: null,
+        city: 'Anyton',
+        postalCode: 'H0H0H0',
+        legalDescription: 'Land Description',
+        whoCreated: 'employee of the month',
+        whoUpdated: 'employee of the month',
+        whenCreated: yesterday,
+        whenUpdated: yesterday,
+        crownLandsFileNo: null,
+        pidStatusCd: 'N',
+        validPid: null,
+        siteSubdivisions: [databaseSiteSubdivision],
+      };
+      databaseSiteSubdivision = {
+        srAction: 'pending',
+        userAction: 'pending',
+        siteId: '10',
+        subdivId: '1',
+        dateNoted: new Date(),
+        initialIndicator: 'N',
+        whoCreated: 'employee of the month',
+        whoUpdated: 'employee of the month',
+        whenCreated: yesterday,
+        whenUpdated: yesterday,
+        sprofDateCompleted: null,
+        siteSubdivId: '100',
+        sendToSr: 'Y',
+        site: null,
+        subdivision: databaseSubdivision,
+      };
+      subdivisionSaveResult = []; // This is never checked or used.
+      siteSubdivisionSaveResult = [];
+      subdivisionFindByResult = [databaseSubdivision];
+      siteSubdivisionFindByResult = [databaseSiteSubdivision];
+
+      // The whenUpdated is tested separately because there isn't a good jest
+      // matcher to test a date property.
+      updatedSubdivision = {
+        srAction: 'approved',
+        userAction: 'approved',
+        id: '1',
+        dateNoted: today,
+        pin: '654321',
+        pid: null,
+        bcaaFolioNumber: null,
+        entityType: null,
+        addrLine_1: 'test addr',
+        addrLine_2: null,
+        addrLine_3: null,
+        addrLine_4: null,
+        city: 'Anyton',
+        postalCode: 'H0H0H0',
+        legalDescription: 'Land Description',
+        whoCreated: 'employee of the month',
+        whoUpdated: 'test',
+        whenCreated: yesterday,
+        crownLandsFileNo: null,
+        pidStatusCd: 'N',
+        validPid: null,
+      };
+      updatedSiteSubdivision = {
+        srAction: 'approved',
+        userAction: 'approved',
+        siteId: '10',
+        subdivId: '1',
+        dateNoted: today,
+        initialIndicator: 'N',
+        whoCreated: 'employee of the month',
+        whoUpdated: 'test',
+        whenCreated: yesterday,
+        sprofDateCompleted: null,
+        siteSubdivId: '100',
+        sendToSr: 'Y',
+        site: null,
+        subdivision: databaseSubdivision,
+      };
+
+      subdivisionFindByMock = jest
+        .fn()
+        .mockResolvedValue(subdivisionFindByResult);
+      subdivisionSaveMock = jest.fn().mockResolvedValue(subdivisionSaveResult);
+      siteSubdivisionFindByMock = jest
+        .fn()
+        .mockResolvedValue(siteSubdivisionFindByResult);
+      siteSubdivisionSaveMock = jest
+        .fn()
+        .mockResolvedValue(siteSubdivisionSaveResult);
+
+      subdivisionsRepository.save = subdivisionSaveMock;
+      subdivisionsRepository.findBy = subdivisionFindByMock;
+      siteSubdivisionsRepository.save = siteSubdivisionSaveMock;
+      siteSubdivisionsRepository.findBy = siteSubdivisionFindByMock;
+    });
+
+    it('logs the call to updateParcelDescriptionsForSite', async () => {
+      await parcelDescriptionsService.updateParcelDescriptionsForSite(
+        siteId,
+        inputParcelDescriptions,
+        userInfo,
+      );
+
+      expect(logMock).toHaveBeenCalledWith(
+        'parcelDescriptionService.updateParcelDescriptionsForSite() start',
+      );
+      expect(debugMock).toHaveBeenCalledWith(
+        'parcelDescriptionService.updateParcelDescriptionsForSite() start',
+      );
+      expect(logMock).toHaveBeenCalledWith(
+        'parcelDescriptionService.updateParcelDescriptionsForSite() end',
+      );
+      expect(debugMock).toHaveBeenCalledWith(
+        'parcelDescriptionService.updateParcelDescriptionsForSite() end',
+      );
+    });
+
+    it('saves an updated subdivision to the database.', async () => {
+      await parcelDescriptionsService.updateParcelDescriptionsForSite(
+        siteId,
+        inputParcelDescriptions,
+        userInfo,
+      );
+
+      expect(subdivisionSaveMock).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining(updatedSubdivision)]),
+      );
+      let whenupdated: Date =
+        subdivisionSaveMock.mock.calls[0][0][0].whenUpdated;
+      expect(whenupdated.getTime()).toBeGreaterThan(yesterday.getTime());
+    });
+
+    it('saves the updated site subdivision to the database.', async () => {
+      await parcelDescriptionsService.updateParcelDescriptionsForSite(
+        siteId,
+        inputParcelDescriptions,
+        userInfo,
+      );
+
+      expect(siteSubdivisionSaveMock).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining(updatedSiteSubdivision),
+        ]),
+      );
+      let whenupdated: Date =
+        siteSubdivisionSaveMock.mock.calls[0][0][0].whenUpdated;
+      expect(whenupdated.getTime()).toBeGreaterThan(yesterday.getTime());
+    });
+
+    describe('when the subdivision to update does not exist', () => {
+      beforeEach(() => {
+        subdivisionFindByMock.mockResolvedValue([]);
+      });
+
+      it('throws an exception and logs the error', async () => {
+        expect(async () => {
+          await parcelDescriptionsService.updateParcelDescriptionsForSite(
+            siteId,
+            inputParcelDescriptions,
+            userInfo,
+          );
+        }).rejects.toThrow(BadRequestException);
+
+        // Need to wait for the above block to reject before testing the logging
+        // mock.
+        await jest.runAllTimersAsync();
+        expect(errorMock).toHaveBeenCalledTimes(1);
+        expect(errorMock).toHaveBeenCalledWith(
+          'Exception occured in parcelDescriptionService.updateParcelDescriptionsForSite() end',
+          expect.anything(),
+        );
+      });
+    });
+
+    describe('when the subdivision fails to save', () => {
+      beforeEach(() => {
+        subdivisionSaveMock = jest.fn().mockImplementation(() => {
+          throw new Error('A bad thing happened!');
+        });
+        subdivisionsRepository.save = subdivisionSaveMock;
+      });
+
+      it('logs and throws the error', async () => {
+        expect(async () => {
+          await parcelDescriptionsService.updateParcelDescriptionsForSite(
+            siteId,
+            inputParcelDescriptions,
+            userInfo,
+          );
+        }).rejects.toThrow(BadRequestException);
+
+        // Need to wait for the above block to reject before testing the logging
+        // mock.
+        await jest.runAllTimersAsync();
+        expect(errorMock).toHaveBeenCalledTimes(1);
+        expect(errorMock).toHaveBeenCalledWith(
+          'Exception occured in parcelDescriptionService.updateParcelDescriptionsForSite() end',
+          expect.anything(),
+        );
+      });
+    });
+
+    describe('when the site subdivision fails to save', () => {
+      beforeEach(() => {
+        siteSubdivisionSaveMock = jest.fn().mockImplementation(() => {
+          throw new Error('A bad thing happened!');
+        });
+        siteSubdivisionsRepository.save = siteSubdivisionSaveMock;
+      });
+
+      it('logs and throws the error', async () => {
+        expect(async () => {
+          await parcelDescriptionsService.updateParcelDescriptionsForSite(
+            siteId,
+            inputParcelDescriptions,
+            userInfo,
+          );
+        }).rejects.toThrow(BadRequestException);
+
+        // Need to wait for the above block to reject before testing the logging
+        // mock.
+        await jest.runAllTimersAsync();
+        expect(errorMock).toHaveBeenCalledTimes(1);
+        expect(errorMock).toHaveBeenCalledWith(
+          'Exception occured in parcelDescriptionService.updateParcelDescriptionsForSite() end',
+          expect.anything(),
+        );
+      });
+    });
+  });
 });

--- a/backend/src/app/services/parcelDescriptions/parcelDescriptions.service.ts
+++ b/backend/src/app/services/parcelDescriptions/parcelDescriptions.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectEntityManager, InjectRepository } from '@nestjs/typeorm';
-import { EntityManager, InsertResult, Repository } from 'typeorm';
+import { EntityManager, In, InsertResult, Repository } from 'typeorm';
 import {
   ParcelDescriptionDto,
   ParcelDescriptionType,
@@ -358,7 +358,103 @@ export class ParcelDescriptionsService {
     parcelDescriptions: ParcelDescriptionInputDTO[],
     userInfo: any,
   ) {
-    // TODO: Implementation to come in another pull request
+    this.sitesLogger.log(
+      'parcelDescriptionService.updateParcelDescriptionsForSite() start',
+    );
+    this.sitesLogger.debug(
+      'parcelDescriptionService.updateParcelDescriptionsForSite() start',
+    );
+
+    const now = new Date();
+    // Fetch subdivision and siteSubdivision entities to update.
+    const subdivIds = parcelDescriptions.map((parcelDescription) => {
+      return parcelDescription.id;
+    });
+    let subdivisions = await this.subdivisionsRepository.findBy({
+      id: In(subdivIds),
+    });
+    let siteSubdivisions = await this.siteSubdivisionsRepository.findBy({
+      subdivId: In(subdivIds),
+      siteId: siteId,
+    });
+
+    // Parse each parcel description's properties into its subdivision and
+    // siteSubdivision database entities.
+    parcelDescriptions.forEach((parcelDescription) => {
+      let subdivision = subdivisions.find((subdivision) => {
+        return subdivision.id === parcelDescription.id;
+      });
+      let siteSubdivision = siteSubdivisions.find((siteSubdivision) => {
+        return siteSubdivision.subdivId === parcelDescription.id;
+      });
+      if (subdivision === undefined || siteSubdivision === undefined) {
+        // This should only happen if the front end becomes out of sync with the
+        // database, or the client modifies the request somehow.
+        const error = new BadRequestException(
+          'Failed to update Parcel Description.',
+        );
+        this.sitesLogger.error(
+          'Exception occured in parcelDescriptionService.updateParcelDescriptionsForSite() end',
+          JSON.stringify(error),
+        );
+        throw error;
+      }
+      subdivision.pid =
+        parcelDescription.descriptionType === ParcelDescriptionType.ParcelID
+          ? parcelDescription.idPinNumber
+          : null;
+      subdivision.pin =
+        parcelDescription.descriptionType === ParcelDescriptionType.CrownLandPIN
+          ? parcelDescription.idPinNumber
+          : null;
+      subdivision.crownLandsFileNo =
+        parcelDescription.descriptionType ===
+        ParcelDescriptionType.CrownLandFileNumber
+          ? parcelDescription.idPinNumber
+          : null;
+      subdivision.dateNoted = parcelDescription.dateNoted;
+      subdivision.srAction = parcelDescription.srAction;
+      subdivision.userAction = parcelDescription.userAction;
+      subdivision.whoUpdated = userInfo?.givenName;
+      subdivision.whenUpdated = now;
+      // Note: the user is never able to update the subdivision's legal/land
+      // description. This data comes from LTSA.
+
+      siteSubdivision.dateNoted = parcelDescription.dateNoted;
+      siteSubdivision.userAction = parcelDescription.userAction;
+      siteSubdivision.srAction = parcelDescription.srAction;
+      siteSubdivision.whoUpdated = userInfo?.givenName;
+      siteSubdivision.whenUpdated = now;
+    });
+
+    // Commit the updates.
+    try {
+      await this.subdivisionsRepository.save(subdivisions);
+    } catch (error) {
+      this.sitesLogger.error(
+        'Exception occured in parcelDescriptionService.updateParcelDescriptionsForSite() end',
+        JSON.stringify(error),
+      );
+      throw new BadRequestException('Failed to update Parcel Description.');
+    }
+    try {
+      await this.siteSubdivisionsRepository.save(siteSubdivisions);
+    } catch (error) {
+      // This code is called within a transaction in the site service, so the
+      // previous save should be rolled back if there is a failure here.
+      this.sitesLogger.error(
+        'Exception occured in parcelDescriptionService.updateParcelDescriptionsForSite() end',
+        JSON.stringify(error),
+      );
+      throw new BadRequestException('Failed to update Parcel Description.');
+    }
+
+    this.sitesLogger.log(
+      'parcelDescriptionService.updateParcelDescriptionsForSite() end',
+    );
+    this.sitesLogger.debug(
+      'parcelDescriptionService.updateParcelDescriptionsForSite() end',
+    );
   }
 
   async deleteParcelDescriptionsForSite(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Implement the method to update Parcel Description entities to the database

Fixes # SRS-361 (Partially)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Manual GraphQL test.
```graphql
mutation updateSiteDetails($siteDetailsDTO: SaveSiteDetailsDTO!) {
    updateSiteDetails(siteDetailsDTO: $siteDetailsDTO) {
        message
        httpStatusCode
        success
    }
}
```
with variables:
```json
{
    "siteDetailsDTO": {
    "siteId": "997",
    "parcelDescriptions": [
      {
        "id": "36989",
        "descriptionType": "Parcel ID",
        "idPinNumber": "123456",
        "dateNoted": "2024-10-17T00:00:00Z",
        "landDescription": "should be disregarded",
        "userAction": "approved",
        "srAction": "approved",
        "apiAction": "updated"
      }
    ]
  }  
}
```

- [x] Unit tests

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-176-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-176-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)