### PR TITLE
fix: Add lat & long deg to graphql query to fix the error in frontend

### DIFF
--- a/frontend/src/app/features/site/graphql/Site.ts
+++ b/frontend/src/app/features/site/graphql/Site.ts
@@ -146,6 +146,8 @@ export const graphqlSiteDetailsQueryForLoggedIn = () => {
           latDegrees
           latMinutes
           latSeconds
+          latdeg
+          longdeg
           city
           generalDescription
           siteRiskCode


### PR DESCRIPTION
- This is quick fix to solve the error received on frontend
- We should remove the SITE public controller and add methods to site controller as the auth issue been addressed already.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-261-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-261-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)