### PR TITLE
fix: SRS-929 Adding log and avoiding multiple calls to get settings related values

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <script src="./config/config.js"></script>
+    <script src="/config/config.js"></script>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/frontend/src/app/helpers/utility.ts
+++ b/frontend/src/app/helpers/utility.ts
@@ -102,12 +102,12 @@ export const flattenFormRows = (arr: IFormField[][]): IFormField[] => {
 };
 
 export function getUser() {
-  const oidcStorage = sessionStorage.getItem(
-    `oidc.user:` +
-      getClientSettings().authority +
-      `:` +
-      getClientSettings().client_id,
-  );
+  const { authority, client_id } = getClientSettings();
+
+  const storageKey = `oidc.user:${authority}:${client_id}`;
+  console.log('OIDC Key:', storageKey);
+
+  const oidcStorage = sessionStorage.getItem(storageKey);
   if (!oidcStorage) {
     return null;
   }

--- a/frontend/src/app/helpers/utility.ts
+++ b/frontend/src/app/helpers/utility.ts
@@ -103,10 +103,7 @@ export const flattenFormRows = (arr: IFormField[][]): IFormField[] => {
 
 export function getUser() {
   const { authority, client_id } = getClientSettings();
-
   const storageKey = `oidc.user:${authority}:${client_id}`;
-  console.log('OIDC Key:', storageKey);
-
   const oidcStorage = sessionStorage.getItem(storageKey);
   if (!oidcStorage) {
     return null;


### PR DESCRIPTION
# Description


The changes have been made to test out a prod bug SRS-929 wherein user gets logged out on hard refresh and received 405 error. The main reason has been the incorrect path from where the config was being picked up. These changes have been tested in dev env

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-310-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-310-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)