### PR TITLE
fix: Fix Authorization header value for unauthenticated users

### DIFF
--- a/frontend/src/app/helpers/utility.ts
+++ b/frontend/src/app/helpers/utility.ts
@@ -130,7 +130,7 @@ export const getAxiosInstance = () => {
     baseURL: API,
     // timeout: 2000,
     headers: {
-      Authorization: 'Bearer ' + user?.access_token,
+      Authorization: `Bearer ${user?.access_token || ''}`,
       requestID: generateRequestId(),
       'Access-Control-Allow-Origin': '*',
       'Content-Type': 'application/json',


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Fix Authorization header value for unauthenticated users

**Before**: `Bearer undefined`
**After**: `Bearer `

## Why this is important

Before, on every unauthenticated request Keycloak was trying to decode the string `"undefined"` as a valid token and, of course, failed every time and never passed the AuthGuard.

When the token is empty, Keycloak skips the decoding part. In turn, this lets us set up public routes/queries like this:

```typescript
  @Query(() => null, { name: 'testQuery' })
  @Unprotected(false) // in this context, `false` means "don't skip authentication if token is on the headers"
  async testQuery(@AuthenticatedUser() user) {
    // this logs undefined for unauthenticated users
    // and the decoded token value for authenticated users
    console.log(user);
  }
```

This means we can reuse the same query for both authenticated and unauthenticated experiences, but change how they are processed by the service. [More context here](https://github.com/bcgov/nr-site-registry/pull/239#discussion_r1893161713)


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-247-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-247-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)