### PR TITLE
feat: Hide Updates Tab when in edit mode

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -24,7 +24,7 @@ COPY . ./
 RUN npm run build
 
 # Stage 1, based on Nginx, to have only the compiled app, ready for production with Nginx
-FROM nginx:1.9 AS deploy
+FROM nginx:alpine AS deploy
 RUN mkdir /app
 COPY --from=build /app/build /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/nginx.conf

--- a/frontend/src/app/features/details/SiteDetails.tsx
+++ b/frontend/src/app/features/details/SiteDetails.tsx
@@ -120,7 +120,7 @@ const SiteDetails = () => {
   }, [auth.user]);
 
   useEffect(() => {
-    if (isUserOfType(UserRoleType.SR) && !hasNoPendingUpdatesFromState) {
+    if (isUserOfType(UserRoleType.SR) && !hasNoPendingUpdatesFromState && viewMode !== SiteDetailsMode.EditMode) {
       SetNavComponents(getNavComponents(true));
       SetNavItems(getNavItems(true));
       SetDropDownNavItems(getDropDownNavItems(true));
@@ -245,7 +245,20 @@ const SiteDetails = () => {
   const mode = useSelector(siteDetailsMode);
 
   useEffect(() => {
+    //alert(mode)
     setViewMode(mode);
+
+    if (isUserOfType(UserRoleType.SR) && !hasNoPendingUpdatesFromState && mode !== SiteDetailsMode.EditMode) {
+      SetNavComponents(getNavComponents(true));
+      SetNavItems(getNavItems(true));
+      SetDropDownNavItems(getDropDownNavItems(true));
+    } else {
+      SetNavComponents(getNavComponents(false));
+      SetNavItems(getNavItems(false));
+      SetDropDownNavItems(getDropDownNavItems(false));
+    }
+
+
   }, [mode]);
 
   useEffect(() => {
@@ -481,7 +494,7 @@ const SiteDetails = () => {
 
   const getActionItemsToRender = () => {
     let userTypeSR: boolean = isUserOfType(UserRoleType.SR) ?? false;
-    let includeSRApprovalActions = userTypeSR && !hasNoPendingUpdatesFromState;
+    let includeSRApprovalActions = userTypeSR && !hasNoPendingUpdatesFromState && viewMode !== SiteDetailsMode.EditMode;
     return getActionItems(includeSRApprovalActions);
   };
 

--- a/frontend/src/app/features/details/SiteDetails.tsx
+++ b/frontend/src/app/features/details/SiteDetails.tsx
@@ -245,9 +245,7 @@ const SiteDetails = () => {
   const mode = useSelector(siteDetailsMode);
 
   useEffect(() => {
-    //alert(mode)
     setViewMode(mode);
-
     if (isUserOfType(UserRoleType.SR) && !hasNoPendingUpdatesFromState && mode !== SiteDetailsMode.EditMode) {
       SetNavComponents(getNavComponents(true));
       SetNavItems(getNavItems(true));


### PR DESCRIPTION
- Change to hide SR updates tab when the user switches to Edit mode.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-187-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-187-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)