### PR TITLE
fix: SRS-850 hoist parcel descriptions editing state into redux

### DIFF
--- a/frontend/src/app/features/details/parcelDescriptions/parcelDescriptions.test.tsx
+++ b/frontend/src/app/features/details/parcelDescriptions/parcelDescriptions.test.tsx
@@ -11,8 +11,6 @@ import thunk from 'redux-thunk';
 import { initialParcelDescriptionsState } from './parcelDescriptionsSlice';
 import { SiteDetailsMode } from '../dto/SiteDetailsMode';
 import { ParcelDescriptionType } from './parcelDescriptionsConfig';
-import { IChangeType } from '../../../components/common/IChangeType';
-import { act } from '@testing-library/react';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -123,6 +121,61 @@ describe('Parcel Descriptions Component', () => {
         sortBy: 'id',
         sortByDir: 'ASC',
         sortByInputValue: {},
+        updatedRows: [],
+        mergedRows: [
+          {
+            id: '11',
+            descriptionType: ParcelDescriptionType.CrownLandPIN,
+            idPinNumber: '123456789',
+            dateNoted: '2023-06-15T00:00:00',
+            landDescription: 'first land description',
+            srAction: '',
+            userAction: '',
+            srValue: false,
+          },
+          {
+            id: '12',
+            descriptionType: ParcelDescriptionType.CrownLandPIN,
+            idPinNumber: '987654321',
+            dateNoted: '2023-06-16T00:00:00',
+            landDescription: 'second land description',
+            srAction: '',
+            userAction: '',
+            srValue: false,
+          },
+          {
+            id: '13',
+            descriptionType: ParcelDescriptionType.CrownLandFileNumber,
+            idPinNumber: 'ax12345',
+            dateNoted: '2023-06-17T00:00:00',
+            landDescription: 'third land description',
+            srAction: '',
+            userAction: '',
+            srValue: false,
+          },
+          {
+            id: '14',
+            descriptionType: ParcelDescriptionType.ParcelID,
+            idPinNumber: '789012345',
+            dateNoted: '2023-06-18T00:00:00',
+            landDescription: 'fourth land description',
+            srAction: '',
+            userAction: '',
+            srValue: false,
+          },
+          {
+            id: '15',
+            descriptionType: ParcelDescriptionType.CrownLandPIN,
+            idPinNumber: '4321098765',
+            dateNoted: '2023-06-19T00:00:00',
+            landDescription: 'fifth land description',
+            srAction: '',
+            userAction: '',
+            srValue: false,
+          },
+        ],
+        addedRows: [],
+        deletedRows: [],
       },
     };
     store = mockStore(testState);
