### PR TITLE
chore: Update frontend local development port

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "concurrently \"react-scripts start\" \"graphql-codegen --watch\"",
+    "start": "concurrently \"PORT=4000 react-scripts start\" \"graphql-codegen --watch\"",
     "build": "react-scripts build",
     "test": "react-scripts test --transformIgnorePatterns \"node_modules/(?!@react-parcelmap-bc)/\"  ",
     "eject": "react-scripts eject",


### PR DESCRIPTION
Something that has bothered me for a while: Our docker image and react's local dev environment use different ports. Docker uses 4000 by default, and react uses 3000. Sometimes I like to run the frontend outside of docker to more easily troubleshoot things. This will reduce a friction point I experience.

@nikhila-aot @midhun-aot @jaspalsingh-aot @anton-bcgov @nupurdixit13 If/when this is merged it may disrupt your development workflow. Make sure to update your .env files with the new port.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-231-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-231-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)