### PR TITLE
fix: alert, change on success or fail toast text and view or download a file even if not saved in s3 object storage

### DIFF
--- a/frontend/src/app/components/alert/Alert.css
+++ b/frontend/src/app/components/alert/Alert.css
@@ -37,3 +37,7 @@
   text-align: left;
   color: var(--typography-color-primary, #2d2d2d);
 }
+
+.Toastify__close-button {
+  padding: 12px 5px 0px 0px; /* Padding */
+}

--- a/frontend/src/app/components/alert/Alert.tsx
+++ b/frontend/src/app/components/alert/Alert.tsx
@@ -12,7 +12,7 @@ interface ErrorMsgProps {
 const createToastOptions = (type: 'error' | 'success'): ToastOptions => ({
   className: `toast-${type}`,
   type,
-  closeButton: false,
+  closeButton: true,
   position: 'top-center',
 });
 

--- a/frontend/src/app/features/details/SiteDetails.tsx
+++ b/frontend/src/app/features/details/SiteDetails.tsx
@@ -239,8 +239,8 @@ const SiteDetails = () => {
 
       showNotification(
         saveSiteDetailsRequestStatus,
-        'Successfully saved site details',
-        'Failed To save site details',
+        'Changes saved successfully',
+        'System error prevented changes from being saved.',
       );
       dispatch(resetSaveSiteDetailsRequestStatus(null));
     } else {

--- a/frontend/src/app/features/details/documents/Documents.tsx
+++ b/frontend/src/app/features/details/documents/Documents.tsx
@@ -438,29 +438,44 @@ const Documents: React.FC<IComponentProps> = ({ showPending = false }) => {
   };
 
   const handleViewOnline = async (document: any) => {
-    if (document?.objectId !== null) {
+    if (document?.objectId !== null && document?.objectId !== undefined) {
       const response = await getObject(document?.objectId);
       window.open(response, '_blank');
+    } else {
+      if (document?.file) {
+        window.open(URL.createObjectURL(document?.file), '_blank');
+      }
     }
   };
 
   const handleDownload = async (doc: any) => {
-    if (doc?.objectId !== null) {
-      const response = await getObject(doc?.objectId, 'proxy');
+    try {
+      let fileBlob: Blob | null = null;
+      if (doc?.objectId !== null && doc?.objectId !== undefined) {
+        fileBlob = await getObject(doc?.objectId, 'proxy');
+      } else {
+        if (doc?.file) {
+          fileBlob = doc?.file;
+        }
+      }
 
-      // Create an object URL for the Blob
-      const objectURL = URL.createObjectURL(response);
+      if (fileBlob) {
+        // Create an object URL for the Blob
+        const objectURL = URL.createObjectURL(fileBlob);
 
-      // Create an anchor element to trigger the download
-      const downloadLink = document.createElement('a');
-      downloadLink.href = objectURL; // Set the href to the Blob URL
-      downloadLink.download = doc?.title; // Provide a filename for the download
+        // Create an anchor element to trigger the download
+        const downloadLink = document.createElement('a');
+        downloadLink.href = objectURL; // Set the href to the Blob URL
+        downloadLink.download = doc?.title; // Provide a filename for the download
 
-      // Trigger the download
-      downloadLink.click();
+        // Trigger the download
+        downloadLink.click();
 
-      // Optionally, revoke the object URL after the download
-      URL.revokeObjectURL(objectURL);
+        // Optionally, revoke the object URL after the download
+        URL.revokeObjectURL(objectURL);
+      }
+    } catch (error) {
+      console.error('Error downloading file:', error);
     }
   };
 


### PR DESCRIPTION
fix alert, change on success or fail toast text and view or download a file even if not saved in s3 object storage

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-399-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-399-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)