### PR TITLE
feat: SRS-556: Map search results table pagination + `icon` button variant

### DIFF
--- a/frontend/src/app/components/button/Button.css
+++ b/frontend/src/app/components/button/Button.css
@@ -75,3 +75,23 @@
 .SITE-Button.tertiary:hover:not(:disabled) {
   background-color: var(--surface-tertiary-hover);
 }
+
+.SITE-Button.btn-icon {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--surface-primary-default);
+}
+.SITE-Button.btn-icon:hover:not(:disabled) {
+  background-color: var(--surface-color-brand-blue-20);
+}
+.SITE-Button.btn-icon:focus {
+  background-color: var(--surface-color-brand-blue-20);
+  border: 1px solid var(--surface-color-primary-active-border);
+}
+.SITE-Button.btn-icon.btn-active {
+  background: var(--surface-color-primary-default);
+  color: var(--typography-color-primary-invert);
+}
+.SITE-Button.btn-icon.btn-active:hover {
+  background: var(--surface-color-primary-default);
+}

--- a/frontend/src/app/components/button/Button.tsx
+++ b/frontend/src/app/components/button/Button.tsx
@@ -3,20 +3,37 @@ import clsx from 'clsx';
 
 import './Button.css';
 
-export type ButtonVariant = 'primary' | 'secondary' | 'tertiary';
+export type ButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'icon';
 export type ButtonSize = 'small' | 'medium';
 
 type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   size?: ButtonSize;
   variant?: ButtonVariant;
