### PR TITLE
chore: Prevent sonarcloud from analysing coverage on the frontend.

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -54,7 +54,7 @@ jobs:
           dir: ${{ matrix.dir }}
           node_version: "22"
           sonar_args: >
-             -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts,**/migrations/**,**/*test.tsx,**/*test.ts
+             -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts,**/migrations/**,**/*test.tsx,**/*test.ts,**/frontend/**
              -Dsonar.organization=bcgov-sonarcloud
              -Dsonar.projectKey=bcgov-sonarcloud_nr-site-registry-${{ matrix.dir }}
              -Dsonar.sources=src


### PR DESCRIPTION
As per team discussion, this PR disabled sonarcloud's frontend coverage checks.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-284-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-284-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)