### PR TITLE
fix: retuning null for non nullable field

### DIFF
--- a/backend/src/app/resolvers/landHistory/landHistory.resolver.spec.ts
+++ b/backend/src/app/resolvers/landHistory/landHistory.resolver.spec.ts
@@ -99,7 +99,7 @@ describe('LandHistoryResolver', () => {
         message: `Land uses data not found for site id: ${siteId}`,
         httpStatusCode: 404,
         success: false,
-        data: null,
+        data: [],
       };
 
       const showPending = false;
@@ -120,7 +120,7 @@ describe('LandHistoryResolver', () => {
         `Land uses data not found for site id: ${siteId}`,
         404,
         false,
-        null,
+        [],
       );
     });
   });

--- a/backend/src/app/resolvers/landHistory/landHistory.resolver.ts
+++ b/backend/src/app/resolvers/landHistory/landHistory.resolver.ts
@@ -69,7 +69,7 @@ export class LandHistoryResolver {
         `Land uses data not found for site id: ${siteId}`,
         HttpStatus.NOT_FOUND,
         false,
-        null,
+        [],
       );
     }
   }

--- a/backend/src/app/services/landHistory/landHistory.service.ts
+++ b/backend/src/app/services/landHistory/landHistory.service.ts
@@ -74,6 +74,12 @@ export class LandHistoryService {
       this.sitesLogger.debug(
         'LandHistoryService.getLandHistoriesForSite() end',
       );
+
+      if(!result.length)
+      {
+        return [];
+      }
+
       return result;
     } catch (error) {
       this.sitesLogger.error(


### PR DESCRIPTION
fix retuning null for non nullable field

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-357-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-357-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)