### PR TITLE
chore: remove limits as it is removed from OpenShift Platform

### DIFF
--- a/charts/app/templates/backend/templates/deployment.yaml
+++ b/charts/app/templates/backend/templates/deployment.yaml
@@ -68,9 +68,6 @@ spec:
                   key: user
                   name: postgres-crunchy-pguser-postgres
           resources: # this is optional
-            limits:
-              cpu: {{ .Values.backend.resources.limits.cpu }}
-              memory: {{ .Values.backend.resources.limits.memory }}
             requests:
               cpu: {{ .Values.backend.resources.requests.cpu }}
               memory: {{ .Values.backend.resources.requests.memory }}
@@ -128,9 +125,6 @@ spec:
             - name: SEED_DATA_PATH
               value: "/mnt/sql/data_migration.sql"
           resources: # this is optional
-            limits:
-              cpu: {{ .Values.backend.resources.limits.cpu }}
-              memory: {{ .Values.backend.resources.limits.memory }}
             requests:
               cpu: {{ .Values.backend.resources.requests.cpu }}
               memory: {{ .Values.backend.resources.requests.memory }}
@@ -217,9 +211,6 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 5
           resources: # this is optional
-            limits:
-              cpu: {{ .Values.backend.resources.limits.cpu }}
-              memory: {{ .Values.backend.resources.limits.memory }}
             requests:
               cpu: {{ .Values.backend.resources.requests.cpu }}
               memory: {{ .Values.backend.resources.requests.memory }}

--- a/charts/app/templates/frontend/templates/deployment.yaml
+++ b/charts/app/templates/frontend/templates/deployment.yaml
@@ -60,9 +60,6 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 5
           resources:
-            limits:
-              cpu: 30m
-              memory: 75Mi
             requests:
               cpu: 15m
               memory: 25Mi

--- a/charts/app/values-pr.yaml
+++ b/charts/app/values-pr.yaml
@@ -23,9 +23,6 @@ backend:
   pdb:
     enabled: false
   resources:
-    limits:
-      cpu: 100m
-      memory: 250Mi
     requests:
       cpu: 50m
       memory: 150Mi

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -45,9 +45,6 @@ backend:
     #-- the target cpu utilization percentage, is from request cpu and NOT LIMIT CPU.
     targetCPUUtilizationPercentage: 80
   resources:
-    limits:
-      cpu: 150m
-      memory: 250Mi
     requests:
       cpu: 50m
       memory: 150Mi

--- a/charts/crunchy/templates/PostgresCluster.yaml
+++ b/charts/crunchy/templates/PostgresCluster.yaml
@@ -54,9 +54,6 @@ spec:
           requests:
             cpu: {{ .Values.crunchy.pgmonitor.exporter.requests.cpu }}
             memory: {{ .Values.crunchy.pgmonitor.exporter.requests.memory }}
-          limits:
-            cpu: {{ .Values.crunchy.pgmonitor.exporter.limits.cpu }}
-            memory: {{ .Values.crunchy.pgmonitor.exporter.limits.memory }}
 
   {{ end }}
 
@@ -71,9 +68,6 @@ spec:
         requests:
           cpu: {{ .Values.crunchy.instances.requests.cpu }}
           memory: {{ .Values.crunchy.instances.requests.memory }}
-        limits:
-          cpu: {{ .Values.crunchy.instances.limits.cpu }}
-          memory: {{ .Values.crunchy.instances.limits.memory }}
 
       sidecars:
         replicaCertCopy:
@@ -81,9 +75,6 @@ spec:
             requests:
               cpu: {{ .Values.crunchy.instances.replicaCertCopy.requests.cpu }}
               memory: {{ .Values.crunchy.instances.replicaCertCopy.requests.memory }}
-            limits:
-              cpu: {{ .Values.crunchy.instances.replicaCertCopy.limits.cpu }}
-              memory: {{ .Values.crunchy.instances.replicaCertCopy.limits.memory }}
       dataVolumeClaimSpec:
         accessModes:
           - "ReadWriteOnce"
@@ -177,9 +168,6 @@ spec:
           requests:
             cpu: {{ .Values.crunchy.pgBackRest.repoHost.requests.cpu }}
             memory: {{ .Values.crunchy.pgBackRest.repoHost.requests.memory }}
-          limits:
-            cpu: {{ .Values.crunchy.pgBackRest.repoHost.limits.cpu }}
-            memory: {{ .Values.crunchy.pgBackRest.repoHost.limits.memory }}
       sidecars:
         # this stuff is for the "pgbackrest" container in the "postgres-crunchy-ha" set of pods
         pgbackrest:
@@ -187,25 +175,16 @@ spec:
             requests:
               cpu: {{ .Values.crunchy.pgBackRest.sidecars.pgBackRest.requests.cpu }}
               memory: {{ .Values.crunchy.pgBackRest.sidecars.pgBackRest.requests.memory }}
