### PR TITLE
fix: SRS-766: refresh access token if expired

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -54,7 +54,7 @@ jobs:
           dir: ${{ matrix.dir }}
           node_version: "22"
           sonar_args: >
-             -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts,**/migrations/**, **/*.test.tsx, **/*.test.ts
+             -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts,**/migrations/**, **/*test.tsx, **/*test.ts
              -Dsonar.organization=bcgov-sonarcloud
              -Dsonar.projectKey=bcgov-sonarcloud_nr-site-registry-${{ matrix.dir }}
              -Dsonar.sources=src

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -54,7 +54,7 @@ jobs:
           dir: ${{ matrix.dir }}
           node_version: "22"
           sonar_args: >
-             -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts,**/migrations/**, **/*test.tsx, **/*test.ts
+             -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts,**/migrations/**,**/*test.tsx,**/*test.ts
              -Dsonar.organization=bcgov-sonarcloud
              -Dsonar.projectKey=bcgov-sonarcloud_nr-site-registry-${{ matrix.dir }}
              -Dsonar.sources=src

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -54,7 +54,7 @@ jobs:
           dir: ${{ matrix.dir }}
           node_version: "22"
           sonar_args: >
-             -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts,**/migrations/**
+             -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts,**/migrations/**, **/*.test.tsx, **/*.test.ts
              -Dsonar.organization=bcgov-sonarcloud
              -Dsonar.projectKey=bcgov-sonarcloud_nr-site-registry-${{ matrix.dir }}
              -Dsonar.sources=src

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -33,7 +33,7 @@ test('Renders Intro', () => {
 });
 
 describe('Access token refresh', () => {
-  it('should call refresh token methods if access token is expired', async () => {
+  it('should call refresh token methods if access token is expired and sings the user out if refresh fails', async () => {
     const userMock = { expired: true };
     const addAccessTokenExpiringMock = jest.fn();
     const signinSilentMock = jest.fn(() => Promise.resolve(null));
@@ -62,6 +62,31 @@ describe('Access token refresh', () => {
 
     await expect(signinSilentMock).toHaveBeenCalled();
     expect(signoutSilentMock).toHaveBeenCalled();
+  });
+
+  it('should call refresh token methods if access token is expired does not sign out the user if refresh is successful', async () => {
+    const userMock = { expired: true };
+    const addAccessTokenExpiringMock = jest.fn();
+    const signinSilentMock = jest.fn(() =>
+      Promise.resolve({ someResolvedValue: 'that is not null' }),
+    );
+    const signoutSilentMock = jest.fn();
+
+    (useAuth as jest.Mock).mockReturnValue({
+      signinSilent: signinSilentMock,
+      signoutSilent: signoutSilentMock,
+      events: { addAccessTokenExpiring: addAccessTokenExpiringMock },
+      user: userMock,
+    });
+
+    render(
+      <Provider store={store}>
+        <RouterProvider router={router} />
+      </Provider>,
+    );
+
+    await expect(signinSilentMock).toHaveBeenCalled();
+    expect(signoutSilentMock).not.toHaveBeenCalled();
   });
 
   it('should not call refresh token methods if access token valid', async () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -4,6 +4,7 @@ import { Provider } from 'react-redux';
 import { useAuth } from 'react-oidc-context';
 import { store } from './app/Store';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 jest.mock('react-oidc-context', () => ({
   useAuth: jest.fn(),
@@ -17,7 +18,12 @@ const router = createBrowserRouter([
 ]);
 
 test('Renders Intro', () => {
-  (useAuth as jest.Mock).mockReturnValue({ isAuthenticated: false });
+  (useAuth as jest.Mock).mockReturnValue({
+    isAuthenticated: false,
+    events: {
+      addAccessTokenExpiring: () => {},
+    },
+  });
   render(
     <Provider store={store}>
       <RouterProvider router={router} />
@@ -25,4 +31,56 @@ test('Renders Intro', () => {
   );
   const siteName = screen.getByText(/SITE/i);
   expect(siteName).toBeInTheDocument();
+});
+
+describe('Access token refresh', () => {
+  it('should call refresh token methods if access token is expired', async () => {
+    const userMock = { expired: true };
+    const addAccessTokenExpiringMock = jest.fn();
+    const signinSilentMock = jest.fn(() => Promise.resolve(null));
+    const signoutSilentMock = jest.fn();
+
+    (useAuth as jest.Mock).mockReturnValue({
+      signinSilent: signinSilentMock,
+      signoutSilent: signoutSilentMock,
+      events: { addAccessTokenExpiring: addAccessTokenExpiringMock },
+      user: userMock,
+    });
+
+    render(
+      <Provider store={store}>
+        <RouterProvider router={router} />
+      </Provider>,
+    );
+
+    expect(addAccessTokenExpiringMock).toHaveBeenCalled();
+    await expect(signinSilentMock).toHaveBeenCalled();
+    expect(signoutSilentMock).toHaveBeenCalled();
+  });
+
+  it('should not call refresh token methods if access token valid', async () => {
+    const userMock = { expired: false };
+    const addAccessTokenExpiringMock = jest.fn();
+    const signinSilentMock = jest.fn(() => Promise.resolve(null));
+    const signoutSilentMock = jest.fn();
+
+    (useAuth as jest.Mock).mockReturnValue({
+      isAuthenticated: false,
+      signinSilent: signinSilentMock,
+      signoutSilent: signoutSilentMock,
+      events: { addAccessTokenExpiring: addAccessTokenExpiringMock },
+      user: userMock,
+    });
+
+    render(
+      <Provider store={store}>
+        <RouterProvider router={router} />
+      </Provider>,
+    );
+
+    expect(addAccessTokenExpiringMock).toHaveBeenCalled();
+
+    await expect(signinSilentMock).not.toHaveBeenCalled();
+    expect(signoutSilentMock).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import App from './App';
 import { Provider } from 'react-redux';
 import { useAuth } from 'react-oidc-context';
@@ -53,6 +53,13 @@ describe('Access token refresh', () => {
     );
 
     expect(addAccessTokenExpiringMock).toHaveBeenCalled();
+
+    // Simulate the token expiring event
+    const callback = addAccessTokenExpiringMock.mock.calls[0][0];
+    await act(async () => {
+      callback();
+    });
+
     await expect(signinSilentMock).toHaveBeenCalled();
     expect(signoutSilentMock).toHaveBeenCalled();
   });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -33,7 +33,7 @@ test('Renders Intro', () => {
 });
 
 describe('Access token refresh', () => {
-  it('should call refresh token methods if access token is expired and sings the user out if refresh fails', async () => {
+  it('should call refresh token methods if access token is expired and signs the user out if refresh fails', async () => {
     const userMock = { expired: true };
     const addAccessTokenExpiringMock = jest.fn();
     const signinSilentMock = jest.fn(() => Promise.resolve(null));

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -4,7 +4,6 @@ import { Provider } from 'react-redux';
 import { useAuth } from 'react-oidc-context';
 import { store } from './app/Store';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import { useLocation } from 'react-router-dom';
 
 jest.mock('react-oidc-context', () => ({
   useAuth: jest.fn(),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+import { useAuth } from 'react-oidc-context';
 import './App.css';
 import Header from './app/components/navigation/Header';
 import { Outlet } from 'react-router-dom';
@@ -8,6 +10,19 @@ import SideBar from './app/components/navigation/SideBar';
 import '@bcgov/bc-sans/css/BCSans.css';
 
 function App() {
+  const { isAuthenticated, signinSilent, events, user } = useAuth();
+
+  useEffect(() => {
+    if (user?.expired) {
+      // Access token expired, trying to refresh
+      signinSilent();
+    }
+    // the `return` is important - addAccessTokenExpiring() returns a cleanup function
+    return events.addAccessTokenExpiring(() => {
+      signinSilent();
+    });
+  }, [events, signinSilent, isAuthenticated, user]);
+
   return (
     <div className="container-fluid p-0">
       <Header />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useAuth } from 'react-oidc-context';
 import './App.css';
 import Header from './app/components/navigation/Header';
@@ -10,18 +10,28 @@ import SideBar from './app/components/navigation/SideBar';
 import '@bcgov/bc-sans/css/BCSans.css';
 
 function App() {
-  const { isAuthenticated, signinSilent, events, user } = useAuth();
+  const { isAuthenticated, signinSilent, events, user, signoutSilent } =
+    useAuth();
+
+  const tryTokenRefresh = useCallback(() => {
+    signinSilent().then((data) => {
+      // Refresh failed, this usually means that refresh token is invalid or expired.
+      // Sign out the user and clear the token data in this case.
+      if (data === null) {
+        signoutSilent();
+      }
+    });
+  }, [signinSilent, signoutSilent]);
 
   useEffect(() => {
     if (user?.expired) {
-      // Access token expired, trying to refresh
-      signinSilent();
+      tryTokenRefresh();
     }
     // the `return` is important - addAccessTokenExpiring() returns a cleanup function
     return events.addAccessTokenExpiring(() => {
-      signinSilent();
+      tryTokenRefresh();
     });
-  }, [events, signinSilent, isAuthenticated, user]);
+  }, [events, isAuthenticated, user, tryTokenRefresh]);
 
   return (
     <div className="container-fluid p-0">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Attempt access token refresh in two cases:
- When token is already expired on the initial load
- When token expires at some point when using the app

With this you won't need to sing out and back in to manually fix the token expiration quite as often, unless the refresh token is also expired.

Fixes [SRS-766](https://env-epd.atlassian.net/browse/SRS-766)

# How Has This Been Tested?

You can verify the changes by:
- Waiting for the token to expire (10 minutes)
- Manually changing the `expires_at` value in session storage and then refreshing the page
- Manually changing the `expires_at` value in session storage + setting the refresh token to something invalid. Refresh the page - this should log you out entirely.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-274-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-274-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)