### PR TITLE
fix: SRS-682 cannot save site details more than once.

### DIFF
--- a/frontend/src/app/features/details/SaveSiteDetailsSlice.test.ts
+++ b/frontend/src/app/features/details/SaveSiteDetailsSlice.test.ts
@@ -2,68 +2,70 @@ import { RequestStatus } from '../../helpers/requests/status';
 import reducer, { resetSaveSiteDetails } from './SaveSiteDetailsSlice';
 
 describe('siteDetailsSlice', () => {
-  it('nullifies data', () => {
-    const initialState = {
-      saveRequestStatus: RequestStatus.loading,
-      notationData: ['notationData'],
-      siteParticipantData: ['siteParticipantData'],
-      documentsData: ['documentsData'],
-      landHistoriesData: ['landHistoriesData'],
-      parcelDescriptionsData: ['parcelDescriptionsData'],
-      profilesData: ['profilesData'],
-      siteAssociationsData: ['siteAssociationsData'],
-      siteId: '123',
-      sitesSummary: ['sitesSummary'],
-    };
+  describe('resetSaveSiteDetails', () => {
+    it('nullifies data', () => {
+      const initialState = {
+        saveRequestStatus: RequestStatus.loading,
+        notationData: ['notationData'],
+        siteParticipantData: ['siteParticipantData'],
+        documentsData: ['documentsData'],
+        landHistoriesData: ['landHistoriesData'],
+        parcelDescriptionsData: ['parcelDescriptionsData'],
+        profilesData: ['profilesData'],
+        siteAssociationsData: ['siteAssociationsData'],
+        siteId: '123',
+        sitesSummary: ['sitesSummary'],
+      };
 
-    const result = reducer(initialState, resetSaveSiteDetails(null));
-    expect(result).toEqual(
-      expect.objectContaining({
-        notationData: null,
-        siteParticipantData: null,
-        documentsData: null,
-        landHistoriesData: null,
-        parcelDescriptionsData: null,
-        profilesData: null,
-        siteAssociationsData: null,
-        sitesSummary: null,
-      }),
-    );
-  });
+      const result = reducer(initialState, resetSaveSiteDetails(null));
+      expect(result).toEqual(
+        expect.objectContaining({
+          notationData: null,
+          siteParticipantData: null,
+          documentsData: null,
+          landHistoriesData: null,
+          parcelDescriptionsData: null,
+          profilesData: null,
+          siteAssociationsData: null,
+          sitesSummary: null,
+        }),
+      );
+    });
 
-  it('sets saveRequestStatus to idle', () => {
-    const initialState = {
-      saveRequestStatus: RequestStatus.loading,
-      notationData: ['notationData'],
-      siteParticipantData: ['siteParticipantData'],
-      documentsData: ['documentsData'],
-      landHistoriesData: ['landHistoriesData'],
-      parcelDescriptionsData: ['parcelDescriptionsData'],
-      profilesData: ['profilesData'],
-      siteAssociationsData: ['siteAssociationsData'],
-      siteId: '123',
-      sitesSummary: ['sitesSummary'],
-    };
+    it('sets saveRequestStatus to idle', () => {
+      const initialState = {
+        saveRequestStatus: RequestStatus.loading,
+        notationData: ['notationData'],
+        siteParticipantData: ['siteParticipantData'],
+        documentsData: ['documentsData'],
+        landHistoriesData: ['landHistoriesData'],
+        parcelDescriptionsData: ['parcelDescriptionsData'],
+        profilesData: ['profilesData'],
+        siteAssociationsData: ['siteAssociationsData'],
+        siteId: '123',
+        sitesSummary: ['sitesSummary'],
+      };
 
-    const result = reducer(initialState, resetSaveSiteDetails(null));
-    expect(result.saveRequestStatus).toEqual(RequestStatus.idle);
-  });
+      const result = reducer(initialState, resetSaveSiteDetails(null));
+      expect(result.saveRequestStatus).toEqual(RequestStatus.idle);
+    });
 
-  it('maintains siteId', () => {
-    const initialState = {
-      saveRequestStatus: RequestStatus.loading,
-      notationData: ['notationData'],
-      siteParticipantData: ['siteParticipantData'],
-      documentsData: ['documentsData'],
-      landHistoriesData: ['landHistoriesData'],
-      parcelDescriptionsData: ['parcelDescriptionsData'],
-      profilesData: ['profilesData'],
-      siteAssociationsData: ['siteAssociationsData'],
-      siteId: '123',
-      sitesSummary: ['sitesSummary'],
-    };
+    it('maintains siteId', () => {
+      const initialState = {
+        saveRequestStatus: RequestStatus.loading,
+        notationData: ['notationData'],
+        siteParticipantData: ['siteParticipantData'],
+        documentsData: ['documentsData'],
+        landHistoriesData: ['landHistoriesData'],
+        parcelDescriptionsData: ['parcelDescriptionsData'],
+        profilesData: ['profilesData'],
+        siteAssociationsData: ['siteAssociationsData'],
+        siteId: '123',
+        sitesSummary: ['sitesSummary'],
+      };
 
-    const result = reducer(initialState, resetSaveSiteDetails(null));
-    expect(result.siteId).toEqual('123');
+      const result = reducer(initialState, resetSaveSiteDetails(null));
+      expect(result.siteId).toEqual('123');
+    });
   });
 });

--- a/frontend/src/app/features/details/SaveSiteDetailsSlice.test.ts
+++ b/frontend/src/app/features/details/SaveSiteDetailsSlice.test.ts
@@ -1,0 +1,69 @@
+import { RequestStatus } from '../../helpers/requests/status';
+import reducer, { resetSaveSiteDetails } from './SaveSiteDetailsSlice';
+
+describe('siteDetailsSlice', () => {
+  it('nullifies data', () => {
+    const initialState = {
+      saveRequestStatus: RequestStatus.loading,
+      notationData: ['notationData'],
+      siteParticipantData: ['siteParticipantData'],
+      documentsData: ['documentsData'],
+      landHistoriesData: ['landHistoriesData'],
+      parcelDescriptionsData: ['parcelDescriptionsData'],
+      profilesData: ['profilesData'],
+      siteAssociationsData: ['siteAssociationsData'],
+      siteId: '123',
+      sitesSummary: ['sitesSummary'],
+    };
+
+    const result = reducer(initialState, resetSaveSiteDetails(null));
+    expect(result).toEqual(
+      expect.objectContaining({
+        notationData: null,
+        siteParticipantData: null,
+        documentsData: null,
+        landHistoriesData: null,
+        parcelDescriptionsData: null,
+        profilesData: null,
+        siteAssociationsData: null,
+        sitesSummary: null,
+      }),
+    );
+  });
+
+  it('sets saveRequestStatus to idle', () => {
+    const initialState = {
+      saveRequestStatus: RequestStatus.loading,
+      notationData: ['notationData'],
+      siteParticipantData: ['siteParticipantData'],
+      documentsData: ['documentsData'],
+      landHistoriesData: ['landHistoriesData'],
+      parcelDescriptionsData: ['parcelDescriptionsData'],
+      profilesData: ['profilesData'],
+      siteAssociationsData: ['siteAssociationsData'],
+      siteId: '123',
+      sitesSummary: ['sitesSummary'],
+    };
+
+    const result = reducer(initialState, resetSaveSiteDetails(null));
+    expect(result.saveRequestStatus).toEqual(RequestStatus.idle);
+  });
+
+  it('maintains siteId', () => {
+    const initialState = {
+      saveRequestStatus: RequestStatus.loading,
+      notationData: ['notationData'],
+      siteParticipantData: ['siteParticipantData'],
+      documentsData: ['documentsData'],
+      landHistoriesData: ['landHistoriesData'],
+      parcelDescriptionsData: ['parcelDescriptionsData'],
+      profilesData: ['profilesData'],
+      siteAssociationsData: ['siteAssociationsData'],
+      siteId: '123',
+      sitesSummary: ['sitesSummary'],
+    };
+
+    const result = reducer(initialState, resetSaveSiteDetails(null));
+    expect(result.siteId).toEqual('123');
+  });
+});

--- a/frontend/src/app/features/details/SaveSiteDetailsSlice.ts
+++ b/frontend/src/app/features/details/SaveSiteDetailsSlice.ts
@@ -52,7 +52,7 @@ const siteDetailsSlice = createSlice({
       newState.parcelDescriptionsData = null;
       newState.profilesData = null;
       newState.siteAssociationsData = null;
-      newState.siteId = '';
+      newState.siteId = state.siteId;
       newState.sitesSummary = null;
       return newState;
     },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This fix prevents the `resetSaveSiteDetails` reducer from reseting the site id. Resetting the ID will cause subsequent calls to save site details to fail because it will not be included in the graphql query. I have verified that the site ID is correctly set when browsing to a new site, and I wasn't able to find any unintentional side effects.

Fixes # SRS-682

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit Tests
- [x] Tested making multiple subsequent save requests
- [x] Tested navigating to a new site and making multiple subsequent save requests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-278-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-278-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)