### PR TITLE
feat: SRS 361 Implement delete parcel descriptions for site

### DIFF
--- a/backend/src/app/services/parcelDescriptions/parcelDescriptions.service.spec.ts
+++ b/backend/src/app/services/parcelDescriptions/parcelDescriptions.service.spec.ts
@@ -28,6 +28,7 @@ describe('SiteSubdivisionsService', () => {
   let logMock: jest.Mock;
   let debugMock: jest.Mock;
   let errorMock: jest.Mock;
+  let warnMock: jest.Mock;
 
   beforeEach(async () => {
     const testingModule: TestingModule = await Test.createTestingModule({
@@ -80,9 +81,11 @@ describe('SiteSubdivisionsService', () => {
     logMock = jest.fn();
     debugMock = jest.fn();
     errorMock = jest.fn();
+    warnMock = jest.fn();
     loggerService.log = logMock;
     loggerService.debug = debugMock;
     loggerService.error = errorMock;
+    loggerService.warn = warnMock;
   });
 
   afterEach(() => {

--- a/backend/src/app/services/parcelDescriptions/parcelDescriptions.service.spec.ts
+++ b/backend/src/app/services/parcelDescriptions/parcelDescriptions.service.spec.ts
@@ -17,7 +17,7 @@ import { BadRequestException } from '@nestjs/common';
 jest.useFakeTimers();
 jest.mock('./parcelDescriptions.queryBuilder');
 
-describe('SiteSubdivisionsService', () => {
+describe('ParcelDescriptionsService', () => {
   let parcelDescriptionsService: ParcelDescriptionsService;
   let entityManager: EntityManager;
   let snapshotsService: SnapshotsService;
@@ -28,7 +28,6 @@ describe('SiteSubdivisionsService', () => {
   let logMock: jest.Mock;
   let debugMock: jest.Mock;
   let errorMock: jest.Mock;
-  let warnMock: jest.Mock;
 
   beforeEach(async () => {
     const testingModule: TestingModule = await Test.createTestingModule({
@@ -81,11 +80,9 @@ describe('SiteSubdivisionsService', () => {
     logMock = jest.fn();
     debugMock = jest.fn();
     errorMock = jest.fn();
-    warnMock = jest.fn();
     loggerService.log = logMock;
     loggerService.debug = debugMock;
     loggerService.error = errorMock;
-    loggerService.warn = warnMock;
   });
 
   afterEach(() => {
@@ -1236,6 +1233,193 @@ describe('SiteSubdivisionsService', () => {
         expect(errorMock).toHaveBeenCalledTimes(1);
         expect(errorMock).toHaveBeenCalledWith(
           'Exception occured in parcelDescriptionService.updateParcelDescriptionsForSite() end',
+          expect.anything(),
+        );
+      });
+    });
+  });
+
+  describe('deleteParcelDescriptionsForSite', () => {
+    let today: Date;
+    let subdivId: string;
+    let siteSubdivId: string;
+
+    let inputParcelDescriptions: ParcelDescriptionInputDTO[];
+    let siteId: string;
+
+    let databaseSubdivision: Subdivisions;
+    let databaseSiteSubdivision: SiteSubdivisions;
+
+    let subdivisionFindByResult: Subdivisions[];
+    let subdivisionRemoveResult: Subdivisions[];
+    let siteSubdivisionFindByResult: SiteSubdivisions[];
+    let siteSubdivisionRemoveResult: SiteSubdivisions[];
+
+    let subdivisionFindByMock: jest.Mock;
+    let subdivisionRemoveMock: jest.Mock;
+    let siteSubdivisionFindByMock: jest.Mock;
+    let siteSubdivisionRemoveMock: jest.Mock;
+
+    beforeEach(() => {
+      today = new Date();
+      subdivId = '1';
+      siteSubdivId = '100';
+
+      siteId = '10';
+      inputParcelDescriptions = [
+        {
+          id: subdivId,
+          descriptionType: ParcelDescriptionType.CrownLandPIN,
+          idPinNumber: '123456',
+          dateNoted: today,
+          landDescription: 'should be ignored',
+          srAction: 'approved',
+          userAction: 'approved',
+          apiAction: 'deleted',
+        },
+      ];
+
+      databaseSubdivision = {
+        srAction: 'approved',
+        userAction: 'approved',
+        id: '1',
+        dateNoted: today,
+        pin: '654321',
+        pid: null,
+        bcaaFolioNumber: null,
+        entityType: null,
+        addrLine_1: 'test addr',
+        addrLine_2: null,
+        addrLine_3: null,
+        addrLine_4: null,
+        city: 'Anyton',
+        postalCode: 'H0H0H0',
+        legalDescription: 'Land Description',
+        whoCreated: 'employee of the month',
+        whoUpdated: 'test',
+        whenCreated: today,
+        crownLandsFileNo: null,
+        pidStatusCd: 'N',
+        validPid: null,
+      } as Subdivisions;
+      databaseSiteSubdivision = {
+        srAction: 'pending',
+        userAction: 'pending',
+        siteId: siteId,
+        subdivId: subdivId,
+        dateNoted: today,
+        initialIndicator: 'N',
+        whoCreated: 'employee of the month',
+        whoUpdated: 'employee of the month',
+        whenCreated: today,
+        whenUpdated: today,
+        sprofDateCompleted: null,
+        siteSubdivId: siteSubdivId,
+        sendToSr: 'Y',
+        site: null,
+        subdivision: null,
+      } as SiteSubdivisions;
+
+      subdivisionFindByResult = [databaseSubdivision];
+      // This value is disregarded.
+      subdivisionRemoveResult = [];
+
+      siteSubdivisionFindByResult = [databaseSiteSubdivision];
+      // This value is disregarded.
+      siteSubdivisionRemoveResult = [];
+
+      subdivisionFindByMock = jest
+        .fn()
+        .mockResolvedValue(subdivisionFindByResult);
+      subdivisionRemoveMock = jest
+        .fn()
+        .mockResolvedValue(subdivisionRemoveResult);
+      siteSubdivisionFindByMock = jest
+        .fn()
+        .mockResolvedValue(siteSubdivisionFindByResult);
+      siteSubdivisionRemoveMock = jest
+        .fn()
+        .mockResolvedValue(siteSubdivisionRemoveResult);
+
+      subdivisionsRepository.remove = subdivisionRemoveMock;
+      subdivisionsRepository.findBy = subdivisionFindByMock;
+      siteSubdivisionsRepository.remove = siteSubdivisionRemoveMock;
+      siteSubdivisionsRepository.findBy = siteSubdivisionFindByMock;
+    });
+
+    it('removes the expected subdivision from the database', async () => {
+      await parcelDescriptionsService.deleteParcelDescriptionsForSite(
+        siteId,
+        inputParcelDescriptions,
+      );
+
+      expect(subdivisionRemoveMock).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining(databaseSubdivision)]),
+      );
+    });
+
+    it('removes the expected site subdivision from the database', async () => {
+      await parcelDescriptionsService.deleteParcelDescriptionsForSite(
+        siteId,
+        inputParcelDescriptions,
+      );
+
+      expect(siteSubdivisionRemoveMock).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining(databaseSiteSubdivision),
+        ]),
+      );
+    });
+
+    describe('when the subdivision fails to remove', () => {
+      beforeEach(() => {
+        subdivisionRemoveMock = jest.fn().mockImplementation(() => {
+          throw new Error('A bad thing happened!');
+        });
+        subdivisionsRepository.remove = subdivisionRemoveMock;
+      });
+
+      it('logs and throws the error', async () => {
+        expect(async () => {
+          await parcelDescriptionsService.deleteParcelDescriptionsForSite(
+            siteId,
+            inputParcelDescriptions,
+          );
+        }).rejects.toThrow(BadRequestException);
+
+        // Need to wait for the above block to reject before testing the logging
+        // mock.
+        await jest.runAllTimersAsync();
+        expect(errorMock).toHaveBeenCalledTimes(1);
+        expect(errorMock).toHaveBeenCalledWith(
+          'Exception occured in parcelDescriptionService.deleteParcelDescriptionsForSite() end',
+          expect.anything(),
+        );
+      });
+    });
+
+    describe('when the site subdivision fails to remove', () => {
+      beforeEach(() => {
+        siteSubdivisionRemoveMock = jest.fn().mockImplementation(() => {
+          throw new Error('A bad thing happened!');
+        });
+        siteSubdivisionsRepository.remove = siteSubdivisionRemoveMock;
+      });
+
+      it('logs and throws the error', async () => {
+        expect(async () => {
+          await parcelDescriptionsService.deleteParcelDescriptionsForSite(
+            siteId,
+            inputParcelDescriptions,
+          );
+        }).rejects.toThrow(BadRequestException);
+
+        // Need to wait for the above block to reject before testing the logging
+        // mock.
+        await jest.runAllTimersAsync();
+        expect(errorMock).toHaveBeenCalledTimes(1);
+        expect(errorMock).toHaveBeenCalledWith(
+          'Exception occured in parcelDescriptionService.deleteParcelDescriptionsForSite() end',
           expect.anything(),
         );
       });

--- a/backend/src/app/services/parcelDescriptions/parcelDescriptions.service.ts
+++ b/backend/src/app/services/parcelDescriptions/parcelDescriptions.service.ts
@@ -492,6 +492,8 @@ export class ParcelDescriptionsService {
     try {
       await this.siteSubdivisionsRepository.remove(siteSubdivisions);
     } catch (error) {
+      // This code is called within a transaction in the site service, so the
+      // previous save should be rolled back if there is a failure here.
       this.sitesLogger.error(
         'Exception occured in parcelDescriptionService.deleteParcelDescriptionsForSite() end',
         JSON.stringify(error),

--- a/backend/src/app/services/parcelDescriptions/parcelDescriptions.service.ts
+++ b/backend/src/app/services/parcelDescriptions/parcelDescriptions.service.ts
@@ -461,6 +461,49 @@ export class ParcelDescriptionsService {
     siteId: string,
     parcelDescriptions: ParcelDescriptionInputDTO[],
   ) {
-    // TODO: Implementation to come in another pull request
+    this.sitesLogger.log(
+      'parcelDescriptionService.deleteParcelDescriptionsForSite() start',
+    );
+    this.sitesLogger.debug(
+      'parcelDescriptionService.deleteParcelDescriptionsForSite() start',
+    );
+
+    const subdivIds = parcelDescriptions.map((parcelDescription) => {
+      return parcelDescription.id;
+    });
+    let siteSubdivisions = await this.siteSubdivisionsRepository.findBy({
+      subdivId: In(subdivIds),
+      siteId: siteId,
+    });
+    let subdivisions = await this.subdivisionsRepository.findBy({
+      id: In(subdivIds),
+    });
+
+    try {
+      await this.subdivisionsRepository.remove(subdivisions);
+    } catch (error) {
+      this.sitesLogger.error(
+        'Exception occured in parcelDescriptionService.deleteParcelDescriptionsForSite() end',
+        JSON.stringify(error),
+      );
+      throw new BadRequestException('Failed removing Parcel Description.');
+    }
+
+    try {
+      await this.siteSubdivisionsRepository.remove(siteSubdivisions);
+    } catch (error) {
+      this.sitesLogger.error(
+        'Exception occured in parcelDescriptionService.deleteParcelDescriptionsForSite() end',
+        JSON.stringify(error),
+      );
+      throw new BadRequestException('Failed removing Parcel Description.');
+    }
+
+    this.sitesLogger.log(
+      'parcelDescriptionService.deleteParcelDescriptionsForSite() end',
+    );
+    this.sitesLogger.debug(
+      'parcelDescriptionService.deleteParcelDescriptionsForSite() end',
+    );
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Implement the method to delete Parcel Description entities from the database

Fixes # SRS-361 (Partially)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Manual GraphQL test.
```graphql
mutation updateSiteDetails($siteDetailsDTO: SaveSiteDetailsDTO!) {
    updateSiteDetails(siteDetailsDTO: $siteDetailsDTO) {
        message
        httpStatusCode
        success
    }
}
```
with variables:
```json
{
    "siteDetailsDTO": {
    "siteId": "997",
    "parcelDescriptions": [
      {
        "id": "",
        "descriptionType": "Parcel ID",
        "idPinNumber": "123456",
        "dateNoted": "2024-10-17T00:00:00Z",
        "landDescription": "should be disregarded",
        "userAction": "pending",
        "srAction": "pending",
        "apiAction": "deleted"
      }
    ]
  }  
}
```
(after adding the parcel description)

- [x] Unit tests

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-181-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-181-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)