### PR TITLE
feat: SRS-782: add ability to query for site's associated sites

### DIFF
--- a/backend/src/app/entities/siteAssocs.entity.ts
+++ b/backend/src/app/entities/siteAssocs.entity.ts
@@ -84,10 +84,12 @@ export class SiteAssocs extends ChangeAuditEntity {
   @Column('character varying', { name: 'common_pid', length: 1 })
   commonPid: string;
 
+  @Field(() => Sites)
   @ManyToOne(() => Sites, (sites) => sites.siteAssocs, { onDelete: 'CASCADE' })
   @JoinColumn([{ name: 'site_id', referencedColumnName: 'id' }])
   site: Sites;
 
+  @Field(() => Sites)
   @ManyToOne(() => Sites, (sites) => sites.siteAssocs2, { onDelete: 'CASCADE' })
   @JoinColumn([{ name: 'site_id_associated_with', referencedColumnName: 'id' }])
   siteIdAssociatedWith2: Sites;

--- a/backend/src/app/services/site/site.service.ts
+++ b/backend/src/app/services/site/site.service.ts
@@ -526,14 +526,14 @@ export class SiteService {
       if (pending) {
         const result = await this.siteRepository.findOne({
           where: { id: siteId, srAction: SRApprovalStatusEnum.PENDING },
+          relations: ['siteAssocs', 'siteAssocs.siteIdAssociatedWith2'],
         });
-
         response.data = result ? result : null;
       } else {
         const result = await this.siteRepository.findOne({
           where: { id: siteId },
+          relations: ['siteAssocs', 'siteAssocs.siteIdAssociatedWith2'],
         });
-
         response.data = result ? result : null;
       }
     } else {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Add ability to query for site's associated sites. The DB relationship is already there, just needed to expose it on the Graphql layer

Required for [SRS-782](https://env-epd.atlassian.net/browse/SRS-782)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-295-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-295-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)