-            limits:
-              cpu: {{ .Values.crunchy.pgBackRest.sidecars.pgBackRest.limits.cpu }}
-              memory: {{ .Values.crunchy.pgBackRest.sidecars.pgBackRest.limits.memory }}
         pgbackrestConfig:
           resources:
             requests:
               cpu: {{ .Values.crunchy.pgBackRest.sidecars.requests.cpu }}
               memory: {{ .Values.crunchy.pgBackRest.sidecars.requests.memory }}
-            limits:
-              cpu: {{ .Values.crunchy.pgBackRest.sidecars.limits.cpu }}
-              memory: {{ .Values.crunchy.pgBackRest.sidecars.limits.memory }}
       jobs:
         resources:
           requests:
             cpu: {{ .Values.crunchy.pgBackRest.jobs.requests.cpu }}
             memory: {{ .Values.crunchy.pgBackRest.jobs.requests.memory }}
-          limits:
-            cpu: {{ .Values.crunchy.pgBackRest.jobs.limits.cpu }}
-            memory: {{ .Values.crunchy.pgBackRest.jobs.limits.memory }}
   {{- end }}
   patroni:
     dynamicConfiguration:
@@ -238,9 +217,6 @@ spec:
         requests:
           cpu: {{ .Values.crunchy.proxy.pgBouncer.requests.cpu }}
           memory: {{ .Values.crunchy.proxy.pgBouncer.requests.memory }}
-        limits:
-          cpu: {{ .Values.crunchy.proxy.pgBouncer.limits.cpu }}
-          memory: {{ .Values.crunchy.proxy.pgBouncer.limits.memory }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/crunchy/values.yaml
+++ b/charts/crunchy/values.yaml
@@ -38,16 +38,10 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
     requests:
       cpu: 50m
       memory: 128Mi
-    limits:
-      cpu: 150m
-      memory: 256Mi
     replicaCertCopy:
       requests:
         cpu: 1m
         memory: 32Mi
-      limits:
-        cpu: 50m
-        memory: 64Mi
 
   pgBackRest:
     enabled: true
@@ -80,37 +74,22 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       requests:
         cpu: 5m
         memory: 32Mi
-      limits:
-        cpu: 20m
-        memory: 64Mi
     repoHost:
       requests:
         cpu: 20m
         memory: 128Mi
-      limits:
-        cpu: 50m
-        memory: 256Mi
     sidecars:
       requests:
         cpu: 5m
         memory: 16Mi
-      limits:
-        cpu: 20m
-        memory: 64Mi
       pgBackRest: # little more as these container in the statefulset pods do the pvc backups
         requests:
           cpu: 25m
           memory: 128Mi
-        limits:
-          cpu: 50m
-          memory: 256Mi
     jobs:
       requests:
         cpu: 20m
         memory: 256Mi
-      limits:
-        cpu: 100m
-        memory: 512Mi
 
   patroni:
     postgresql:
@@ -135,9 +114,6 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       requests:
         cpu: 5m
         memory: 32Mi
-      limits:
-        cpu: 20m
-        memory: 64Mi
       maxConnections: 10 # make sure less than postgres max connections
 
   # Postgres Cluster resource values:
@@ -148,8 +124,5 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       requests:
         cpu: 1m
         memory: 16Mi
-      limits:
-        cpu: 35m
-        memory: 32Mi
   databaseInitSQL:
     enabled: true

--- a/ora2pg/openshift/temp-pod.yaml
+++ b/ora2pg/openshift/temp-pod.yaml
@@ -11,9 +11,6 @@ spec:
     - name: sql-volume
       mountPath: /mnt/sql
     resources:
-      limits:
-        cpu: "80m"
-        memory: "128Mi"
       requests:
         cpu: "40m"
         memory: "64Mi"


### PR DESCRIPTION
Dear OpenShift Project Teams,
We’re excited to share that as of this morning, December 10, 2024, we’ve made updates to the Quota section to enhance its flexibility and usability:
**Removal of Resource Limits - The concept of limit has been removed. OpenShift now uses only request values configured by the OpenShift Provisioner.**
What this means: Resource requests configured for a namespace are always guaranteed, while additional resources are only available when node capacity allows.
Why limits were removed: Setting CPU limits on Kubernetes can lead to inefficiencies and CPU throttling, even when additional resources are available. By relying on requests, we ensure that resources are reserved for critical workloads without unnecessary constraints, enabling optimal resource utilization and preventing CPU starvation.
Enhanced Numeric Input Options
To provide greater flexibility, the UI now features numeric inputs instead of dropdowns, enabling more precise resource allocation:
CPU: Adjustable from 0 to 64 cores in 0.5-core increments.
Memory: Adjustable from 0 to 128 GB in 1 GB increments.
Storage: Adjustable from 0 to 512 GB in 1 GB increments.

If you have any concerns or questions, please reach out to us via platformservicesteam@gov.bc.ca.

Regards,
Platform Services Team
---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-249-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-249-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-249-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-249-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)