### PR TITLE
feat: SRS-871:Add input option to radius search

### DIFF
--- a/frontend/src/app/features/map/MapSearch.css
+++ b/frontend/src/app/features/map/MapSearch.css
@@ -83,11 +83,11 @@
   gap: 8px;
 }
 
-.point-search-slider-content {
+/* .point-search-slider-content {
   display: flex;
   align-items: center;
   gap: 16px;
-}
+} */
 
 .point-search-slider {
   flex: 0 0 290px;
@@ -126,9 +126,16 @@ p.point-search-slider-text {
   font-size: 14px;
 }
 
-.point-search-menu .MuiPaper-root {
+/* .point-search-menu .MuiPaper-root {
   overflow: visible;
   width: 400px;
+} */
+
+/* Fix overflow - change from visible to hidden/auto */
+.point-search-menu .MuiPaper-root {
+  overflow: hidden; /* Changed from visible to hidden */
+  width: 400px;
+  max-width: 400px;
 }
 
 .search-autocomplete .search-input {
@@ -157,4 +164,67 @@ div.search-autocomplete.MuiAutocomplete-hasClearIcon .MuiInputBase-root {
 .polygon-vertex {
   background-color: var(--surface-color-primary-default);
   border: 1px solid var(--surface-color-border-default);
+}
+
+/* Update existing point-search-slider-content */
+.point-search-slider-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  min-width: 350px;
+  max-width: 100%;
+  width: 100%;
+  box-sizing: border-box;
+  overflow: hidden; /* Prevent overflow */
+}
+
+/* Radius Input Container */
+.radius-input-container {
+  width: 100%;
+  margin-bottom: 4px;
+  box-sizing: border-box;
+}
+
+.radius-text-input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.radius-text-input .MuiOutlinedInput-root {
+  font-size: 14px;
+}
+
+.radius-text-input .MuiFormHelperText-root {
+  font-size: 11px;
+  margin-top: 4px;
+  margin-bottom: 0;
+}
+
+/* Slider Row - keeps slider and value on same row, contained */
+.radius-slider-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  flex-wrap: nowrap;
+  box-sizing: border-box;
+  min-width: 0; /* Allow flex shrinking */
+}
+
+/* Make slider responsive and contained */
+.radius-slider-row .point-search-slider {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 100%;
+  margin-left: 0;
+  width: auto;
+}
+
+/* Ensure text stays on same line and doesn't overflow */
+.radius-slider-row .point-search-slider-text {
+  flex-shrink: 0;
+  white-space: nowrap;
+  min-width: fit-content;
+  font-size: 14px;
 }

--- a/frontend/src/app/features/map/MapSearch.css
+++ b/frontend/src/app/features/map/MapSearch.css
@@ -83,12 +83,6 @@
   gap: 8px;
 }
 
-/* .point-search-slider-content {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-} */
-
 .point-search-slider {
   flex: 0 0 290px;
   min-width: 290px;
@@ -125,11 +119,6 @@ p.point-search-slider-text {
   color: black;
   font-size: 14px;
 }
-
-/* .point-search-menu .MuiPaper-root {
-  overflow: visible;
-  width: 400px;
-} */
 
 /* Fix overflow - change from visible to hidden/auto */
 .point-search-menu .MuiPaper-root {

--- a/frontend/src/app/features/map/search/RadiusSearch.test.tsx
+++ b/frontend/src/app/features/map/search/RadiusSearch.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RadiusSearch } from './RadiusSearch';
+import { useMapSearchContext } from '../mapSearchContext/MapSearchContext';
+import {
+  MIN_CIRCLE_RADIUS,
+  MAX_CIRCLE_RADIUS,
+} from '../../../constants/Constant';
+
+jest.mock('../mapSearchContext/MapSearchContext');
+
+describe('RadiusSearch component', () => {
+  const mockHandleRadiusChange = jest.fn();
+  const mockClearRadiusSearch = jest.fn();
+
+  const renderComponent = (
+    center: [number, number] | null,
+    radius: number = MIN_CIRCLE_RADIUS,
+    isSmall: boolean = false,
+  ) => {
+    (useMapSearchContext as jest.Mock).mockReturnValue({
+      center,
+      radius,
+      handleRadiusChange: mockHandleRadiusChange,
+      clearRadiusSearch: mockClearRadiusSearch,
+    });
+    return render(<RadiusSearch isSmall={isSmall} />);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the component', () => {
+    renderComponent([49.2827, -123.1207]);
+    const cancelButton = screen.getByText('Cancel');
+    expect(cancelButton).toBeInTheDocument();
+  });
+
+  it('should render Set Radius button when center is valid', () => {
+    renderComponent([49.2827, -123.1207]);
+    const setRadiusButton = screen.getByText('Set Radius');
+    expect(setRadiusButton).toBeInTheDocument();
+  });
+
+  it('should call clearRadiusSearch when Cancel button is clicked', () => {
+    renderComponent([49.2827, -123.1207]);
+    const cancelButton = screen.getByText('Cancel');
+    fireEvent.click(cancelButton);
+    expect(mockClearRadiusSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should disable controls when center is not valid', () => {
+    renderComponent(null);
+    const setRadiusButton = screen.getByText('Set Radius');
+    expect(setRadiusButton).toBeDisabled();
+  });
+
+  it('should render radius input field', () => {
+    const { container } = renderComponent(
+      [49.2827, -123.1207],
+      MIN_CIRCLE_RADIUS,
+      true,
+    );
+    const input = container.querySelector(
+      'input[type="number"]',
+    ) as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+  });
+
+  it('should update input value when user types', () => {
+    const { container } = renderComponent(
+      [49.2827, -123.1207],
+      MIN_CIRCLE_RADIUS,
+      true,
+    );
+    const input = container.querySelector(
+      'input[type="number"]',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '2' } });
+    expect(input.value).toBe('2');
+  });
+
+  it('should show error message for value below minimum radius', () => {
+    const { container } = renderComponent(
+      [49.2827, -123.1207],
+      MIN_CIRCLE_RADIUS,
+      true,
+    );
+    const input = container.querySelector(
+      'input[type="number"]',
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '0.3' } }); // 300m < 500m minimum
+    const errorMessages = screen.getAllByText((content, element) => {
+      return element?.textContent?.includes('Minimum radius is') ?? false;
+    });
+    expect(errorMessages.length).toBeGreaterThan(0);
+  });
+
+  it('should show error message for value above maximum radius', () => {
+    const { container } = renderComponent(
+      [49.2827, -123.1207],
+      MIN_CIRCLE_RADIUS,
+      true,
+    );
+    const input = container.querySelector(
+      'input[type="number"]',
+    ) as HTMLInputElement;
+    const maxKm = MAX_CIRCLE_RADIUS / 1000;
+    fireEvent.change(input, { target: { value: (maxKm + 1).toString() } });
+    const errorMessages = screen.getAllByText((content, element) => {
+      return element?.textContent?.includes('Maximum radius is') ?? false;
+    });
+    expect(errorMessages.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/app/features/map/search/RadiusSearch.tsx
+++ b/frontend/src/app/features/map/search/RadiusSearch.tsx
@@ -1,4 +1,4 @@
-import { Slider, Typography } from '@mui/material';
+import { Slider, Typography, TextField } from '@mui/material';
 import clsx from 'clsx';
 import {
   ActiveToolEnum,
@@ -8,7 +8,7 @@ import {
 import { XmarkIcon } from '../../../components/common/icon';
 import DropdownButton from '../DropDownButton';
 import { formatDistance } from '../../../helpers/utility';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '../../../components/button/Button';
 import { Site } from '../MapView';
 import { useMapSearchContext } from '../mapSearchContext/MapSearchContext';
@@ -27,21 +27,177 @@ export function RadiusSearch({
 
   const [localRadius, setLocalRadius] = useState(radius);
 
+  // Helper to get km value using same logic as formatDistance
+  const getKmValue = (meters: number): string => {
+    if (isNaN(meters)) return '0';
+    const kms = Number((meters / 1000).toFixed(2));
+    return kms.toString();
+  };
+
+  const [inputValue, setInputValue] = useState(getKmValue(radius));
+  const [inputError, setInputError] = useState<string>('');
+
   const isCenterValid = center !== null;
 
+  // Sync with context radius when it changes externally
+  useEffect(() => {
+    if (radius !== localRadius) {
+      setLocalRadius(radius);
+      setInputValue(getKmValue(radius));
+      setInputError('');
+    }
+  }, [radius]);
+
+  // Convert km to meters
+  const kmToMeters = (km: number): number => {
+    return Math.round(km * 1000);
+  };
+
+  // Debounce timer ref
+  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const DEBOUNCE_DELAY_MS = 500; // 500ms pause before API call
+
+  // Helper function to clear debounce timer
+  const clearDebounceTimer = useCallback(() => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+  }, []);
+
+  /*Debounced commit function - called after user pauses typing
+  // * It delays the API call until typing pauses for 500ms. It:
+  // * Resets the timer on each keystroke
+  // * Cancels pending calls when needed
+  // * Calls handleRadiusChange after the delay
+  // * Cleans up on unmount
+  // This balances responsiveness (immediate UI updates) with efficiency (fewer API calls).*/
+  const debouncedCommit = useCallback(
+    (metersValue: number) => {
+      // Clear any existing timer
+      clearDebounceTimer();
+
+      // Set new timer
+      debounceTimerRef.current = setTimeout(() => {
+        handleRadiusChange(metersValue);
+      }, DEBOUNCE_DELAY_MS);
+    },
+    [handleRadiusChange, clearDebounceTimer],
+  );
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      clearDebounceTimer();
+    };
+  }, [clearDebounceTimer]);
+
+  // Keep original logic - just adding input sync
   const handleChange = (_ev: any, newValue: number | number[]) => {
     if (typeof newValue === 'number') {
       setLocalRadius(newValue);
+      setInputValue(getKmValue(newValue));
+      setInputError('');
     } else if (Array.isArray(newValue) && newValue.length > 0) {
       setLocalRadius(newValue[0]);
+      setInputValue(getKmValue(newValue[0]));
+      setInputError('');
     }
   };
 
+  // Keep original logic - no changes
   const handleChangeCommitted = (_ev: any, newValue: number | number[]) => {
     if (typeof newValue === 'number') {
       handleRadiusChange(newValue);
     } else if (Array.isArray(newValue) && newValue.length > 0) {
       handleRadiusChange(newValue[0]);
+    }
+  };
+
+  // Handle input change - updates local state and slider (input in km, convert to meters)
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setInputValue(value);
+
+    // Parse as number (interpreted as kilometers)
+    const numericValue = value.trim() === '' ? null : parseFloat(value);
+
+    if (numericValue === null || isNaN(numericValue)) {
+      setInputError('Enter a number (in kilometers)');
+      clearDebounceTimer();
+      return;
+    }
+
+    // Convert km to meters
+    const metersValue = kmToMeters(numericValue);
+
+    // Validate bounds (in meters)
+    if (metersValue < MIN_CIRCLE_RADIUS) {
+      setInputError(
+        `Minimum radius is ${formatDistance(MIN_CIRCLE_RADIUS, 1)}`,
+      );
+      setLocalRadius(Math.max(metersValue, MIN_CIRCLE_RADIUS));
+      clearDebounceTimer();
+      return;
+    }
+
+    if (metersValue > MAX_CIRCLE_RADIUS) {
+      setInputError(
+        `Maximum radius is ${formatDistance(MAX_CIRCLE_RADIUS, 1)}`,
+      );
+      setLocalRadius(Math.min(metersValue, MAX_CIRCLE_RADIUS));
+      clearDebounceTimer();
+      return;
+    }
+
+    // Valid value - update both input display and slider
+    setInputError('');
+    setLocalRadius(metersValue);
+
+    // Trigger debounced API call
+    debouncedCommit(metersValue);
+  };
+
+  // Handle input blur/enter - commit the change
+  const handleInputCommit = () => {
+    const numericValue =
+      inputValue.trim() === '' ? null : parseFloat(inputValue);
+
+    // Clear any pending debounced call
+    clearDebounceTimer();
+
+    if (numericValue === null || isNaN(numericValue)) {
+      // Invalid - reset to current valid radius
+      setInputValue(getKmValue(radius));
+      setLocalRadius(radius);
+      setInputError('');
+      return;
+    }
+
+    // Convert km to meters
+    const metersValue = kmToMeters(numericValue);
+
+    // Validate bounds
+    if (metersValue < MIN_CIRCLE_RADIUS || metersValue > MAX_CIRCLE_RADIUS) {
+      // Out of bounds - reset to current valid radius
+      setInputValue(getKmValue(radius));
+      setLocalRadius(radius);
+      setInputError('');
+      return;
+    }
+
+    // Valid value - commit it
+    setInputError('');
+    setLocalRadius(metersValue);
+    handleRadiusChange(metersValue);
+    // Ensure input shows the formatted km value
+    setInputValue(getKmValue(metersValue));
+  };
+
+  const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleInputCommit();
     }
   };
 
@@ -52,25 +208,52 @@ export function RadiusSearch({
           Set Radius:
         </Typography>
       )}
-      <Slider
-        className={clsx(
-          'point-search-slider',
-          isSmall && 'point-search-slider--shrink',
-        )}
-        aria-label="Search radius"
-        valueLabelDisplay="off"
-        min={MIN_CIRCLE_RADIUS}
-        // 500 km is roughly half the size of BC
-        max={MAX_CIRCLE_RADIUS}
-        step={MIN_CIRCLE_RADIUS}
-        defaultValue={MIN_CIRCLE_RADIUS}
-        value={localRadius}
-        onChangeCommitted={handleChangeCommitted} //Make fetch request on change commit
-        onChange={handleChange} //This is kept to keep the slider move smoothly without making fetch requests
-      />
-      <Typography className="point-search-slider-text">
-        {formatDistance(localRadius, 1)}
-      </Typography>
+
+      {/* Text Input for Precise Radius - Compact layout */}
+      <div className="radius-input-container">
+        <TextField
+          label="Radius (km)"
+          value={inputValue}
+          onChange={handleInputChange}
+          onBlur={handleInputCommit}
+          onKeyDown={handleInputKeyDown}
+          error={!!inputError}
+          helperText={
+            inputError ||
+            `Enter radius in kilometers (min: ${formatDistance(MIN_CIRCLE_RADIUS, 1)}, max: ${formatDistance(MAX_CIRCLE_RADIUS, 1)})`
+          }
+          size="small"
+          disabled={!isCenterValid}
+          className="radius-text-input"
+          type="number"
+          inputProps={{
+            'aria-label': 'Radius input in kilometers',
+            step: 0.1,
+          }}
+        />
+      </div>
+
+      {/* Slider Row - slider and value on same row */}
+      <div className="radius-slider-row">
+        <Slider
+          className={clsx(
+            'point-search-slider',
+            isSmall && 'point-search-slider--shrink',
+          )}
+          aria-label="Search radius"
+          valueLabelDisplay="off"
+          min={MIN_CIRCLE_RADIUS}
+          max={MAX_CIRCLE_RADIUS}
+          step={MIN_CIRCLE_RADIUS}
+          defaultValue={MIN_CIRCLE_RADIUS}
+          value={localRadius}
+          onChangeCommitted={handleChangeCommitted}
+          onChange={handleChange}
+        />
+        <Typography className="point-search-slider-text">
+          {formatDistance(localRadius, 1)}
+        </Typography>
+      </div>
     </div>
   );
 


### PR DESCRIPTION
# Description

For radius search, other than the slider, add the text input radius option to allow numeric input for precise radius adjustment (e.g., 200m).

Before:

<img width="737" height="432" alt="Screenshot 2025-12-17 at 11 15 10 AM" src="https://github.com/user-attachments/assets/6ee3b881-b747-45d6-8c80-dc7b8cd55f5c" />


After:

Currently looks like this:
<img width="1008" height="502" alt="Screenshot 2025-12-17 at 11 12 54 AM" src="https://github.com/user-attachments/assets/0e0e437b-ff0e-425f-afab-71470109a80d" />


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-432-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-432-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)