### PR TITLE
chore: Update bcgov/action-test-and-analyse to latest version to support nod…

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -43,7 +43,7 @@ jobs:
           - dir: frontend
             token: SONAR_TOKEN_FRONTEND
     steps:
-      - uses: bcgov/action-test-and-analyse@v1.7.0
+      - uses: bcgov/action-test-and-analyse@v1.6.0
         env:
           LOG_LEVEL: info
           LOG_FILE_LOCATION: /tmp/sites-%DATE%.log

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -43,7 +43,7 @@ jobs:
           - dir: frontend
             token: SONAR_TOKEN_FRONTEND
     steps:
-      - uses: bcgov/action-test-and-analyse@v1.2.1
+      - uses: bcgov/action-test-and-analyse@v1.7.0
         env:
           LOG_LEVEL: info
           LOG_FILE_LOCATION: /tmp/sites-%DATE%.log


### PR DESCRIPTION

# Description

We're using this action https://github.com/bcgov/action-test-and-analyse with a pinned 1.2.1 version in analysis.yml. The current version is 1.7.0 which runs a currently supported version of ubuntu and node. Thus updating the same.


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-440-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-440-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)