### PR TITLE
feat: Add validation to site details page

### DIFF
--- a/backend/src/app/services/site/site.service.spec.ts
+++ b/backend/src/app/services/site/site.service.spec.ts
@@ -502,7 +502,18 @@ describe('SiteService', () => {
               userAction: 'pending',
               apiAction: 'pending',
               srAction: 'pending',
-              notationParticipant: null,
+              notationParticipant: [
+                {
+                  apiAction: UserActionEnum.ADDED,
+                  eventParticId: 'xxx-xxx',
+                  eventId: '1',
+                  eprCode: 'RVB',
+                  psnorgId: '1',
+                  displayName: 'SAGER, J.',
+                  srAction: 'false',
+                  userAction: 'pending',
+                },
+              ],
             },
           ],
         };
@@ -1046,7 +1057,17 @@ describe('SiteService', () => {
           id: '1',
           etypCode: 'type',
           eclsCode: 'class',
-          notationParticipant: [],
+          notationParticipant: [
+            {
+              apiAction: UserActionEnum.ADDED,
+              eventParticId: 'xxx-xxx',
+              eventId: '1',
+              eprCode: 'RVB',
+              psnorgId: '1',
+              displayName: 'SAGER, J.',
+              srAction: 'false',
+            },
+          ],
         },
       ];
       const userInfo = { givenName: 'Updated User' };

--- a/backend/src/app/services/site/site.service.ts
+++ b/backend/src/app/services/site/site.service.ts
@@ -1090,6 +1090,14 @@ export class SiteService {
           // Process related participants regardless of event action
           if (notationParticipant?.length > 0) {
             await processParticipants(notationId, notationParticipant);
+          } else {
+            this.sitesLogger.warn(
+              `SiteService.processEvents(): There is no notation participants. Atleast every notation should have one notation participant.`,
+            );
+            throw new HttpException(
+              `Failed to process site notation participants. There is no notation participants. Atleast every notation should have one notation participant.`,
+              HttpStatus.NOT_FOUND,
+            );
           }
         });
 