@@ -625,46 +678,6 @@ describe('Parcel Descriptions Component', () => {
     });
 
     describe('when editing the description type', () => {
-      it('sets up the parcel description for saving, and tracks the action', async () => {
-        render(
-          <Provider store={store}>
-            <ParcelDescriptions />
-          </Provider>,
-        );
-
-        // The first row on the table.
-        const descriptionTypeInputs =
-          await screen.findAllByDisplayValue('Crown Land PIN');
-
-        fireEvent.change(descriptionTypeInputs[0], {
-          target: { value: 'Crown Land File Number' },
-        });
-
-        jest.runAllTimers();
-
-        let actions = store.getActions();
-        expect(actions).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              type: 'siteDetails/setupParcelDescriptionsDataForSaving',
-              payload: expect.arrayContaining([
-                expect.objectContaining({
-                  descriptionType: 'Crown Land File Number',
-                  apiAction: 'updated',
-                }),
-              ]),
-            }),
-            expect.objectContaining({
-              type: 'sites/trackChanges',
-              payload: expect.objectContaining({
-                changeType: IChangeType.Modified,
-                label: 'Parcel Descriptions: 11',
-              }),
-            }),
-          ]),
-        );
-      });
-
       describe('when selecting Crown Land File Number', () => {
         it('truncates the value in id/pin/number', async () => {
           render(
@@ -680,56 +693,24 @@ describe('Parcel Descriptions Component', () => {
             target: { value: 'Crown Land File Number' },
           });
 
-          // the first id/pin/number should have been truncated from 123456789 to 1234567.
-          expect(
-            await screen.findByDisplayValue('1234567'),
-          ).toBeInTheDocument();
-          expect(
-            screen.queryByDisplayValue('123456789'),
-          ).not.toBeInTheDocument();
+          let actions = store.getActions();
+          expect(actions).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                type: 'parcelDescriptions/updateUpdatedRows',
+                payload: expect.arrayContaining([
+                  expect.objectContaining({
+                    idPinNumber: '1234567',
+                  }),
+                ]),
+              }),
+            ]),
+          );
         });
       });
     });
 
     describe('when editing the id/pin/number', () => {
-      it('sets up the parcel description for saving, and tracks the action', () => {
-        render(
-          <Provider store={store}>
-            <ParcelDescriptions />
-          </Provider>,
-        );
-
-        const descriptionTypeInput = screen.getByDisplayValue('123456789');
-
-        fireEvent.change(descriptionTypeInput, {
-          target: { value: '192837465' },
-        });
-
-        jest.runAllTimers();
-
-        let actions = store.getActions();
-        expect(actions).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              type: 'siteDetails/setupParcelDescriptionsDataForSaving',
-              payload: expect.arrayContaining([
-                expect.objectContaining({
-                  idPinNumber: '192837465',
-                  apiAction: 'updated',
-                }),
-              ]),
-            }),
-            expect.objectContaining({
-              type: 'sites/trackChanges',
-              payload: expect.objectContaining({
-                changeType: IChangeType.Modified,
-                label: 'Parcel Descriptions: 11',
-              }),
-            }),
-          ]),
-        );
-      });
-
       describe('when entering an id/pin/number that is too long', () => {
         describe('and the row is a crown land PIN or parcel ID', () => {
           it('does not update the input value', async () => {
@@ -780,352 +761,6 @@ describe('Parcel Descriptions Component', () => {
             ).not.toBeInTheDocument();
           });
         });
-      });
-    });
-
-    describe('when editing the date noted', () => {
-      const originalConsoleError = console.error;
-
-      beforeAll(() => {
-        console.error = (msg: any) => {
-          // Suppress react printing an error about wrapping updates in act(...)
-          // this is an issue caused by rsuite's date picker component
-          // performing updates asynchronously. I have thoroughly tested that
-          // everything works as expected during these tests.
-          if (
-            !msg.toString().includes('inside a test was not wrapped in act')
-          ) {
-            originalConsoleError(msg);
-          }
-        };
-      });
-
-      afterAll(() => {
-        console.error = originalConsoleError;
-      });
-
-      describe('when inputting a new date', () => {
-        it('sets up the parcel description for saving, and tracks the action', async () => {
-          await act(async () => {
-            render(
-              <Provider store={store}>
-                <ParcelDescriptions />
-              </Provider>,
-            );
-          });
-
-          // Get the first date picker input (Jun 15, 2023).
-          let dateNotedInput = screen.getByDisplayValue('Jun 15, 2023');
-          await act(async () => {
-            fireEvent.click(dateNotedInput);
-          });
-          let targetDate = screen.getByText('11');
-          await act(async () => {
-            // Click on Jun 11, 2023
-            fireEvent.click(targetDate);
-          });
-
-          let actions = store.getActions();
-          expect(actions).toEqual(
-            expect.arrayContaining([
-              expect.objectContaining({
-                type: 'siteDetails/setupParcelDescriptionsDataForSaving',
-                payload: expect.arrayContaining([
-                  expect.objectContaining({
-                    // Match only the date without the timezone. This is necessary
-                    // because the timezone will necessarily be in the test
-                    // environment's timezone which will be different in our
-                    // development and CI environments.
-                    dateNoted: expect.stringMatching(/^2023-06-11.*$/),
-                    apiAction: 'updated',
-                  }),
-                ]),
-              }),
-              expect.objectContaining({
-                type: 'sites/trackChanges',
-                payload: expect.objectContaining({
-                  changeType: IChangeType.Modified,
-                  label: expect.stringMatching(/^Parcel Descriptions: 11$/),
-                }),
-              }),
-            ]),
-          );
-        });
-      });
-
-      describe('when clearing the date', () => {
-        it('sets up the parcel description for saving, and tracks the action', async () => {
-          await act(async () => {
-            render(
-              <Provider store={store}>
-                <ParcelDescriptions />
-              </Provider>,
-            );
-          });
-
-          // Get the first (Parcel Description 11) date clear button.
-          let clearButton = screen.getAllByLabelText('Clear')[0];
-          await act(async () => {
-            fireEvent.click(clearButton);
-          });
-
-          let actions = store.getActions();
-          expect(actions).toEqual(
-            expect.arrayContaining([
-              expect.objectContaining({
-                type: 'siteDetails/setupParcelDescriptionsDataForSaving',
-                payload: expect.arrayContaining([
-                  expect.objectContaining({
-                    dateNoted: expect.stringMatching(/^$/),
-                    apiAction: 'updated',
-                  }),
-                ]),
-              }),
-              expect.objectContaining({
-                type: 'sites/trackChanges',
-                payload: expect.objectContaining({
-                  changeType: IChangeType.Modified,
-                  label: expect.stringMatching(/^Parcel Descriptions: 11$/),
-                }),
-              }),
-            ]),
-          );
-        });
-      });
-    });
-  });
-
-  describe('when adding a new parcel description', () => {
-    beforeEach(() => {
-      jest.useFakeTimers();
-      testState.sites.siteDetailsMode = SiteDetailsMode.EditMode;
-      store = mockStore(testState);
-    });
-
-    afterEach(() => {
-      jest.runOnlyPendingTimers();
-      jest.useRealTimers();
-    });
-
-    it('renders the added row in a new table', async () => {
-      await act(async () => {
-        render(
-          <Provider store={store}>
-            <ParcelDescriptions />
-          </Provider>,
-        );
-      });
-
-      let addButton = screen.getByText('Add Parcel Description');
-      await act(async () => {
-        fireEvent.click(addButton);
-      });
-      jest.runAllTimers();
-
-      expect(
-        await screen.findByTestId('parcel-descriptions-component-added'),
-      ).toBeInTheDocument();
-    });
-
-    describe('when editing the added row', () => {
-      it('sets up the parcel description for saving, and tracks the action', async () => {
-        await act(async () => {
-          render(
-            <Provider store={store}>
-              <ParcelDescriptions />
-            </Provider>,
-          );
-        });
-
-        const addButton = screen.getByText('Add Parcel Description');
-        await act(async () => {
-          fireEvent.click(addButton);
-        });
-        const addedParcelDescriptionsTable = screen.getByTestId(
-          'parcel-descriptions-component-added',
-        );
-        const idPinNumberInput = within(
-          addedParcelDescriptionsTable,
-        ).getByLabelText('ID/PIN/Number');
-
-        fireEvent.change(idPinNumberInput, {
-          target: { value: '192837465' },
-        });
-
-        jest.runAllTimers();
-
-        let actions = store.getActions();
-        expect(actions).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              type: 'siteDetails/setupParcelDescriptionsDataForSaving',
-              payload: expect.arrayContaining([
-                expect.objectContaining({
-                  id: '-1',
-                  apiAction: 'added',
-                }),
-              ]),
-            }),
-            expect.objectContaining({
-              type: 'sites/trackChanges',
-              payload: expect.objectContaining({
-                changeType: IChangeType.Added,
-                label: expect.stringMatching(
-                  /^Parcel Descriptions: Added New Parcel Description\(s\)$/,
-                ),
-              }),
-            }),
-          ]),
-        );
-      });
-    });
-
-    describe('when removing the added row', () => {
-      it('removes the unused table.', async () => {
-        await act(async () => {
-          render(
-            <Provider store={store}>
-              <ParcelDescriptions />
-            </Provider>,
-          );
-        });
-
-        const addButton = screen.getByText('Add Parcel Description');
-        await act(async () => {
-          fireEvent.click(addButton);
-        });
-        const addedParcelDescriptionsTable = screen.getByTestId(
-          'parcel-descriptions-component-added',
-        );
-        const removeButton = within(
-          addedParcelDescriptionsTable,
-        ).getByLabelText('Delete');
-
-        await act(async () => {
-          fireEvent.click(removeButton);
-        });
-
-        jest.runAllTimers();
-
-        expect(
-          screen.queryByTestId('parcel-descriptions-component-added'),
-        ).not.toBeInTheDocument();
-      });
-    });
-  });
-
-  describe('when deleting a parcel description', () => {
-    beforeEach(() => {
-      jest.useFakeTimers();
-      testState.sites.siteDetailsMode = SiteDetailsMode.EditMode;
-      store = mockStore(testState);
-    });
-
-    afterEach(() => {
-      jest.runOnlyPendingTimers();
-      jest.useRealTimers();
-    });
-
-    it('renders the row in a new table', async () => {
-      await act(async () => {
-        render(
-          <Provider store={store}>
-            <ParcelDescriptions />
-          </Provider>,
-        );
-      });
-
-      let selectBox = screen.getAllByLabelText('Select Row')[0];
-      await act(async () => {
-        fireEvent.click(selectBox);
-      });
-      let deleteButton = screen.getByText('Remove Parcel Description');
-      await act(async () => {
-        fireEvent.click(deleteButton);
-      });
-      jest.runAllTimers();
-
-      expect(
-        await screen.findByTestId('parcel-descriptions-component-deleted'),
-      ).toBeInTheDocument();
-    });
-
-    it('sets up the parcel description for saving, and tracks the action', async () => {
-      await act(async () => {
-        render(
-          <Provider store={store}>
-            <ParcelDescriptions />
-          </Provider>,
-        );
-      });
-
-      let selectBox = screen.getAllByLabelText('Select Row')[0];
-      await act(async () => {
-        fireEvent.click(selectBox);
-      });
-      let deleteButton = screen.getByText('Remove Parcel Description');
-      await act(async () => {
-        fireEvent.click(deleteButton);
-      });
-      jest.runAllTimers();
-
-      let actions = store.getActions();
-      expect(actions).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            type: 'siteDetails/setupParcelDescriptionsDataForSaving',
-            payload: expect.arrayContaining([
-              expect.objectContaining({
-                id: '11',
-                apiAction: 'deleted',
-              }),
-            ]),
-          }),
-          expect.objectContaining({
-            type: 'sites/trackChanges',
-            payload: expect.objectContaining({
-              changeType: IChangeType.Deleted,
-              label: expect.stringMatching(/^Parcel Descriptions: 11$/),
-            }),
-          }),
-        ]),
-      );
-    });
-
-    describe('when removing the deleted row', () => {
-      it('removes the unused table.', async () => {
-        await act(async () => {
-          render(
-            <Provider store={store}>
-              <ParcelDescriptions />
-            </Provider>,
-          );
-        });
-
-        let selectBox = screen.getAllByLabelText('Select Row')[0];
-        await act(async () => {
-          fireEvent.click(selectBox);
-        });
-        let deleteButton = screen.getByText('Remove Parcel Description');
-        await act(async () => {
-          fireEvent.click(deleteButton);
-        });
-        const deletedParcelDescriptionsTable = screen.getByTestId(
-          'parcel-descriptions-component-deleted',
-        );
-        const removeButton = within(
-          deletedParcelDescriptionsTable,
-        ).getByLabelText('Delete');
-
-        await act(async () => {
-          fireEvent.click(removeButton);
-        });
-
-        jest.runAllTimers();
-
-        expect(
-          screen.queryByTestId('parcel-descriptions-component-deleted'),
-        ).not.toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/app/features/details/parcelDescriptions/parcelDescriptions.tsx
+++ b/frontend/src/app/features/details/parcelDescriptions/parcelDescriptions.tsx
@@ -9,12 +9,16 @@ import {
   initialParcelDescriptionsState,
   parcelDescriptions,
   resetAllDataForSite,
+  updateAddedRows,
   updateCurrentPage,
+  updateDeletedRows,
+  updateMergedRows,
   updateResultsPerPage,
   updateSearchParam,
   updateSortBy,
   updateSortByDir,
   updateSortByInputValue,
+  updateUpdatedRows,
 } from './parcelDescriptionsSlice';
 import {
   getAddDeleteParcelDescriptionTableColumns,
@@ -120,19 +124,19 @@ const ParcelDescriptions = () => {
   );
   const [updatedRows, setUpdatedRows] = React.useState<
     IParcelDescriptionSaveDto[]
-  >([]);
+  >(reduxState.updatedRows);
   const [mergedRows, setMergedRows] = React.useState<IParcelDescriptionDto[]>(
-    [],
+    reduxState.mergedRows,
   );
   const [selectedRows, setSelectedRows] = React.useState<
     IParcelDescriptionDto[]
   >([]);
   const [addedRows, setAddedRows] = React.useState<IParcelDescriptionSaveDto[]>(
-    [],
+    reduxState.addedRows,
   );
   const [deletedRows, setDeletedRows] = React.useState<
     IParcelDescriptionSaveDto[]
-  >([]);
+  >(reduxState.deletedRows);
 
   const handleSelectPage = (newPage: number) => {
     if (newPage !== currentPage) {
@@ -254,7 +258,7 @@ const ParcelDescriptions = () => {
       } as IParcelDescriptionSaveDto);
     }
 
-    setUpdatedRows(newUpdatedRows);
+    dispatch(updateUpdatedRows(newUpdatedRows));
     dispatch(
       trackChanges(
         new ChangeTracker(
@@ -279,7 +283,7 @@ const ParcelDescriptions = () => {
         }
       },
     );
-    setAddedRows(newAddedRows);
+    dispatch(updateAddedRows(newAddedRows));
     dispatch(
       trackChanges(
         new ChangeTracker(
@@ -297,7 +301,7 @@ const ParcelDescriptions = () => {
       }
       return true;
     });
-    setAddedRows(newAddedRows);
+    dispatch(updateAddedRows(newAddedRows));
     // TODO: There needs to be a way to remove the change tracker entry.
   };
 
@@ -308,7 +312,7 @@ const ParcelDescriptions = () => {
       }
       return true;
     });
-    setDeletedRows(newDeletedRows);
+    dispatch(updateDeletedRows(newDeletedRows));
     // TODO: There needs to be a way to remove the change tracker entry.
   };
 
@@ -391,7 +395,7 @@ const ParcelDescriptions = () => {
       userAction: '',
       srValue: false,
     };
-    setAddedRows([...addedRows, newRow]);
+    dispatch(updateAddedRows([...addedRows, newRow]));
   };
 
   const handleDeleteRows = () => {
@@ -403,7 +407,7 @@ const ParcelDescriptions = () => {
         } as IParcelDescriptionSaveDto;
       }),
     );
