### PR TITLE
fix: Fix IconMarker compilation errors

### DIFF
--- a/frontend/src/app/features/map/IconMarker.tsx
+++ b/frontend/src/app/features/map/IconMarker.tsx
@@ -20,47 +20,44 @@ interface Props {
   [key: string]: any;
 }
 
-export const IconMarker = forwardRef<LeafletMarker, Props>(
-  (
-    {
-      position,
-      icon,
-      onClick,
-      onHover,
-      eventHandlers = {},
-      children = null,
-      riseOnHover = false,
-      ...rest
-    }: Props,
-    ref,
-  ) => {
-    if (onClick) {
-      eventHandlers = {
-        ...eventHandlers,
-        click: onClick,
-      };
-    }
+export const IconMarker = forwardRef<LeafletMarker, Props>((props, ref) => {
+  let {
+    position,
+    icon,
+    onClick,
+    onHover,
+    eventHandlers = {},
+    children = null,
+    riseOnHover = false,
+    ...rest
+  } = props;
 
-    if (onHover) {
-      eventHandlers = {
-        ...eventHandlers,
-        mouseover: () => onHover(true),
-        mouseout: () => onHover(false),
-      };
-    }
-    return (
-      <Marker
-        ref={ref}
-        position={position}
-        icon={icon}
-        eventHandlers={eventHandlers}
-        riseOnHover={riseOnHover}
-        {...rest}
-      >
-        {children}
-      </Marker>
-    );
-  },
-);
+  if (onClick) {
+    eventHandlers = {
+      ...eventHandlers,
+      click: onClick,
+    };
+  }
+
+  if (onHover) {
+    eventHandlers = {
+      ...eventHandlers,
+      mouseover: () => onHover(true),
+      mouseout: () => onHover(false),
+    };
+  }
+  return (
+    <Marker
+      ref={ref}
+      position={position}
+      icon={icon}
+      eventHandlers={eventHandlers}
+      riseOnHover={riseOnHover}
+      {...rest}
+    >
+      {children}
+    </Marker>
+  );
+});
 
 IconMarker.displayName = 'IconMarker';


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This fixes a compilation error that popped up for @midhun-aot after updating dependencies locally and could have appeared for others in the future

The error is:
```
ERROR in src/app/features/map/IconMarker.tsx:24:3
TS2345: Argument of type '({ position, icon, onClick, onHover, eventHandlers, children, riseOnHover, ...rest }: Props, ref: ForwardedRef<Marker<any>>) => Element' is not assignable to parameter of type 'ForwardRefRenderFunction<Marker<any>, Omit<Props, "ref">>'.
  Types of parameters '__0' and 'props' are incompatible.
    Type 'Omit<Props, "ref">' is missing the following properties from type 'Props': position, onHover
```

The fix is that we now destructure the props in the function body instead of the parameter list, which apparently you shouldn't do when wrapping a component in a `forwardRef`

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-241-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-241-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)