### PR TITLE
fix: add api call  for  not logged in users as well as impacted area beacuse of keycloak changes.

### DIFF
--- a/backend/src/app/resolvers/dropdown/dropdown.resolver.ts
+++ b/backend/src/app/resolvers/dropdown/dropdown.resolver.ts
@@ -1,5 +1,5 @@
 import { Resolver, Query, Args } from '@nestjs/graphql';
-import { RoleMatchingMode, Roles } from 'nest-keycloak-connect';
+import { RoleMatchingMode, Roles, Unprotected } from 'nest-keycloak-connect';
 import {
   DropdownDto,
   DropdownResponse,
@@ -225,6 +225,7 @@ export class DropdownResolver {
   }
 
   @Query(() => DropdownResponse, { name: 'getSiteRiskCd' })
+  @Unprotected()
   async getSiteRiskCd() {
     this.sitesLogger.log('DropdownResolver.getSiteRiskCd() start');
     const result = await this.dropdownService.getSiteRiskCd();

--- a/frontend/src/app/features/dashboard/Dashboard.tsx
+++ b/frontend/src/app/features/dashboard/Dashboard.tsx
@@ -6,7 +6,7 @@ import { UserType } from '../../helpers/requests/userType';
 import './Dashboard.css';
 import PageContainer from '../../components/simple/PageContainer';
 import Widget from '../../components/widget/Widget';
-import { getUser } from '../../helpers/utility';
+import { getUser, isUserOfType, UserRoleType } from '../../helpers/utility';
 import Actions from '../../components/action/Actions';
 import { useNavigate } from 'react-router-dom';
 import { fetchRecentViews } from './DashboardSlice';
@@ -67,15 +67,13 @@ const Dashboard = () => {
   const [userType, setUserType] = useState<UserType>(UserType.External);
 
   useEffect(() => {
-    if (loggedInUser?.profile.preferred_username?.indexOf('bceid') !== -1) {
-      setUserType(UserType.External);
-    } else if (
-      loggedInUser?.profile.preferred_username?.indexOf('idir') !== -1
+    if (
+      isUserOfType(UserRoleType.CLIENT) ||
+      isUserOfType(UserRoleType.PUBLIC)
     ) {
-      setUserType(UserType.Internal);
-    } else {
-      // not logged in
       setUserType(UserType.External);
+    } else if (isUserOfType(UserRoleType.INTERNAL)) {
+      setUserType(UserType.Internal);
     }
 
     loggedInUser

--- a/frontend/src/app/features/details/SiteDetails.tsx
+++ b/frontend/src/app/features/details/SiteDetails.tsx
@@ -144,7 +144,6 @@ import {
 } from './documents/DocumentEndpoints';
 import { HttpStatusCode } from '../../common/httpStatusCode';
 import { GetSummaryConfig } from './summary/SummaryConfig';
-import { de } from 'date-fns/locale';
 import { siteDisclosureConfig } from './disclosure/DisclosureConfig';
 
 const SiteDetails = () => {
@@ -332,15 +331,13 @@ const SiteDetails = () => {
   }, []);
 
   useEffect(() => {
-    if (loggedInUser?.profile.preferred_username?.indexOf('bceid') !== -1) {
-      setUserType(UserType.External);
-    } else if (
-      loggedInUser?.profile.preferred_username?.indexOf('idir') !== -1
+    if (
+      isUserOfType(UserRoleType.CLIENT) ||
+      isUserOfType(UserRoleType.PUBLIC)
     ) {
-      setUserType(UserType.Internal);
-    } else {
-      // not logged in
       setUserType(UserType.External);
+    } else if (isUserOfType(UserRoleType.INTERNAL)) {
+      setUserType(UserType.Internal);
     }
   }, [loggedInUser]);
 
@@ -895,7 +892,6 @@ const SiteDetails = () => {
   };
   const handleAddToCart = () => {
     dispatch(resetCartItemAddedStatus);
-    const loggedInUser = getUser();
     if (loggedInUser === null) {
       auth.signinRedirect({ extraQueryParams: { kc_idp_hint: 'bceid' } });
     } else {

--- a/frontend/src/app/features/details/associates/Associate.tsx
+++ b/frontend/src/app/features/details/associates/Associate.tsx
@@ -11,10 +11,12 @@ import {
 import {
   getAxiosInstance,
   getUser,
+  isUserOfType,
   resultCache,
   sortArray,
   UpdateDisplayTypeParams,
   updateTableColumn,
+  UserRoleType,
 } from '../../../helpers/utility';
 import { UserType } from '../../../helpers/requests/userType';
 import { SiteDetailsMode } from '../dto/SiteDetailsMode';
@@ -90,12 +92,13 @@ const Associate: React.FC<IComponentProps> = ({ showPending = false }) => {
 
   // Handle user type based on username
   useEffect(() => {
-    if (loggedInUser?.profile.preferred_username?.includes('bceid')) {
+    if (
+      isUserOfType(UserRoleType.CLIENT) ||
+      isUserOfType(UserRoleType.PUBLIC)
+    ) {
       setUserType(UserType.External);
-    } else if (loggedInUser?.profile.preferred_username?.includes('idir')) {
+    } else if (isUserOfType(UserRoleType.INTERNAL)) {
       setUserType(UserType.Internal);
-    } else {
-      setUserType(UserType.External);
     }
   }, [loggedInUser]);
 

--- a/frontend/src/app/features/details/disclosure/Disclosure.tsx
+++ b/frontend/src/app/features/details/disclosure/Disclosure.tsx
@@ -17,8 +17,10 @@ import {
 import {
   flattenFormRows,
   getUser,
+  isUserOfType,
   serializeDate,
   sortArray,
+  UserRoleType,
 } from '../../../helpers/utility';
 import { SRVisibility } from '../../../helpers/requests/srVisibility';
 import {
@@ -136,12 +138,13 @@ const Disclosure: React.FC<IComponentProps> = ({ showPending = false }) => {
   // Handle user type based on username
 
   useEffect(() => {
-    if (loggedInUser?.profile.preferred_username?.includes('bceid')) {
+    if (
+      isUserOfType(UserRoleType.CLIENT) ||
+      isUserOfType(UserRoleType.PUBLIC)
+    ) {
       setUserType(UserType.External);
-    } else if (loggedInUser?.profile.preferred_username?.includes('idir')) {
+    } else if (isUserOfType(UserRoleType.INTERNAL)) {
       setUserType(UserType.Internal);
-    } else {
-      setUserType(UserType.External);
     }
   }, [loggedInUser]);
 

--- a/frontend/src/app/features/details/documents/Documents.tsx
+++ b/frontend/src/app/features/details/documents/Documents.tsx
@@ -18,10 +18,12 @@ import {
   formatDate,
   getAxiosInstance,
   getUser,
+  isUserOfType,
   parseDate,
   resultCache,
   UpdateDisplayTypeParams,
   updateFields,
+  UserRoleType,
 } from '../../../helpers/utility';
 import SearchInput from '../../../components/search/SearchInput';
 import Sort from '../../../components/sort/Sort';
@@ -257,12 +259,13 @@ const Documents: React.FC<IComponentProps> = ({ showPending = false }) => {
 
   // Handle user type based on username
   useEffect(() => {
-    if (loggedInUser?.profile.preferred_username?.includes('bceid')) {
+    if (
+      isUserOfType(UserRoleType.CLIENT) ||
+      isUserOfType(UserRoleType.PUBLIC)
+    ) {
       setUserType(UserType.External);
-    } else if (loggedInUser?.profile.preferred_username?.includes('idir')) {
+    } else if (isUserOfType(UserRoleType.INTERNAL)) {
       setUserType(UserType.Internal);
-    } else {
-      setUserType(UserType.External);
     }
   }, [loggedInUser]);
 

--- a/frontend/src/app/features/details/notations/Notations.tsx
+++ b/frontend/src/app/features/details/notations/Notations.tsx
@@ -18,11 +18,13 @@ import {
   flattenFormRows,
   getAxiosInstance,
   getUser,
+  isUserOfType,
   parseDate,
   resultCache,
   sortArray,
   UpdateDisplayTypeParams,
   updateTableColumn,
+  UserRoleType,
 } from '../../../helpers/utility';
 import SearchInput from '../../../components/search/SearchInput';
 import Sort from '../../../components/sort/Sort';
@@ -223,12 +225,13 @@ const Notations: React.FC<IComponentProps> = ({ showPending = false }) => {
 
   // Handle user type based on username
   useEffect(() => {
-    if (loggedInUser?.profile.preferred_username?.includes('bceid')) {
+    if (
+      isUserOfType(UserRoleType.CLIENT) ||
+      isUserOfType(UserRoleType.PUBLIC)
+    ) {
       setUserType(UserType.External);
-    } else if (loggedInUser?.profile.preferred_username?.includes('idir')) {
+    } else if (isUserOfType(UserRoleType.INTERNAL)) {
       setUserType(UserType.Internal);
-    } else {
-      setUserType(UserType.External);
     }
   }, [loggedInUser]);
 

--- a/frontend/src/app/features/details/participants/Participant.tsx
+++ b/frontend/src/app/features/details/participants/Participant.tsx
@@ -28,11 +28,13 @@ import { v4 } from 'uuid';
 import {
   getAxiosInstance,
   getUser,
+  isUserOfType,
   parseDate,
   resultCache,
   sortArray,
   UpdateDisplayTypeParams,
   updateTableColumn,
+  UserRoleType,
 } from '../../../helpers/utility';
 import ModalDialog from '../../../components/modaldialog/ModalDialog';
 import { participantRoleDrpdown } from '../dropdowns/DropdownSlice';
@@ -91,12 +93,13 @@ const Participants: React.FC<IComponentProps> = ({ showPending = false }) => {
 
   // Handle user type based on username
   useEffect(() => {
-    if (loggedInUser?.profile.preferred_username?.includes('bceid')) {
+    if (
+      isUserOfType(UserRoleType.CLIENT) ||
+      isUserOfType(UserRoleType.PUBLIC)
+    ) {
       setUserType(UserType.External);
-    } else if (loggedInUser?.profile.preferred_username?.includes('idir')) {
+    } else if (isUserOfType(UserRoleType.INTERNAL)) {
       setUserType(UserType.Internal);
-    } else {
-      setUserType(UserType.External);
     }
   }, [loggedInUser]);
 


### PR DESCRIPTION
add API call  for  not logged in users as well as impacted area because of keycloak changes

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-401-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-401-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)