--- a/frontend/src/app/components/modaldialog/ModalDialog.tsx
+++ b/frontend/src/app/components/modaldialog/ModalDialog.tsx
@@ -14,7 +14,10 @@ interface ModalDialogCloseHandlerProps {
   saveBtnLabel?: string;
   cancelBtnLabel?: string;
   dicardBtnLabel?: string;
+  headerLabel?: string;
+  customHeaderCss?: string;
   discardOption?: boolean;
+  errorOption?: boolean;
 }
 
 const ModalDialog: React.FC<ModalDialogCloseHandlerProps> = ({
@@ -25,6 +28,9 @@ const ModalDialog: React.FC<ModalDialogCloseHandlerProps> = ({
   cancelBtnLabel,
   dicardBtnLabel,
   discardOption,
+  errorOption,
+  headerLabel,
+  customHeaderCss,
 }) => {
   saveBtnLabel = saveBtnLabel ?? '';
   cancelBtnLabel = cancelBtnLabel ?? '';
@@ -55,14 +61,18 @@ const ModalDialog: React.FC<ModalDialogCloseHandlerProps> = ({
       {open && (
         <ModalDialogWrapper closeHandler={handleClose}>
           <div className="custom-modal-header">
-            <span className="custom-modal-header-text">{displayLabel}</span>
+            <span
+              className={`${customHeaderCss || 'custom-modal-header-text'}`}
+            >
+              {headerLabel || displayLabel}
+            </span>
             <XmarkIcon
               className="custom-modal-header-close"
               onClick={handleClose}
             ></XmarkIcon>
           </div>
           {children && <div className="custom-modal-data">{children}</div>}
-          {!discardOption && (
+          {!discardOption && !errorOption && (
             <div className="custom-modal-actions-footer">
               <CancelButton
                 variant="tertiary"
@@ -85,6 +95,11 @@ const ModalDialog: React.FC<ModalDialogCloseHandlerProps> = ({
                 showIcon={false}
               />
               <SaveButton clickHandler={handleSave} label={saveBtnLabel} />
+            </div>
+          )}
+          {errorOption && (
+            <div className="custom-modal-actions-footer">
+              <CancelButton clickHandler={handleClose} label={cancelBtnLabel} />
             </div>
           )}
         </ModalDialogWrapper>

--- a/frontend/src/app/features/details/SiteDetails.css
+++ b/frontend/src/app/features/details/SiteDetails.css
@@ -142,3 +142,11 @@
 .pos-relative {
   position: relative;
 }
+
+.custom-modal-error-header-text {
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 34px;
+  text-align: left;
+  color: #f00;
+}

--- a/frontend/src/app/features/details/SiteDetails.tsx
+++ b/frontend/src/app/features/details/SiteDetails.tsx
@@ -42,13 +42,17 @@ import {
   isUserOfType,
   showNotification,
   UserRoleType,
+  validateForm,
 } from '../../helpers/utility';
 import { addRecentView } from '../dashboard/DashboardSlice';
 import { fetchSiteParticipants } from './participants/ParticipantSlice';
 import { fetchSiteDisclosure } from './disclosure/DisclosureSlice';
 import { addCartItem, resetCartItemAddedStatus } from '../cart/CartSlice';
 import { useAuth } from 'react-oidc-context';
-import { fetchNotationParticipants } from './notations/NotationSlice';
+import {
+  fetchNotationParticipants,
+  notationParticipants,
+} from './notations/NotationSlice';
 import { fetchDocuments } from './documents/DocumentsSlice';
 import {
   fetchSnapshots,
@@ -96,6 +100,8 @@ import {
   resetBulkUpdateStatus,
 } from './srUpdates/state/srUpdatesTableSlice';
 import { Button } from '../../components/button/Button';
+import { IFormField } from '../../components/input-controls/IFormField';
+import { GetNotationConfig } from './notations/NotationsConfig';
 
 const SiteDetails = () => {
   const [confirmSiteReview, SetConfirmSiteReview] = useState<Boolean | null>(
@@ -134,6 +140,12 @@ const SiteDetails = () => {
   const [showLocationDetails, SetShowLocationDetails] = useState(false);
   const [showParcelDetails, SetShowParcelDetails] = useState(false);
   const [save, setSave] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const [errorList, setErrorList] = useState<any[]>([]);
+  const savedChanges = useSelector(trackedChanges);
+  const siteNotation = useSelector(notationParticipants);
+  const { notationFormRowEditMode, notationColumnInternal } =
+    GetNotationConfig();
   const [userType, setUserType] = useState<UserType | null>(null);
   const [viewMode, setViewMode] = useState(SiteDetailsMode.ViewOnlyMode);
   const [isLoading, setIsLoading] = useState(true);
@@ -236,7 +248,6 @@ const SiteDetails = () => {
     }
   }, [loggedInUser]);
 
-  const savedChanges = useSelector(trackedChanges);
   const mode = useSelector(siteDetailsMode);
 
   useEffect(() => {
@@ -392,7 +403,7 @@ const SiteDetails = () => {
     }
   }, [details]);
 
-  const handleItemClick = (value: string) => {
+  const handleItemClick = async (value: string) => {
     switch (value) {
       case SiteDetailsMode.EditMode:
         setEdit(true);
@@ -434,7 +445,16 @@ const SiteDetails = () => {
         //   );
         break;
       case SiteActionBtn.SAVE:
-        setSave(true);
+        const errors = await validateSiteForms();
+        if (errors.length > 0) {
+          setErrorList(errors);
+          setHasError(true);
+          setSave(false);
+        } else {
+          setErrorList([]);
+          setHasError(false);
+          setSave(true);
+        }
         break;
       case SiteActionBtn.CANCEL:
         handleCancelButton();
@@ -444,10 +464,92 @@ const SiteDetails = () => {
     }
   };
 
+  const validateSiteForms = async () => {
+    try {
+      // Run all validation functions in parallel using Promise.all
+      const [errors] = await Promise.all([validateNotationsForm()]);
+
+      // Combine all errors into one list
+      const allErrors = [...errors];
+
+      // You can now use `allErrors` for further processing
+      return allErrors;
+    } catch (error) {
+      return []; // Return empty array in case of error to avoid breaking further logic
+    }
+  };
+
+  const validateNotationsForm = async () => {
+    try {
+      // Run both validations in parallel and wait for them to finish
+      const [notationErrors, notationParticipantErrors] = await Promise.all([
+        validateNotations(), // Async function handling Notation validation
+        validateNotationParticipants(), // Async function handling Notation Participant validation
+      ]);
+
+      // Combine and return the errors from both functions
+      return [...notationErrors, ...notationParticipantErrors];
+    } catch (error) {
+      return []; // Return empty array in case of error to avoid breaking further logic
+    }
+  };
+
+  const validateNotations = async () => {
+    // Directly return the result of validateForm if it's not async
+    return validateForm(
+      notationFormRowEditMode,
+      siteNotation?.siteNotation,
+      'Notation',
+    );
+  };
+
+  const validateNotationParticipants = async () => {
+    const notationParticipantTable: IFormField[][] = [
+      notationColumnInternal
+        .map((column) => column.displayType)
+        .filter(
+          (displayType): displayType is IFormField => displayType !== undefined,
+        ),
+    ];
+
+    const notationParticipantErrors: any[] = [];
+
+    // Loop through siteNotation and their notationParticipants
+    for (const [index, notation] of siteNotation?.siteNotation.entries()) {
+      if (
+        notation?.notationParticipant &&
+        notation?.notationParticipant?.length > 0
+      ) {
+        for (const [
+          participantIndex,
+          notationParticipant,
+        ] of notation.notationParticipant.entries()) {
+          // Validate and accumulate errors for each notation participant
+          const errors = await validateForm(
+            notationParticipantTable,
+            notationParticipant,
+            `Notation [${index + 1}] Notation Participant [${participantIndex + 1}]`,
+          );
+          notationParticipantErrors.push(...errors);
+        }
+      } else {
+        notationParticipantErrors.push({
+          label: 'Notation Participants',
+          objectId: 'Notation Participants',
+          errorMessage: `Notation [${index + 1}] Atleast one  Notation Participant is required.`,
+        });
+      }
+    }
+
+    // Return the accumulated errors
+    return notationParticipantErrors;
+  };
+
   const handleCancelButton = () => {
     dispatch(updateSiteDetailsMode(SiteDetailsMode.ViewOnlyMode));
     dispatch(clearTrackChanges({}));
     setSave(false);
+    setHasError(false);
     setEdit(false);
   };
 
@@ -595,7 +697,7 @@ const SiteDetails = () => {
                   />
                   <SaveButton
                     variant="secondary"
-                    clickHandler={() => setSave(true)}
+                    clickHandler={() => handleItemClick(SiteActionBtn.SAVE)}
                     isDisabled={savedChanges?.length > 0 ? false : true}
                   />
                   <CancelButton clickHandler={handleCancelButton} />
@@ -653,7 +755,7 @@ const SiteDetails = () => {
               }}
             />
           )}
-        {save && (
+        {/* {save && !error && errors?.length === 0 && (
           <ModalDialog
             closeHandler={(response) => {
               setSave(false);
@@ -691,6 +793,98 @@ const SiteDetails = () => {
           </ModalDialog>
         )}
 
+        {save && error && errors?.length > 0 && (
+          <ModalDialog
+            closeHandler={(response) => {
+              setError(false);
+              if (response) {
+                // dispatch(saveSiteDetails()).unwrap();
+              }
+            }}>
+              <React.Fragment>
+                <div>
+                  <span className="custom-modal-data-text text-danger">
+                    The following fields have errors:
+                  </span>
+                </div>
+                <div>
+                  <ul className="custom-modal-data-text text-danger">
+                    {errors.map((item: any) => (
+                      <li key={item.label}>
+                        {IChangeType[item.changeType]} {item.label}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </React.Fragment>
+          </ModalDialog>
+        )} */}
+        {(save || hasError) && (
+          <ModalDialog
+            errorOption={hasError}
+            customHeaderCss={hasError ? 'custom-modal-error-header-text' : ''}
+            headerLabel={hasError ? 'Please fix the errors' : ''}
+            closeHandler={(response) => {
+              setSave(false);
+              if (response && errorList?.length === 0) {
+                // Proceed with saving if there are no errors
+                dispatch(saveSiteDetails()).unwrap();
+              } else {
+                // If there are errors, you can handle accordingly (perhaps reset or keep showing the errors)
+                setHasError(false);
+              }
+            }}
+          >
+            {/* Show error message if errors exist */}
+            {hasError && errorList && errorList?.length > 0 ? (
+              <React.Fragment>
+                <div>
+                  <span className="custom-modal-data-text text-danger">
+                    The following fields have errors:
+                  </span>
+                </div>
+                <div
+                  style={{
+                    maxHeight: '200px', // Adjust based on your modal size
+                    overflowY: 'auto',
+                  }}
+                >
+                  <ul className="custom-modal-data-text text-danger">
+                    {errorList.map((item: any, index) => (
+                      <li key={index}>
+                        {/* Assuming item has changeType and label */}
+                        {IChangeType[item.changeType]} {item.errorMessage}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </React.Fragment>
+            ) : (
+              // Show success message or saved changes if there are no errors
+              <React.Fragment>
+                <div>
+                  <span className="custom-modal-data-text">
+                    {savedChanges.length > 0
+                      ? 'The following fields will be updated:'
+                      : 'No changes to save'}
+                  </span>
+                </div>
+                {savedChanges.length > 0 && (
+                  <div>
+                    <ul className="custom-modal-data-text">
+                      {savedChanges.map((item: any) => (
+                        <li key={item.label}>
+                          {IChangeType[item.changeType]} {item.label}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </React.Fragment>
+            )}
+          </ModalDialog>
+        )}
+
         {!isVisible && (
           <div className="d-flex justify-content-between">
             <Button variant="secondary" onClick={onClickBackButton}>
@@ -719,7 +913,7 @@ const SiteDetails = () => {
                     />
                     <SaveButton
                       variant="secondary"
-                      clickHandler={() => setSave(true)}
+                      clickHandler={() => handleItemClick(SiteActionBtn.SAVE)}
                       isDisabled={savedChanges?.length > 0 ? false : true}
                     />
                     <CancelButton clickHandler={handleCancelButton} />

--- a/frontend/src/app/helpers/utility.ts
+++ b/frontend/src/app/helpers/utility.ts
@@ -451,3 +451,67 @@ export function sortArray<T>(
     }
   });
 }
+
+export const validateForm = (
+  formRows: IFormField[][],
+  formData: any,
+  source: string,
+) => {
+  const errors: any[] = [];
+  const traverse = (
+    rows: IFormField[][],
+    data: any,
+    parentLabel: string = source,
+    parentIndex: string = '',
+    currentContext: string = '',
+  ) => {
+    rows.forEach((items) => {
+      items.forEach((row) => {
+        const propertyName = row.graphQLPropertyName;
+
+        // Ensure graphQLPropertyName exists
+        if (propertyName) {
+          const fieldValue = data[propertyName];
+
+          // Validate the current field
+          if (row.validation?.required && !fieldValue) {
+            // Building the error label with index
+            const errorLabel = parentIndex
+              ? `${parentLabel} [${parentIndex}] ${row?.validation.customMessage}`
+              : `${parentLabel} ${row?.validation.customMessage}`;
+
+            errors.push({
+              label: row.label,
+              objectId: propertyName,
+              errorMessage: errorLabel,
+            });
+          }
+
+          // Recursively handle children
+          if (row.children && Array.isArray(data[propertyName])) {
+            const childData = data[propertyName];
+            childData.forEach((child: any, index: number) => {
+              traverse(
+                row.children as any,
+                child,
+                `${parentLabel} [${parentIndex}] ${row.label}`,
+                `${++index}`,
+              );
+            });
+          }
+        }
+      });
+    });
+  };
+
+  // Handle both arrays and single objects
+  if (Array.isArray(formData)) {
+    formData.forEach((item, index) =>
+      traverse(formRows, item, source, `${++index}`),
+    );
+  } else {
+    traverse(formRows, formData, source);
+  }
+
+  return errors;
+};


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
   Add validation to site details page. If there is any error in notations, site participant, associated sites, documents and disclosure, modal popup will show the list of error and its location. 

Please let me know if anybody else is implementing the validations. 

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-237-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-237-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)