### PR TITLE
chore: Increase pgbackrest backup storage.

### DIFF
--- a/charts/crunchy/values.yaml
+++ b/charts/crunchy/values.yaml
@@ -67,7 +67,7 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       incrementalBackupSchedule: 0 0,12 * * * # every 12 hour incremental
       volume:
         accessModes: "ReadWriteOnce"
-        storage: 512Mi
+        storage: 1Gi
         storageClassName: netapp-file-backup
 
     config:


### PR DESCRIPTION
The storage was full, and when I examined it, it turned out that the size of the daily backup has grown to large for 512Mi storage.


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-441-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-441-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)