### PR TITLE
fix: Disabled Add  button as long as source of data is not available.

### DIFF
--- a/frontend/src/app/features/details/disclosure/Disclosure.tsx
+++ b/frontend/src/app/features/details/disclosure/Disclosure.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { UserType } from '../../../helpers/requests/userType';
 import { SiteDetailsMode } from '../dto/SiteDetailsMode';
 import {
@@ -23,12 +23,9 @@ import {
 } from '../../../components/common/IChangeType';
 import {
   flattenFormRows,
-  getAxiosInstance,
   getUser,
-  resultCache,
   serializeDate,
   sortArray,
-  updateFields,
 } from '../../../helpers/utility';
 import { SRVisibility } from '../../../helpers/requests/srVisibility';
 import {
@@ -39,15 +36,11 @@ import {
 import { useParams } from 'react-router-dom';
 import { IComponentProps } from '../navigation/NavigationPillsConfig';
 import DisclosureComponent from './DisclosureComponent';
-import { GRAPHQL } from '../../../helpers/endpoints';
-import { graphQLPeopleOrgsCd } from '../../site/graphql/Dropdowns';
-import { print } from 'graphql';
 import {
   getSiteDisclosure,
   saveRequestStatus,
   setupSiteDisclosureDataForSaving,
 } from '../SaveSiteDetailsSlice';
-import infoIcon from '../../../images/info-icon.png';
 import { SRApprovalStatusEnum } from '../../../common/srApprovalStatusEnum';
 import { UserActionEnum } from '../../../common/userActionEnum';
 import ModalDialog from '../../../components/modaldialog/ModalDialog';

--- a/frontend/src/app/features/details/disclosure/DisclosureComponent.tsx
+++ b/frontend/src/app/features/details/disclosure/DisclosureComponent.tsx
@@ -157,6 +157,7 @@ const DisclosureComponent: React.FC<IDisclosureComponent> = ({
                     <Button
                       variant="secondary"
                       onClick={() => handleAddDisclosureSchedule(formData.id)}
+                      disabled={!isAnyDisclosureScheduleSelected(formData.id)}
                     >
                       <Plus />
                       Add


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This PR contains a disabling of Add button on site disclosure page because the source of data is not confirm yet. Once the data will be available, Add button should be enabled and implementation related to table will be required.


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-205-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-205-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)