### PR TITLE
feat: SRS-554 - polygon search FE

### DIFF
--- a/frontend/codegen.ts
+++ b/frontend/codegen.ts
@@ -2,7 +2,7 @@ import { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
   overwrite: true,
-  schema: 'http://localhost:4007/graphql',
+  schema: 'http://host.docker.internal:4007/graphql',
   documents: ['src/**/*.graphql'],
   generates: {
     './src/graphql/generated.ts': {

--- a/frontend/src/app/features/map/MapSearch.css
+++ b/frontend/src/app/features/map/MapSearch.css
@@ -232,6 +232,11 @@ div.search-autocomplete.MuiAutocomplete-hasClearIcon .MuiInputBase-root {
   background-color: var(--surface-color-primary-default) !important;
 }
 
+.polygon-vertex {
+  background-color: var(--surface-primary-default);
+  border: 1px solid var(--surface-color-border-light);
+}
+
 :root {
   --layout-margin-xsmall: 4px;
   --layout-margin-small: 8px;

--- a/frontend/src/app/features/map/MapSearch.tsx
+++ b/frontend/src/app/features/map/MapSearch.tsx
@@ -15,14 +15,14 @@ import { TextSearchButton } from './search/TextSearchButton';
 
 import './MapSearch.css';
 import { SearchInput } from './search/SearchInput';
-import React, { RefObject, useContext, useState } from 'react';
+import React, { RefObject, useState } from 'react';
 import { FindMeButton } from './FindMeButton';
 import { HorizontalScroller } from './controls/HorizontalScroller';
 import { PolygonSearchButton } from './search/PolygonSearchButton';
 import { RadiusSearchButton } from './search/RadiusSearchButton';
-import { MapSearchQueryParamsContext } from './mapSearchQueryParamsContext/MapSearchQueryParamsContext';
+import { useMapSearchContext } from './mapSearchQueryParamsContext/MapSearchQueryParamsContext';
 import { RadiusSearch } from './search/RadiusSearch';
-import { PolygonSearch } from './search/PolygonSearch';
+import { PolygonSearchControls } from './search/PolygonSearchControls';
 import {
   MapSearch_FindSitesAndPlacesQuery,
   useMapSearch_FindSitesAndPlacesQuery,
@@ -101,8 +101,6 @@ function formatDataForAutocomplete(
 
 interface MapSearchProps {
   mapRef: RefObject<Map | null>;
-  activeTool?: ActiveToolEnum | null;
-  setActiveTool?: React.Dispatch<React.SetStateAction<ActiveToolEnum | null>>;
   radius: number;
   setRadius: React.Dispatch<React.SetStateAction<number>>;
   isLocationVisible: boolean;
@@ -110,17 +108,14 @@ interface MapSearchProps {
 }
 
 export function MapSearch({
-  activeTool,
-  setActiveTool,
   radius,
   setRadius,
   isLocationVisible,
   setLocationVisible,
   mapRef,
 }: MapSearchProps) {
-  const { searchTerm, setQuery, clearQuery } = useContext(
-    MapSearchQueryParamsContext,
-  );
+  const { searchTerm, setQuery, clearQuery, activeTool, setActiveTool } =
+    useMapSearchContext();
 
   const [searchValue, setSearchValue] = useState(searchTerm);
   const searchValueDebounced = useDebouncedValue(searchValue);
@@ -158,25 +153,12 @@ export function MapSearch({
   const isRadiusTool = activeTool === ActiveToolEnum.radiusSearch;
 
   const handlePolygonToolClick = () => {
-    if (setActiveTool) {
-      setActiveTool((prevTool) =>
-        prevTool === ActiveToolEnum.polygonSearch
-          ? null
-          : ActiveToolEnum.polygonSearch,
-      );
-    }
+    setActiveTool(ActiveToolEnum.polygonSearch);
   };
 
   const handleRadiusToolClick = () => {
-    console.log('Radius tool clicked');
-    if (setActiveTool) {
-      setActiveTool((prevTool) =>
-        prevTool === ActiveToolEnum.radiusSearch
-          ? null
-          : ActiveToolEnum.radiusSearch,
-      );
-      setRadius(MIN_CIRCLE_RADIUS);
-    }
+    setActiveTool(ActiveToolEnum.radiusSearch);
+    setRadius(MIN_CIRCLE_RADIUS);
   };
 
   const onOptionSelect = (option: AutocompleteOption) => {
@@ -270,13 +252,9 @@ export function MapSearch({
         <div className="map-search-tool-row">
           <div className="map-search-tool-box">
             {isPolygonTool ? (
-              <PolygonSearch />
+              <PolygonSearchControls />
             ) : (
-              <RadiusSearch
-                radius={radius}
-                setRadius={setRadius}
-                setActiveTool={setActiveTool}
-              />
+              <RadiusSearch radius={radius} setRadius={setRadius} />
             )}
           </div>
         </div>

--- a/frontend/src/app/features/map/MapSearch.tsx
+++ b/frontend/src/app/features/map/MapSearch.tsx
@@ -20,7 +20,7 @@ import { FindMeButton } from './FindMeButton';
 import { HorizontalScroller } from './controls/HorizontalScroller';
 import { PolygonSearchButton } from './search/PolygonSearchButton';
 import { RadiusSearchButton } from './search/RadiusSearchButton';
-import { useMapSearchContext } from './mapSearchQueryParamsContext/MapSearchQueryParamsContext';
+import { useMapSearchContext } from './mapSearchContext/MapSearchContext';
 import { RadiusSearch } from './search/RadiusSearch';
 import { PolygonSearchControls } from './search/PolygonSearchControls';
 import {

--- a/frontend/src/app/features/map/MapView.tsx
+++ b/frontend/src/app/features/map/MapView.tsx
@@ -17,7 +17,7 @@ import { MAP_FLY_OPTIONS } from './mapOptions';
 import {
   MapSearchQueryProvider,
   useMapSearchContext,
-} from './mapSearchQueryParamsContext/MapSearchQueryParamsContext';
+} from './mapSearchContext/MapSearchContext';
 import { MapSearchDrawer } from './siteDrawer/MapSearchDrawer';
 import { MIN_CIRCLE_RADIUS } from '../../constants/Constant';
 import { RadiusSearchLayer } from './layers/RadiusSearchLayer';

--- a/frontend/src/app/features/map/MapView.tsx
+++ b/frontend/src/app/features/map/MapView.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { LatLngBounds, LatLngTuple, Map } from 'leaflet';
 import { MapContainer, TileLayer } from 'react-leaflet';
 import { useTheme } from '@mui/material/styles';
@@ -15,12 +15,13 @@ import { SiteMarkers } from './siteMarkers/SiteMarkers';
 import { MapControls } from './MapControls';
 import { MAP_FLY_OPTIONS } from './mapOptions';
 import {
-  MapSearchQueryParamsContext,
   MapSearchQueryProvider,
+  useMapSearchContext,
 } from './mapSearchQueryParamsContext/MapSearchQueryParamsContext';
 import { MapSearchDrawer } from './siteDrawer/MapSearchDrawer';
-import { ActiveToolEnum, MIN_CIRCLE_RADIUS } from '../../constants/Constant';
+import { MIN_CIRCLE_RADIUS } from '../../constants/Constant';
 import { RadiusSearchLayer } from './layers/RadiusSearchLayer';
+import { PolygonSearchLayer } from './layers/PolygonSearchLayer';
 
 // Set the position of the marker for center of BC
 const CENTER_OF_BC: LatLngTuple = [53.7267, -127.6476];
@@ -36,7 +37,7 @@ function MapView() {
   // Feature flag for turning OpenStreetMap tiles gray
   const osmGrayscale = false;
 
-  const { searchTerm } = useContext(MapSearchQueryParamsContext);
+  const { searchTerm, activeTool } = useMapSearchContext();
 
   const { data, loading: sitesLoading } = useMapSearchQuery({
     variables: {
@@ -66,7 +67,6 @@ function MapView() {
   const mapRef = useRef<Map>(null);
   const [isLocationVisible, setLocationVisible] = useState(false);
   const [radius, setRadius] = useState(MIN_CIRCLE_RADIUS);
-  const [activeTool, setActiveTool] = useState<ActiveToolEnum | null>(null);
   const [sites, setSites] = useState<Site[]>([]);
   const clearSites = () => setSites([]);
 
@@ -100,19 +100,18 @@ function MapView() {
         {<MyLocationMarker isLocationVisible={isLocationVisible} />}
         <SiteMarkers sites={sites} />
         <RadiusSearchLayer
-          activeTool={activeTool}
           radius={radius}
           onCrossHairClick={clearSites}
           sites={sites}
           setSites={setSites}
         />
+
+        <PolygonSearchLayer />
       </MapContainer>
       <MapSearch
         mapRef={mapRef}
         isLocationVisible={isLocationVisible}
         setLocationVisible={setLocationVisible}
-        activeTool={activeTool}
-        setActiveTool={setActiveTool}
         radius={radius}
         setRadius={setRadius}
       />

--- a/frontend/src/app/features/map/layers/PolygonSearchLayer.tsx
+++ b/frontend/src/app/features/map/layers/PolygonSearchLayer.tsx
@@ -35,7 +35,7 @@ export function PolygonSearch() {
   } = useMapSearchContext();
 
   const map = useMap();
-  useMapCrosshairsCursor(map);
+  useMapCrosshairsCursor(map, isDrawingPolygon);
 
   const dottedLineRef = useRef<LeafletPolyline>(null);
   const mousePositionRef = useRef<LatLng>(map.getCenter());
@@ -58,7 +58,7 @@ export function PolygonSearch() {
     },
   });
 
-  const showCrosshairs = drawShapeVertices.length === 0;
+  const showCrosshairs = isDrawingPolygon && drawShapeVertices.length === 0;
   const drawLine = isDrawingPolygon && drawShapeVertices.length >= 2;
   const drawDottedLine = isDrawingPolygon && drawShapeVertices.length > 0;
   let dottedLinePositions: LatLngExpression[] = [];

--- a/frontend/src/app/features/map/layers/PolygonSearchLayer.tsx
+++ b/frontend/src/app/features/map/layers/PolygonSearchLayer.tsx
@@ -1,0 +1,112 @@
+import { Polygon, Polyline, useMap, useMapEvents } from 'react-leaflet';
+import { useRef } from 'react';
+import L, {
+  LatLngTuple,
+  LeafletMouseEvent,
+  Polyline as LeafletPolyline,
+  LatLng,
+  LatLngExpression,
+} from 'leaflet';
+import { useMapCrosshairsCursor } from '../../../hooks/useMapCrossHairCursor';
+import { CrosshairsTooltipMarker } from '../CrossHairToolTipMarker';
+import { IconMarker } from '../IconMarker';
+import { ActiveToolEnum } from '../../../constants/Constant';
+import { useMapSearchContext } from '../mapSearchQueryParamsContext/MapSearchQueryParamsContext';
+
+const PolygonVertexIcon = L.divIcon({
+  html: `<div />`,
+  className: 'polygon-vertex',
+});
+
+export function PolygonSearchLayer() {
+  const { activeTool } = useMapSearchContext();
+  if (activeTool === ActiveToolEnum.polygonSearch) {
+    return <PolygonSearch />;
+  }
+  return null;
+}
+
+export function PolygonSearch() {
+  const {
+    isDrawingPolygon,
+    drawShapeVertices,
+    addDrawShapeVertex,
+    polygonVertices,
+  } = useMapSearchContext();
+
+  const map = useMap();
+  useMapCrosshairsCursor(map);
+
+  const dottedLineRef = useRef<LeafletPolyline>(null);
+  const mousePositionRef = useRef<LatLng>(map.getCenter());
+
+  useMapEvents({
+    mousemove: (ev: LeafletMouseEvent) => {
+      mousePositionRef.current = ev.latlng;
+      if (drawShapeVertices.length > 0 && dottedLineRef.current) {
+        const lastPosition = drawShapeVertices[drawShapeVertices.length - 1];
+        dottedLineRef.current.setLatLngs([
+          lastPosition,
+          [ev.latlng.lat, ev.latlng.lng],
+        ]);
+      }
+    },
+    click: (ev: LeafletMouseEvent) => {
+      if (isDrawingPolygon) {
+        addDrawShapeVertex([ev.latlng.lat, ev.latlng.lng]);
+      }
+    },
+  });
+
+  const showCrosshairs = drawShapeVertices.length === 0;
+  const drawLine = isDrawingPolygon && drawShapeVertices.length >= 2;
+  const drawDottedLine = isDrawingPolygon && drawShapeVertices.length > 0;
+  let dottedLinePositions: LatLngExpression[] = [];
+  if (drawDottedLine) {
+    dottedLinePositions = [
+      drawShapeVertices[drawShapeVertices.length - 1],
+      mousePositionRef.current,
+    ];
+  }
+
+  const markerPositions: LatLngTuple[] = !isDrawingPolygon
+    ? []
+    : drawShapeVertices;
+  return (
+    <>
+      {showCrosshairs && (
+        <CrosshairsTooltipMarker>
+          Click to start drawing a shape
+        </CrosshairsTooltipMarker>
+      )}
+      {!isDrawingPolygon && (
+        <Polygon
+          positions={polygonVertices}
+          className="polygon-search-polygon"
+        />
+      )}
+      {drawLine && (
+        <Polyline
+          positions={drawShapeVertices}
+          className="polygon-search-line"
+        />
+      )}
+      {drawDottedLine && (
+        <Polyline
+          ref={dottedLineRef}
+          positions={dottedLinePositions}
+          className="polygon-search-line polygon-search-line--dotted"
+        />
+      )}
+      {markerPositions.map((position, i) => (
+        <IconMarker
+          key={`PolygonVertex-${i}-${position[0]}-${position[1]}`}
+          position={position}
+          icon={PolygonVertexIcon}
+          draggable={false}
+          interactive={false}
+        />
+      ))}
+    </>
+  );
+}

--- a/frontend/src/app/features/map/layers/PolygonSearchLayer.tsx
+++ b/frontend/src/app/features/map/layers/PolygonSearchLayer.tsx
@@ -11,7 +11,7 @@ import { useMapCrosshairsCursor } from '../../../hooks/useMapCrossHairCursor';
 import { CrosshairsTooltipMarker } from '../CrossHairToolTipMarker';
 import { IconMarker } from '../IconMarker';
 import { ActiveToolEnum } from '../../../constants/Constant';
-import { useMapSearchContext } from '../mapSearchQueryParamsContext/MapSearchQueryParamsContext';
+import { useMapSearchContext } from '../mapSearchContext/MapSearchContext';
 
 const PolygonVertexIcon = L.divIcon({
   html: `<div />`,

--- a/frontend/src/app/features/map/layers/RadiusSearchLayer.tsx
+++ b/frontend/src/app/features/map/layers/RadiusSearchLayer.tsx
@@ -1,7 +1,7 @@
 import { ActiveToolEnum } from '../../../constants/Constant';
 import { CircleLayer } from '../CircleLayer';
 import { Site } from '../MapView';
-import { useMapSearchContext } from '../mapSearchQueryParamsContext/MapSearchQueryParamsContext';
+import { useMapSearchContext } from '../mapSearchContext/MapSearchContext';
 
 interface RadiusSearchLayerProps {
   radius: number;

--- a/frontend/src/app/features/map/layers/RadiusSearchLayer.tsx
+++ b/frontend/src/app/features/map/layers/RadiusSearchLayer.tsx
@@ -1,21 +1,21 @@
 import { ActiveToolEnum } from '../../../constants/Constant';
 import { CircleLayer } from '../CircleLayer';
 import { Site } from '../MapView';
+import { useMapSearchContext } from '../mapSearchQueryParamsContext/MapSearchQueryParamsContext';
 
 interface RadiusSearchLayerProps {
-  activeTool: ActiveToolEnum | null;
   radius: number;
   onCrossHairClick: () => void;
   sites: Site[];
   setSites: React.Dispatch<React.SetStateAction<Site[]>> | null;
 }
 export function RadiusSearchLayer({
-  activeTool,
   radius,
   onCrossHairClick,
   sites,
   setSites,
 }: Readonly<RadiusSearchLayerProps>) {
+  const { activeTool } = useMapSearchContext();
   if (activeTool === ActiveToolEnum.radiusSearch) {
     return (
       <CircleLayer

--- a/frontend/src/app/features/map/mapSearchContext/MapSearchContext.tsx
+++ b/frontend/src/app/features/map/mapSearchContext/MapSearchContext.tsx
@@ -20,7 +20,7 @@ const acceptedParams = {
   search: StringParam,
   polygon: JsonParam,
 };
-interface MapSearchQueryParamsContextType {
+interface MapSearchContextType {
   selectedSiteId: string | null;
   searchTerm: string | null;
   setQuery: (
@@ -39,22 +39,21 @@ interface MapSearchQueryParamsContextType {
   setActiveTool: (tool: ActiveToolEnum | null) => void;
 }
 
-export const MapSearchQueryParamsContext =
-  createContext<MapSearchQueryParamsContextType>({
-    selectedSiteId: null,
-    searchTerm: null,
-    setQuery: () => {},
-    clearQuery: () => {},
-    isDrawingPolygon: false,
-    drawShapeVertices: [],
-    polygonVertices: [],
-    addDrawShapeVertex: () => {},
-    deleteLastDrawShapeVertex: () => {},
-    finishPolygonDraw: () => {},
-    deletePolygon: () => {},
-    activeTool: null,
-    setActiveTool: () => {},
-  });
+export const MapSearchContext = createContext<MapSearchContextType>({
+  selectedSiteId: null,
+  searchTerm: null,
+  setQuery: () => {},
+  clearQuery: () => {},
+  isDrawingPolygon: false,
+  drawShapeVertices: [],
+  polygonVertices: [],
+  addDrawShapeVertex: () => {},
+  deleteLastDrawShapeVertex: () => {},
+  finishPolygonDraw: () => {},
+  deletePolygon: () => {},
+  activeTool: null,
+  setActiveTool: () => {},
+});
 
 export const MapSearchQueryProvider = ({
   children,
@@ -117,7 +116,7 @@ export const MapSearchQueryProvider = ({
   const clearQuery = () => setQuery({}, 'replace');
 
   return (
-    <MapSearchQueryParamsContext.Provider
+    <MapSearchContext.Provider
       value={{
         selectedSiteId: query.site || null,
         searchTerm: query.search || null,
@@ -135,9 +134,8 @@ export const MapSearchQueryProvider = ({
       }}
     >
       {children}
-    </MapSearchQueryParamsContext.Provider>
+    </MapSearchContext.Provider>
   );
 };
 
-export const useMapSearchContext = () =>
-  useContext(MapSearchQueryParamsContext);
+export const useMapSearchContext = () => useContext(MapSearchContext);

--- a/frontend/src/app/features/map/mapSearchQueryParamsContext/MapSearchQueryParamsContext.tsx
+++ b/frontend/src/app/features/map/mapSearchQueryParamsContext/MapSearchQueryParamsContext.tsx
@@ -1,12 +1,25 @@
-import { createContext, ReactElement } from 'react';
+import { LatLngTuple } from 'leaflet';
+import {
+  createContext,
+  ReactElement,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 import {
   DecodedValueMap,
   StringParam,
   UrlUpdateType,
+  JsonParam,
   useQueryParams,
 } from 'use-query-params';
+import { ActiveToolEnum } from '../../../constants/Constant';
 
-const acceptedParams = { site: StringParam, search: StringParam };
+const acceptedParams = {
+  site: StringParam,
+  search: StringParam,
+  polygon: JsonParam,
+};
 interface MapSearchQueryParamsContextType {
   selectedSiteId: string | null;
   searchTerm: string | null;
@@ -15,6 +28,15 @@ interface MapSearchQueryParamsContextType {
     updateType?: UrlUpdateType,
   ) => void;
   clearQuery: () => void;
+  isDrawingPolygon: boolean;
+  drawShapeVertices: LatLngTuple[];
+  polygonVertices: LatLngTuple[];
+  addDrawShapeVertex: (coordinates: LatLngTuple) => void;
+  deleteLastDrawShapeVertex: () => void;
+  finishPolygonDraw: () => void;
+  deletePolygon: () => void;
+  activeTool: ActiveToolEnum | null;
+  setActiveTool: (tool: ActiveToolEnum | null) => void;
 }
 
 export const MapSearchQueryParamsContext =
@@ -23,6 +45,15 @@ export const MapSearchQueryParamsContext =
     searchTerm: null,
     setQuery: () => {},
     clearQuery: () => {},
+    isDrawingPolygon: false,
+    drawShapeVertices: [],
+    polygonVertices: [],
+    addDrawShapeVertex: () => {},
+    deleteLastDrawShapeVertex: () => {},
+    finishPolygonDraw: () => {},
+    deletePolygon: () => {},
+    activeTool: null,
+    setActiveTool: () => {},
   });
 
 export const MapSearchQueryProvider = ({
@@ -31,6 +62,57 @@ export const MapSearchQueryProvider = ({
   children: ReactElement;
 }) => {
   const [query, setQuery] = useQueryParams(acceptedParams);
+  const [activeTool, setActiveToolState] = useState<ActiveToolEnum | null>(
+    null,
+  );
+
+  const [isDrawingPolygon, setIsDrawingPolygon] = useState(false);
+  const [drawShapeVertices, setDrawShapeVertices] = useState<LatLngTuple[]>([]);
+
+  useEffect(() => {
+    const { polygon } = query;
+    if (polygon && Array.isArray(polygon) && polygon.length > 2) {
+      setActiveToolState(ActiveToolEnum.polygonSearch);
+    }
+    // This should only run on the initial load to read the query params
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const addDrawShapeVertex = (coordinates: LatLngTuple) => {
+    setDrawShapeVertices((prev) => [...prev, coordinates]);
+  };
+
+  const deleteLastDrawShapeVertex = () => {
+    setDrawShapeVertices((prev) => prev.slice(0, -1));
+  };
+
+  const deletePolygon = () => {
+    clearQuery();
+    setDrawShapeVertices([]);
+    setIsDrawingPolygon(true);
+  };
+
+  const finishPolygonDraw = () => {
+    setIsDrawingPolygon(false);
+    if (drawShapeVertices.length > 2) {
+      setQuery({ polygon: drawShapeVertices }, 'replace');
+    }
+  };
+
+  const setActiveTool = (tool: ActiveToolEnum | null) => {
+    const nextTool = activeTool === tool ? null : tool;
+    setActiveToolState(nextTool);
+
+    if (nextTool === null) {
+      clearQuery();
+      setDrawShapeVertices([]);
+      setIsDrawingPolygon(false);
+    }
+
+    if (nextTool === ActiveToolEnum.polygonSearch) {
+      setIsDrawingPolygon(true);
+    }
+  };
 
   const clearQuery = () => setQuery({}, 'replace');
 
@@ -41,9 +123,21 @@ export const MapSearchQueryProvider = ({
         searchTerm: query.search || null,
         setQuery,
         clearQuery,
+        isDrawingPolygon,
+        drawShapeVertices: drawShapeVertices,
+        polygonVertices: (query.polygon || []) as LatLngTuple[],
+        addDrawShapeVertex,
+        deleteLastDrawShapeVertex,
+        finishPolygonDraw,
+        deletePolygon,
+        activeTool,
+        setActiveTool,
       }}
     >
       {children}
     </MapSearchQueryParamsContext.Provider>
   );
 };
+
+export const useMapSearchContext = () =>
+  useContext(MapSearchQueryParamsContext);

--- a/frontend/src/app/features/map/search/PolygonSearch.tsx
+++ b/frontend/src/app/features/map/search/PolygonSearch.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export function PolygonSearch() {
-  return <div>Polygon Search</div>;
-}

--- a/frontend/src/app/features/map/search/PolygonSearchControls.tsx
+++ b/frontend/src/app/features/map/search/PolygonSearchControls.tsx
@@ -4,7 +4,7 @@ import {
   TrashCanIcon,
   XmarkIcon,
 } from '../../../components/common/icon';
-import { useMapSearchContext } from '../mapSearchQueryParamsContext/MapSearchQueryParamsContext';
+import { useMapSearchContext } from '../mapSearchContext/MapSearchContext';
 
 export const PolygonSearchControls = () => {
   const {

--- a/frontend/src/app/features/map/search/PolygonSearchControls.tsx
+++ b/frontend/src/app/features/map/search/PolygonSearchControls.tsx
@@ -1,0 +1,49 @@
+import { Button } from '../../../components/button/Button';
+import {
+  TickIcon,
+  TrashCanIcon,
+  XmarkIcon,
+} from '../../../components/common/icon';
+import { useMapSearchContext } from '../mapSearchQueryParamsContext/MapSearchQueryParamsContext';
+
+export const PolygonSearchControls = () => {
+  const {
+    deleteLastDrawShapeVertex,
+    finishPolygonDraw,
+    setActiveTool,
+    isDrawingPolygon,
+    drawShapeVertices,
+    deletePolygon,
+  } = useMapSearchContext();
+  return (
+    <div className="d-flex gap-2">
+      <Button onClick={() => setActiveTool(null)}>
+        <XmarkIcon />
+        Cancel
+      </Button>
+      {isDrawingPolygon && (
+        <Button
+          onClick={deleteLastDrawShapeVertex}
+          disabled={drawShapeVertices.length === 0}
+        >
+          <TrashCanIcon />
+          Delete Last Point
+        </Button>
+      )}
+      {!isDrawingPolygon && (
+        <Button onClick={deletePolygon}>
+          <TrashCanIcon />
+          Delete Shape
+        </Button>
+      )}
+
+      <Button
+        onClick={finishPolygonDraw}
+        disabled={!isDrawingPolygon || drawShapeVertices.length < 3}
+      >
+        <TickIcon />
+        Finish Shape
+      </Button>
+    </div>
+  );
+};

--- a/frontend/src/app/features/map/search/RadiusSearch.tsx
+++ b/frontend/src/app/features/map/search/RadiusSearch.tsx
@@ -8,13 +8,13 @@ import { formatDistance } from '../../../helpers/utility';
 import { useState } from 'react';
 import { Button } from '../../../components/button/Button';
 import { Site } from '../MapView';
+import { useMapSearchContext } from '../mapSearchQueryParamsContext/MapSearchQueryParamsContext';
 
 interface RadiusSearchProps {
   radius: number;
   setRadius: React.Dispatch<React.SetStateAction<number>>;
   isSmall?: boolean;
   className?: string;
-  setActiveTool?: React.Dispatch<React.SetStateAction<ActiveToolEnum | null>>;
 }
 
 export function RadiusSearch({
@@ -22,13 +22,13 @@ export function RadiusSearch({
   setRadius,
   isSmall = false,
   className,
-  setActiveTool,
 }: Readonly<RadiusSearchProps>) {
+  const { setActiveTool } = useMapSearchContext();
   const [isVisible, setIsVisible] = useState(true);
 
   const onCancel = () => {
     setIsVisible(false);
-    setActiveTool && setActiveTool(null);
+    setActiveTool(null);
     setRadius(MIN_CIRCLE_RADIUS);
   };
 

--- a/frontend/src/app/features/map/search/RadiusSearch.tsx
+++ b/frontend/src/app/features/map/search/RadiusSearch.tsx
@@ -8,7 +8,7 @@ import { formatDistance } from '../../../helpers/utility';
 import { useState } from 'react';
 import { Button } from '../../../components/button/Button';
 import { Site } from '../MapView';
-import { useMapSearchContext } from '../mapSearchQueryParamsContext/MapSearchQueryParamsContext';
+import { useMapSearchContext } from '../mapSearchContext/MapSearchContext';
 
 interface RadiusSearchProps {
   radius: number;

--- a/frontend/src/app/features/map/siteDrawer/MapSearchDrawer.tsx
+++ b/frontend/src/app/features/map/siteDrawer/MapSearchDrawer.tsx
@@ -2,7 +2,7 @@ import { Map } from 'leaflet';
 import { Drawer } from '../../../components/drawer/Drawer';
 import { Site } from '../MapView';
 import { FC, RefObject } from 'react';
-import { useMapSearchContext } from '../mapSearchQueryParamsContext/MapSearchQueryParamsContext';
+import { useMapSearchContext } from '../mapSearchContext/MapSearchContext';
 import { SearchResultsDrawerContent } from './SearchResultsDrawerContent';
 import { SiteDetailsDrawerContent } from './SiteDetailsDrawerContent';
 import { ActiveToolEnum } from '../../../constants/Constant';

--- a/frontend/src/app/features/map/siteDrawer/MapSearchDrawer.tsx
+++ b/frontend/src/app/features/map/siteDrawer/MapSearchDrawer.tsx
@@ -1,8 +1,8 @@
 import { Map } from 'leaflet';
 import { Drawer } from '../../../components/drawer/Drawer';
 import { Site } from '../MapView';
-import { FC, RefObject, useContext } from 'react';
-import { MapSearchQueryParamsContext } from '../mapSearchQueryParamsContext/MapSearchQueryParamsContext';
+import { FC, RefObject } from 'react';
+import { useMapSearchContext } from '../mapSearchQueryParamsContext/MapSearchQueryParamsContext';
 import { SearchResultsDrawerContent } from './SearchResultsDrawerContent';
 import { SiteDetailsDrawerContent } from './SiteDetailsDrawerContent';
 import { ActiveToolEnum } from '../../../constants/Constant';
@@ -21,9 +21,7 @@ export const MapSearchDrawer: FC<MapSearchDrawerProps> = ({
   activeTool,
   radius,
 }) => {
-  const { selectedSiteId, searchTerm, clearQuery } = useContext(
-    MapSearchQueryParamsContext,
-  );
+  const { selectedSiteId, searchTerm, clearQuery } = useMapSearchContext();
 
   let drawerTitle = '';
   if (searchTerm) drawerTitle = 'Search Results';

--- a/frontend/src/app/features/map/siteDrawer/SiteDetailsDrawerContent.tsx
+++ b/frontend/src/app/features/map/siteDrawer/SiteDetailsDrawerContent.tsx
@@ -16,7 +16,7 @@ import './MapSearchDrawer.css';
 import { Button } from '../../../components/button/Button';
 import AddToFolio from '../../folios/AddToFolio';
 import { getZoom, MAP_FLY_OPTIONS } from '../mapOptions';
-import { useMapSearchContext } from '../mapSearchQueryParamsContext/MapSearchQueryParamsContext';
+import { useMapSearchContext } from '../mapSearchContext/MapSearchContext';
 import { AppDispatch } from '../../../Store';
 import { fetchCartItems } from '../../cart/CartSlice';
 import { notifyError, notifySuccess } from '../../../components/alert/Alert';

--- a/frontend/src/app/features/map/siteDrawer/SiteDetailsDrawerContent.tsx
+++ b/frontend/src/app/features/map/siteDrawer/SiteDetailsDrawerContent.tsx
@@ -1,4 +1,4 @@
-import { FC, RefObject, useContext } from 'react';
+import { FC, RefObject } from 'react';
 import { Link } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { Map } from 'leaflet';
@@ -16,7 +16,7 @@ import './MapSearchDrawer.css';
 import { Button } from '../../../components/button/Button';
 import AddToFolio from '../../folios/AddToFolio';
 import { getZoom, MAP_FLY_OPTIONS } from '../mapOptions';
-import { MapSearchQueryParamsContext } from '../mapSearchQueryParamsContext/MapSearchQueryParamsContext';
+import { useMapSearchContext } from '../mapSearchQueryParamsContext/MapSearchQueryParamsContext';
 import { AppDispatch } from '../../../Store';
 import { fetchCartItems } from '../../cart/CartSlice';
 import { notifyError, notifySuccess } from '../../../components/alert/Alert';
@@ -62,7 +62,7 @@ interface SiteDetailsDrawerContentProps {
 export const SiteDetailsDrawerContent: FC<SiteDetailsDrawerContentProps> = ({
   mapRef,
 }) => {
-  const { selectedSiteId } = useContext(MapSearchQueryParamsContext);
+  const { selectedSiteId } = useMapSearchContext();
 
   const dispatch = useDispatch<AppDispatch>();
 

--- a/frontend/src/app/features/map/siteMarkers/SiteMarkers.tsx
+++ b/frontend/src/app/features/map/siteMarkers/SiteMarkers.tsx
@@ -4,7 +4,7 @@ import { SiteMarker } from './SiteMarker';
 import { useMap } from 'react-leaflet';
 import { getZoom, MAP_FLY_OPTIONS } from '../mapOptions';
 import { Site } from '../MapView';
-import { useMapSearchContext } from '../mapSearchQueryParamsContext/MapSearchQueryParamsContext';
+import { useMapSearchContext } from '../mapSearchContext/MapSearchContext';
 
 interface SiteMarkersProps {
   sites: Site[];

--- a/frontend/src/app/features/map/siteMarkers/SiteMarkers.tsx
+++ b/frontend/src/app/features/map/siteMarkers/SiteMarkers.tsx
@@ -1,10 +1,10 @@
-import { FC, useCallback, useContext, useMemo } from 'react';
+import { FC, useCallback, useMemo } from 'react';
 import MarkerClusterGroup from 'react-leaflet-cluster';
 import { SiteMarker } from './SiteMarker';
 import { useMap } from 'react-leaflet';
 import { getZoom, MAP_FLY_OPTIONS } from '../mapOptions';
 import { Site } from '../MapView';
-import { MapSearchQueryParamsContext } from '../mapSearchQueryParamsContext/MapSearchQueryParamsContext';
+import { useMapSearchContext } from '../mapSearchQueryParamsContext/MapSearchQueryParamsContext';
 
 interface SiteMarkersProps {
   sites: Site[];
@@ -13,7 +13,7 @@ interface SiteMarkersProps {
 export const SiteMarkers: FC<SiteMarkersProps> = ({ sites }) => {
   const map = useMap();
 
-  const { selectedSiteId, setQuery } = useContext(MapSearchQueryParamsContext);
+  const { selectedSiteId, setQuery } = useMapSearchContext();
 
   const moveToSiteLocation = useCallback(
     (site: Site) => {

--- a/frontend/src/graphql/generated.ts
+++ b/frontend/src/graphql/generated.ts
@@ -17,6 +17,7 @@ export type Scalars = {
   Float: { input: number; output: number; }
   DateTime: { input: any; output: any; }
   JSON: { input: any; output: any; }
+  LatLngTuple: { input: any; output: any; }
   _Any: { input: any; output: any; }
   federation__FieldSet: { input: any; output: any; }
   link__Import: { input: any; output: any; }
@@ -857,6 +858,7 @@ export type QueryGetSnapshotsByUserIdArgs = {
 
 
 export type QueryMapSearchArgs = {
+  polygon?: InputMaybe<Array<Scalars['LatLngTuple']['input']>>;
   searchParam?: InputMaybe<Scalars['String']['input']>;
 };
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This PR:
- Adds controls for drawing polygons on the map 
- Renames `MapSearchQueryParamsContext` to `MapSearchContext` and expands its responsibilities to handle search-related state management. Code related to text and radius searches will be moved there shortly.

This is a front-end only change, backend changes and data fetching will be added in the upcoming PR

## Demo
<img width="1451" alt="Screenshot 2025-01-16 at 8 37 52 PM" src="https://github.com/user-attachments/assets/0abc8323-f2cc-4f88-bf78-4e0cb97a699b" />

<img width="1451" alt="Screenshot 2025-01-16 at 8 37 40 PM" src="https://github.com/user-attachments/assets/5ceb4e77-379a-4551-8abd-301d9398343f" />


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-264-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-264-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)