### PR TITLE
fix: Remove alert and SR Visibiity dropdown and fix SR functionality in Site Associate

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -54,6 +54,7 @@ jobs:
           dir: ${{ matrix.dir }}
           node_version: "22"
           sonar_args: >
+             -Dsonar.nodejs.executable=node
              -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts,**/migrations/**,**/*test.tsx,**/*test.ts
              -Dsonar.organization=bcgov-sonarcloud
              -Dsonar.projectKey=bcgov-sonarcloud_nr-site-registry-${{ matrix.dir }}

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -54,7 +54,6 @@ jobs:
           dir: ${{ matrix.dir }}
           node_version: "22"
           sonar_args: >
-             -Dsonar.nodejs.executable=node
              -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts,**/migrations/**,**/*test.tsx,**/*test.ts
              -Dsonar.organization=bcgov-sonarcloud
              -Dsonar.projectKey=bcgov-sonarcloud_nr-site-registry-${{ matrix.dir }}

--- a/frontend/src/app/features/details/associates/Associate.tsx
+++ b/frontend/src/app/features/details/associates/Associate.tsx
@@ -363,10 +363,6 @@ const Associate: React.FC<IComponentProps> = ({ showPending = false }) => {
     setFormData(sorted);
   };
 
-  const handleWidgetCheckBox = (event: any) => {
-    alert(event);
-  };
-
   const handleTableChange = (event: any) => {
     if (
       event.property.includes('select_all') ||
@@ -447,7 +443,7 @@ const Associate: React.FC<IComponentProps> = ({ showPending = false }) => {
                 apiAction: assoc?.apiAction ?? UserActionEnum.updated,
                 srAction: event.value
                   ? SRApprovalStatusEnum.Public
-                  : SRApprovalStatusEnum.Pending,
+                  : SRApprovalStatusEnum.Private,
               };
             } else {
               return {
@@ -517,10 +513,8 @@ const Associate: React.FC<IComponentProps> = ({ showPending = false }) => {
   const handleItemClick = (value: string) => {
     switch (value) {
       case SRVisibility.ShowSR:
-        alert('show');
         break;
       case SRVisibility.HideSR:
-        alert('hide');
         break;
       default:
         break;
@@ -631,7 +625,7 @@ const Associate: React.FC<IComponentProps> = ({ showPending = false }) => {
         <div>
           <AssociateSiteComponent
             handleTableChange={handleTableChange}
-            handleWidgetCheckBox={handleWidgetCheckBox}
+            handleWidgetCheckBox={() => {}}
             userType={userType}
             viewMode={viewMode}
             internalRow={internalRow}

--- a/frontend/src/app/features/details/associates/AssociateSiteComponent.tsx
+++ b/frontend/src/app/features/details/associates/AssociateSiteComponent.tsx
@@ -80,7 +80,8 @@ const AssociateSiteComponent: React.FC<IAssociateSiteComponent> = ({
           viewMode === SiteDetailsMode.EditMode &&
           userType === UserType.Internal
         }
-        srMode={false}
+        srMode={viewMode === SiteDetailsMode.SRMode}
+        hideWidgetCheckbox={true}
         primaryKeycolumnName="id"
         sortHandler={(row: any, ascDir: any) => {
           handleTableSort(row, ascDir);
@@ -104,16 +105,16 @@ const AssociateSiteComponent: React.FC<IAssociateSiteComponent> = ({
               </Button>
             </div>
           )}
-        {viewMode === SiteDetailsMode.SRMode &&
+        {/* {viewMode === SiteDetailsMode.SRMode &&
           userType === UserType.Internal && (
             <Actions
               label="Set SR Visibility"
               items={srVisibilityAssocConfig}
               onItemClick={handleItemClick}
-              disable={viewMode !== SiteDetailsMode.SRMode}
+              disable={true}
               toggleButtonVariant="secondary"
             />
-          )}
+          )} */}
       </Widget>
     </React.Fragment>
   );

--- a/frontend/src/app/features/details/participants/Participant.tsx
+++ b/frontend/src/app/features/details/participants/Participant.tsx
@@ -312,10 +312,6 @@ const Participants: React.FC<IComponentProps> = ({ showPending = false }) => {
     setFormData(siteParticipant);
   };
 
-  const handleWidgetCheckBox = (event: any) => {
-    alert(event);
-  };
-
   const handleRemoveParticipant = (particIsDelete: boolean = false) => {
     if (particIsDelete) {
       // Remove selected rows from formData state
@@ -578,10 +574,8 @@ const Participants: React.FC<IComponentProps> = ({ showPending = false }) => {
   const handleItemClick = (value: string) => {
     switch (value) {
       case SRVisibility.ShowSR:
-        alert('show');
         break;
       case SRVisibility.HideSR:
-        alert('hide');
         break;
       default:
         break;
@@ -615,7 +609,7 @@ const Participants: React.FC<IComponentProps> = ({ showPending = false }) => {
       )}
       <ParticipantTable
         handleTableChange={handleTableChange}
-        handleWidgetCheckBox={handleWidgetCheckBox}
+        handleWidgetCheckBox={() => {}}
         internalRow={internalRow}
         externalRow={externalRow}
         userType={userType}

--- a/frontend/src/app/features/details/participants/ParticipantTable.tsx
+++ b/frontend/src/app/features/details/participants/ParticipantTable.tsx
@@ -113,16 +113,16 @@ const ParticipantTable: React.FC<IParticipantTableProps> = ({
               </Button>
             </div>
           )}
-        {viewMode === SiteDetailsMode.SRMode &&
+        {/* {viewMode === SiteDetailsMode.SRMode &&
           userType === UserType.Internal && (
             <Actions
               label="Set SR Visibility"
               items={srVisibilityParcticConfig}
               onItemClick={handleItemClick}
-              disable={viewMode === SiteDetailsMode.SRMode}
+              disable={true}
               toggleButtonVariant="secondary"
             />
-          )}
+          )} */}
       </Widget>
     </div>
   );


### PR DESCRIPTION
Remove alert and SR Visibiity dropdown and fix SR functionality in Site Associate


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-405-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-405-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)