-    setDeletedRows(newDeletedRows);
+    dispatch(updateDeletedRows(newDeletedRows));
     newDeletedRows.forEach((deletedRow) => {
       dispatch(
         trackChanges(
@@ -561,16 +565,16 @@ const ParcelDescriptions = () => {
           return dbRow;
         }
       });
-      setMergedRows(newMergedRows);
+      dispatch(updateMergedRows(newMergedRows));
     } else {
-      setMergedRows(dbRows);
+      dispatch(updateMergedRows(dbRows));
     }
   }, [dbRows, updatedRows, viewMode]);
 
   React.useEffect(() => {
     if (resetDetails) {
       fetchNewParcelDescriptions({});
-      setUpdatedRows([]);
+      dispatch(updateUpdatedRows([]));
     }
   }, [resetDetails, saveSiteDetailsRequestStatus]);
 
@@ -585,6 +589,10 @@ const ParcelDescriptions = () => {
     setSortByDir(reduxState.sortByDir);
     setSortByInputValue(reduxState.sortByInputValue);
     setTotalResults(reduxState.totalResults);
+    setUpdatedRows(reduxState.updatedRows);
+    setMergedRows(reduxState.mergedRows);
+    setAddedRows(reduxState.addedRows);
+    setDeletedRows(reduxState.deletedRows);
   }, [reduxState]);
 
   const addRemoveButtons = () => {

--- a/frontend/src/app/features/details/parcelDescriptions/parcelDescriptionsInterfaces.tsx
+++ b/frontend/src/app/features/details/parcelDescriptions/parcelDescriptionsInterfaces.tsx
@@ -43,4 +43,8 @@ export interface IParcelDescriptionsState {
   sortBy: string;
   sortByDir: string;
   sortByInputValue: { [key: string]: any };
+  updatedRows: IParcelDescriptionSaveDto[];
+  mergedRows: IParcelDescriptionDto[];
+  addedRows: IParcelDescriptionSaveDto[];
+  deletedRows: IParcelDescriptionSaveDto[];
 }

--- a/frontend/src/app/features/details/parcelDescriptions/parcelDescriptionsSlice.ts
+++ b/frontend/src/app/features/details/parcelDescriptions/parcelDescriptionsSlice.ts
@@ -21,6 +21,10 @@ export const initialParcelDescriptionsState: IParcelDescriptionsState = {
   sortBy: 'id',
   sortByDir: 'ASC',
   sortByInputValue: {},
+  updatedRows: [],
+  mergedRows: [],
+  addedRows: [],
+  deletedRows: [],
 };
 
 export const fetchParcelDescriptions = createAsyncThunk(
@@ -70,6 +74,18 @@ export const parcelDescriptionsSlice = createSlice({
     updateSortByInputValue: (state, action) => {
       state.sortByInputValue = action.payload;
     },
+    updateUpdatedRows: (state, action) => {
+      state.updatedRows = action.payload;
+    },
+    updateMergedRows: (state, action) => {
+      state.mergedRows = action.payload;
+    },
+    updateAddedRows: (state, action) => {
+      state.addedRows = action.payload;
+    },
+    updateDeletedRows: (state, action) => {
+      state.deletedRows = action.payload;
+    },
     resetAllDataForSite: (state, action) => {
       state.siteId = action.payload;
       state.currentPage = initialParcelDescriptionsState.currentPage;
@@ -81,6 +97,10 @@ export const parcelDescriptionsSlice = createSlice({
       state.sortByDir = initialParcelDescriptionsState.sortByDir;
       state.sortByInputValue = initialParcelDescriptionsState.sortByInputValue;
       state.totalResults = initialParcelDescriptionsState.totalResults;
+      state.updatedRows = initialParcelDescriptionsState.updatedRows;
+      state.mergedRows = initialParcelDescriptionsState.mergedRows;
+      state.addedRows = initialParcelDescriptionsState.addedRows;
+      state.deletedRows = initialParcelDescriptionsState.deletedRows;
     },
   },
   extraReducers: (builder) => {
@@ -117,6 +137,10 @@ export const {
   updateSortBy,
   updateSortByDir,
   updateSortByInputValue,
+  updateUpdatedRows,
+  updateMergedRows,
+  updateAddedRows,
+  updateDeletedRows,
   resetAllDataForSite,
 } = parcelDescriptionsSlice.actions;
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Previously edits made to parcel descriptions in the frontend would not survive navigating across tabs, but the changes to be committed would. This moves all of Parcel Descriptions editing state into redux so that a user can resume where they left off and not be in an inconsistent state when they navigate to and from the Parcel Descriptions component.

Some tests that are no longer viable were deleted leaving only ones that directly test logic.

Fixes # SRS-850

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Made creations, deletions, and updates to parcel descriptions, navigated across tabs and validated that all three were persisted, and subsequently able to be committed to the database.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-282-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-282-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)