+  active?: boolean;
 };
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ variant = 'primary', size = 'medium', className, ...props }, ref) => {
+  (
+    {
+      variant = 'primary',
+      size = 'medium',
+      className,
+      active = false,
+      ...props
+    },
+    ref,
+  ) => {
+    const variantCssClass = variant === 'icon' ? 'btn-icon' : variant;
     return (
       <button
         ref={ref}
-        className={clsx(['SITE-Button', variant, size, className])}
+        className={clsx([
+          'SITE-Button',
+          variantCssClass,
+          size,
+          active && 'btn-active',
+          className,
+        ])}
         {...props}
       />
     );

--- a/frontend/src/app/components/table/pagination/Pagination.test.tsx
+++ b/frontend/src/app/components/table/pagination/Pagination.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 import Pagination from './Pagination';
-import { text } from 'stream/consumers';
 
 describe('Pagination Component', () => {
   const selectPageMock = jest.fn(() => {});
@@ -22,12 +21,8 @@ describe('Pagination Component', () => {
       />,
     );
 
-    expect(
-      screen.getByText('1', { selector: '.pagination-page-active' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText('100', { selector: '.pagination-page' }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '100' })).toBeInTheDocument();
     // Add more assertions based on your component's logic
   });
 
@@ -42,10 +37,8 @@ describe('Pagination Component', () => {
       />,
     );
 
-    expect(
-      screen.getByText('1', { selector: '.pagination-page-active' }),
-    ).toBeInTheDocument();
-    fireEvent.click(screen.getByText('2', { selector: '.pagination-page' }));
+    expect(screen.getByRole('button', { name: '1' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '2' }));
     expect(selectPageMock).toHaveBeenCalledWith(2);
   });
 

--- a/frontend/src/app/components/table/pagination/Pagination.tsx
+++ b/frontend/src/app/components/table/pagination/Pagination.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 import './Pagination.css';
 import { AngleLeft, AngleRight } from '../../common/icon';
+import { Button } from '../../button/Button';
 
 interface PaginationProps {
   selectPage?: (pageNumber: number) => void;
@@ -69,14 +70,13 @@ const Pagination: React.FC<PaginationProps> = ({
 
   const page = (pageNumber: number) => {
     return (
-      <div
+      <Button
         onClick={() => selectPage?.(pageNumber)}
-        className={`pagination-page ${
-          currentPage === pageNumber ? 'pagination-page-active' : ''
-        }`}
+        variant="icon"
+        active={currentPage === pageNumber}
       >
         {pageNumber}
-      </div>
+      </Button>
     );
   };
 
@@ -100,10 +100,9 @@ const Pagination: React.FC<PaginationProps> = ({
         <React.Fragment>
           {paginationDots}
           <div className="pagination-section">{page(totalPagesRequired)}</div>
-          <AngleRight
-            className="pagination-page"
-            onClick={() => selectPage?.(currentPage + 1)}
-          />
+          <Button variant="icon" onClick={() => selectPage?.(currentPage + 1)}>
+            <AngleRight size={18} />
+          </Button>
         </React.Fragment>
       );
     } else {
@@ -129,10 +128,9 @@ const Pagination: React.FC<PaginationProps> = ({
     if (startPage !== 1) {
       return (
         <React.Fragment>
-          <AngleLeft
-            className="pagination-page"
-            onClick={() => selectPage?.(currentPage - 1)}
-          />
+          <Button variant="icon" onClick={() => selectPage?.(currentPage - 1)}>
+            <AngleLeft size={18} />
+          </Button>
           <div className="pagination-section">{page(1)}</div>
           {paginationDots}
         </React.Fragment>

--- a/frontend/src/app/features/map/MapSearch.graphql
+++ b/frontend/src/app/features/map/MapSearch.graphql
@@ -32,8 +32,8 @@ query MapSearch_findSiteBySiteId($siteId: String!) {
     }
 }
 
-query MapSearch_filterSearchResults($siteIds: [String!]) {
-  searchSites(searchParam: "", page: 1, pageSize: 100, siteIds: $siteIds) {
+query MapSearch_filterSearchResults($siteIds: [String!], $page: Int!, $pageSize: Int!) {
+  searchSites(searchParam: "", page: $page, pageSize: $pageSize, siteIds: $siteIds) {
     sites {
       id
       addrLine_1

--- a/frontend/src/app/features/map/siteDrawer/SearchResultsDrawerContent.tsx
+++ b/frontend/src/app/features/map/siteDrawer/SearchResultsDrawerContent.tsx
@@ -6,10 +6,19 @@ import { SearchResultsActions } from '../../site/searchResults/SearchResultsActi
 import FilterPills from '../../site/filters/FilterPills';
 import { getSiteSearchResultsColumns } from '../../site/dto/Columns';
 import { TableColumn } from '../../../components/table/TableColumn';
-import { useMapSearch_FilterSearchResultsQuery } from '../../../../graphql/generated';
+import {
+  MapSearch_FilterSearchResultsQuery,
+  useMapSearch_FilterSearchResultsQuery,
+} from '../../../../graphql/generated';
 import { SpinnerIcon } from '../../../components/common/icon';
+import useDebouncedValue from '../../../helpers/useDebouncedValue';
 
 const defaultColumns = getSiteSearchResultsColumns();
+
+type Pagination = {
+  page: number;
+  pageSize: number;
+};
 
 interface SearchResultsDrawerContentProps {
   sites: Site[];
@@ -19,13 +28,36 @@ export const SearchResultsDrawerContent: FC<
   SearchResultsDrawerContentProps
 > = ({ sites, loading: siteIdsLoading }) => {
   const siteIds = sites.map((site) => site.id);
+  // Saving fetched data to local state allows us avoid table component flickering
+  // when a refetch with new variables takes place
+  const [searchResults, setSearchResults] = useState<
+    MapSearch_FilterSearchResultsQuery['searchSites']
+  >({
+    sites: [],
+    pageSize: 0,
+    count: 0,
+    page: 1,
+  });
 
-  const { data, loading: siteDetailsLoading } =
-    useMapSearch_FilterSearchResultsQuery({
+  const [pagination, setPagination] = useState<Pagination>({
+    page: 1,
+    pageSize: 5,
+  });
+
+  const { loading: siteDetailsLoading } = useMapSearch_FilterSearchResultsQuery(
+    {
       variables: {
         siteIds,
+        page: pagination.page,
+        pageSize: pagination.pageSize,
       },
-    });
+      onCompleted: (data) => {
+        setSearchResults(data.searchSites);
+      },
+    },
+  );
+
+  const siteDetailsLoadingDebounced = useDebouncedValue(siteDetailsLoading);
 
   const [columnsToDisplay, setColumnsToDisplay] =
     useState<TableColumn[]>(defaultColumns);
@@ -72,7 +104,7 @@ export const SearchResultsDrawerContent: FC<
     }
   };
 
-  const loading = siteIdsLoading || siteDetailsLoading;
+  const loading = siteIdsLoading || siteDetailsLoadingDebounced;
 
   return (
     <div className="d-flex flex-column gap-3">
@@ -91,15 +123,13 @@ export const SearchResultsDrawerContent: FC<
 
       {loading && <SpinnerIcon size={20} className="site-fa-spin" />}
 
-      {!siteDetailsLoading && (
-        <SearchResults
-          pageChange={() => console.log('todo')}
-          data={data?.searchSites.sites || []}
-          columns={columnsToDisplay.filter((x) => x.isChecked === true)}
-          totalRecords={0}
-          changeHandler={changeHandler}
-        />
-      )}
+      <SearchResults
+        pageChange={(page, pageSize) => setPagination({ page, pageSize })}
+        data={searchResults.sites}
+        columns={columnsToDisplay.filter((x) => x.isChecked === true)}
+        totalRecords={searchResults.count}
+        changeHandler={changeHandler}
+      />
     </div>
   );
 };

--- a/frontend/src/graphql/generated.ts
+++ b/frontend/src/graphql/generated.ts
@@ -1354,6 +1354,8 @@ export type MapSearch_FindSiteBySiteIdQuery = { __typename?: 'Query', findSiteBy
 
 export type MapSearch_FilterSearchResultsQueryVariables = Exact<{
   siteIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
+  page: Scalars['Int']['input'];
+  pageSize: Scalars['Int']['input'];
 }>;
 
 
@@ -1551,8 +1553,13 @@ export type MapSearch_FindSiteBySiteIdLazyQueryHookResult = ReturnType<typeof us
 export type MapSearch_FindSiteBySiteIdSuspenseQueryHookResult = ReturnType<typeof useMapSearch_FindSiteBySiteIdSuspenseQuery>;
 export type MapSearch_FindSiteBySiteIdQueryResult = Apollo.QueryResult<MapSearch_FindSiteBySiteIdQuery, MapSearch_FindSiteBySiteIdQueryVariables>;
 export const MapSearch_FilterSearchResultsDocument = gql`
-    query MapSearch_filterSearchResults($siteIds: [String!]) {
-  searchSites(searchParam: "", page: 1, pageSize: 100, siteIds: $siteIds) {
+    query MapSearch_filterSearchResults($siteIds: [String!], $page: Int!, $pageSize: Int!) {
+  searchSites(
+    searchParam: ""
+    page: $page
+    pageSize: $pageSize
+    siteIds: $siteIds
+  ) {
     sites {
       id
       addrLine_1
@@ -1597,10 +1604,12 @@ export const MapSearch_FilterSearchResultsDocument = gql`
  * const { data, loading, error } = useMapSearch_FilterSearchResultsQuery({
  *   variables: {
  *      siteIds: // value for 'siteIds'
+ *      page: // value for 'page'
+ *      pageSize: // value for 'pageSize'
  *   },
  * });
  */
-export function useMapSearch_FilterSearchResultsQuery(baseOptions?: Apollo.QueryHookOptions<MapSearch_FilterSearchResultsQuery, MapSearch_FilterSearchResultsQueryVariables>) {
+export function useMapSearch_FilterSearchResultsQuery(baseOptions: Apollo.QueryHookOptions<MapSearch_FilterSearchResultsQuery, MapSearch_FilterSearchResultsQueryVariables> & ({ variables: MapSearch_FilterSearchResultsQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
         const options = {...defaultOptions, ...baseOptions}
         return Apollo.useQuery<MapSearch_FilterSearchResultsQuery, MapSearch_FilterSearchResultsQueryVariables>(MapSearch_FilterSearchResultsDocument, options);
       }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

In this PR: 
- Add pagination to map search result table
- Add 'icon' button variant that matches the design system ([Figma link](https://www.figma.com/design/ds1JjB8vYykPb6SF1RskfG/EPD-Design-System---Bespoke?node-id=574-1406&t=mO8Q8cETEmToHYlv-1))
- Make Table's pagination controls actual buttons instead of clickable divs - **_this affects all tables with pagination!_**

Demo:

https://github.com/user-attachments/assets/13a66190-ebf6-4483-9ebc-6cd7e3947fa9



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-235-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-235-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)