### PR TITLE
Fix double `--` in redirect uri

### DIFF
--- a/charts/app/templates/frontend/templates/configmap.yaml
+++ b/charts/app/templates/frontend/templates/configmap.yaml
@@ -3,7 +3,7 @@
 {{$REACT_APP_AUTH_AUTHORITY:= printf "https://epd-keycloak-dev.apps.silver.devops.gov.bc.ca/auth/realms/forms-flow-ai/" }}
 {{$REACT_APP_AUTH_CLIENT_ID:= printf "epd-local" }}
 {{$REACT_APP_AUTH_REDIRECT_URI:=  printf "https://%s-frontend.%s" .Release.Name  .Values.global.domain }}
-{{$REACT_APP_AUTH_LOGOUT_REDIRECT_URI:=  printf "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow: 1&returl: https://epd-keycloak-dev.apps.silver.devops.gov.bc.ca/auth/realms/forms-flow-ai/protocol/openid-connect/logout?post_logout_redirect_uri=https://%s--frontend.%s" .Release.Name .Values.global.domain }}
+{{$REACT_APP_AUTH_LOGOUT_REDIRECT_URI:=  printf "https://logontest7.gov.bc.ca/clp-cgi/logoff.cgi?retnow: 1&returl: https://epd-keycloak-dev.apps.silver.devops.gov.bc.ca/auth/realms/forms-flow-ai/protocol/openid-connect/logout?post_logout_redirect_uri=https://%s-frontend.%s" .Release.Name .Values.global.domain }}
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
This is a very small 1-line fix as discussed on call to fix issue with duplicate `--`, where it should only be one `-` to match url.