### PR TITLE
chore: log thrown error in mapSearch query

### DIFF
--- a/backend/src/app/resolvers/site/site.resolver.ts
+++ b/backend/src/app/resolvers/site/site.resolver.ts
@@ -236,7 +236,9 @@ export class SiteResolver {
         data,
       );
     } catch (e) {
-      this.sitesLogger.log('SiteResolver.mapSearch() failed');
+      this.sitesLogger.log(
+        `SiteResolver.mapSearch() failed, ${JSON.stringify(e)}`,
+      );
       return this.mapSearchGenericResponseProvider.createResponse(
         'Error fetching sites for map',
         HttpStatus.INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Log thrown error in the `mapSearch` query


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-220-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-220-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)