### PR TITLE
feat: Implement notation soft delete endpoint

### DIFF
--- a/backend/src/app/dto/notation.dto.ts
+++ b/backend/src/app/dto/notation.dto.ts
@@ -53,6 +53,9 @@ export class NotationDto extends ChangeAuditObjectTypeDTO {
   @Field({ nullable: true })
   whenUpdated: Date | null;
 
+  @Field({ nullable: true })
+  whenDeleted: Date | null;
+
   @Field(() => [NotationParticipantDto], { nullable: true })
   notationParticipant: NotationParticipantDto[] | null;
 }

--- a/backend/src/app/entities/events.entity.ts
+++ b/backend/src/app/entities/events.entity.ts
@@ -112,6 +112,13 @@ export class Events extends ChangeAuditEntity {
   })
   whenUpdated: Date | null;
 
+  @Field({ nullable: true })
+  @Column('timestamp without time zone', {
+    name: 'when_deleted',
+    nullable: true,
+  })
+  whenDeleted: Date | null;
+
   //Make this nullable because we are not using it anymore and keeing it for historical data
   @Field({ nullable: true })
   @Column('smallint', { name: 'rwm_flag', nullable: true })

--- a/backend/src/app/resolvers/notation/notation.resolver.spec.ts
+++ b/backend/src/app/resolvers/notation/notation.resolver.spec.ts
@@ -20,6 +20,7 @@ describe('NotationResolver', () => {
           provide: NotationService,
           useValue: {
             getSiteNotationBySiteId: jest.fn(),
+            deleteSiteNotation: jest.fn(),
           },
         },
         {
@@ -79,6 +80,7 @@ describe('NotationResolver', () => {
         srValue: false,
         whenCreated: new Date('2024-07-17'),
         whenUpdated: new Date('2024-07-17'),
+        whenDeleted: null,
         notationParticipant: [
           {
             eventParticId: 'GUID001',
@@ -243,5 +245,103 @@ describe('NotationResolver', () => {
 
     expect(result.success).toEqual(true);
     expect(result.data).toHaveLength(1000);
+  });
+
+  describe('deleteSiteNotation', () => {
+    it('should delete a site notation successfully', async () => {
+      const eventId = '123';
+      const mockDeleteResult = true;
+      const expectedResult: NotationResponse = {
+        message: 'Site Notation deleted successfully',
+        httpStatusCode: 200,
+        success: true,
+        data: null,
+      };
+
+      jest
+        .spyOn(notationService, 'deleteSiteNotation')
+        .mockResolvedValueOnce(mockDeleteResult);
+      const user = {
+        identity_provider: UserTypeEum.IDIR,
+      };
+      const result = await resolver.deleteSiteNotation(eventId, user);
+
+      expect(result).toEqual(expectedResult);
+      expect(notationService.deleteSiteNotation).toHaveBeenCalledWith(
+        eventId,
+        user,
+      );
+      expect(genericResponseProvider.createResponse).toHaveBeenCalledWith(
+        'Site Notation deleted successfully',
+        200,
+        true,
+        null,
+      );
+    });
+
+    it('should return error message if site notation not found for deletion', async () => {
+      const eventId = '123';
+      const mockDeleteResult = false;
+      const expectedResult: NotationResponse = {
+        message: `Site Notation not found for event id: ${eventId}`,
+        httpStatusCode: 404,
+        success: false,
+        data: null,
+      };
+
+      jest
+        .spyOn(notationService, 'deleteSiteNotation')
+        .mockResolvedValueOnce(mockDeleteResult);
+      const user = {
+        identity_provider: UserTypeEum.IDIR,
+      };
+      const result = await resolver.deleteSiteNotation(eventId, user);
+
+      expect(result).toEqual(expectedResult);
+      expect(notationService.deleteSiteNotation).toHaveBeenCalledWith(
+        eventId,
+        user,
+      );
+      expect(genericResponseProvider.createResponse).toHaveBeenCalledWith(
+        `Site Notation not found for event id: ${eventId}`,
+        404,
+        false,
+        null,
+      );
+    });
+
+    it('should validate eventId parameter type', async () => {
+      const eventId = 123; // Invalid type
+      const mockDeleteResult = false;
+
+      jest
+        .spyOn(notationService, 'deleteSiteNotation')
+        .mockResolvedValueOnce(mockDeleteResult);
+      const user = {
+        identity_provider: UserTypeEum.IDIR,
+      };
+      const result = await resolver.deleteSiteNotation(eventId as any, user);
+
+      expect(result.httpStatusCode).toEqual(404);
+      expect(result.success).toEqual(false);
+      expect(result.message).toContain(
+        `Site Notation not found for event id: ${eventId}`,
+      );
+    });
+
+    it('should return an error for empty eventId parameter', async () => {
+      const eventId = '';
+      const mockDeleteResult = false;
+      const user = {
+        identity_provider: UserTypeEum.IDIR,
+      };
+      const result = await resolver.deleteSiteNotation(eventId, user);
+
+      expect(result.httpStatusCode).toEqual(404);
+      expect(result.success).toEqual(false);
+      expect(result.message).toContain(
+        'Site Notation not found for event id: ',
+      );
+    });
   });
 });

--- a/backend/src/app/resolvers/notation/notation.resolver.ts
+++ b/backend/src/app/resolvers/notation/notation.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Query, Resolver } from '@nestjs/graphql';
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { HttpStatus, UsePipes } from '@nestjs/common';
 import {
   AuthenticatedUser,
@@ -68,6 +68,40 @@ export class NotationResolver {
       );
       return this.genericResponseProvider.createResponse(
         `Site Notation data not found for site id: ${siteId}`,
+        HttpStatus.NOT_FOUND,
+        false,
+        null,
+      );
+    }
+  }
+
+  @Roles({
+    roles: [CustomRoles.Internal, CustomRoles.SiteRegistrar],
+    mode: RoleMatchingMode.ANY,
+  })
+  @Mutation(() => NotationResponse, { name: 'deleteSiteNotation' })
+  @UsePipes(new GenericValidationPipe())
+  async deleteSiteNotation(
+    @Args('eventId', { type: () => String }) eventId: string,
+    @AuthenticatedUser() user: any,
+  ) {
+    this.sitesLogger.log(
+      'NotationResolver.deleteSiteNotation() start eventId:' + eventId,
+    );
+
+    const result = await this.notationService.deleteSiteNotation(eventId, user);
+    if (result) {
+      this.sitesLogger.log('NotationResolver.deleteSiteNotation() RES:200 end');
+      return this.genericResponseProvider.createResponse(
+        'Site Notation deleted successfully',
+        HttpStatus.OK,
+        true,
+        null,
+      );
+    } else {
+      this.sitesLogger.log('NotationResolver.deleteSiteNotation() RES:404 end');
+      return this.genericResponseProvider.createResponse(
+        `Site Notation not found for event id: ${eventId}`,
         HttpStatus.NOT_FOUND,
         false,
         null,

--- a/backend/src/app/services/notation/notation.service.spec.ts
+++ b/backend/src/app/services/notation/notation.service.spec.ts
@@ -69,6 +69,7 @@ describe('NotationService', () => {
           whoCreated: 'creator123',
           whoUpdated: null,
           whenCreated: new Date(),
+          whenDeleted: null,
           whenUpdated: null,
           rwmFlag: 1,
           rwmNoteFlag: 0,
@@ -194,6 +195,7 @@ describe('NotationService', () => {
           whoUpdated: null,
           whenCreated: new Date(),
           whenUpdated: null,
+          whenDeleted: null,
           rwmFlag: 1,
           rwmNoteFlag: 0,
           rwmApprovalDate: new Date(),
@@ -267,6 +269,7 @@ describe('NotationService', () => {
           whoUpdated: null,
           whenCreated: new Date(),
           whenUpdated: null,
+          whenDeleted: null,
           rwmFlag: 1,
           rwmNoteFlag: 0,
           rwmApprovalDate: new Date(),
@@ -330,6 +333,7 @@ describe('NotationService', () => {
           whoUpdated: null,
           whenCreated: new Date(),
           whenUpdated: null,
+          whenDeleted: null,
           rwmFlag: 1,
           rwmNoteFlag: 0,
           rwmApprovalDate: new Date(),
@@ -421,6 +425,84 @@ describe('NotationService', () => {
       await expect(
         service.getSiteNotationBySiteId(siteId, false, user),
       ).rejects.toThrow(mockError);
+    });
+  });
+
+  describe('deleteSiteNotation', () => {
+    it('should return true when event is successfully deleted', async () => {
+      const eventId = 'event1';
+      const mockEvent = {
+        id: eventId,
+        siteId: 'site1',
+        eventDate: new Date(),
+        completionDate: new Date(),
+        etypCode: 'ETYP01',
+        psnorgId: 'PSNORG01',
+        spId: 'SP01',
+        requiredAction: 'Complete task X',
+        note: 'This is a note about the event.',
+        regionAppFlag: 'Y',
+        regionUserid: 'user123',
+        regionDate: new Date(),
+        whoCreated: 'creator123',
+        whoUpdated: null,
+        whenCreated: new Date(),
+        whenUpdated: null,
+        whenDeleted: null,
+        rwmFlag: 1,
+        rwmNoteFlag: 0,
+        rwmApprovalDate: new Date(),
+        eclsCode: 'ECLS01',
+        requirementDueDate: new Date(),
+        requirementReceivedDate: new Date(),
+        conditionsTexts: null,
+        eventTypeCd: null,
+        site: null,
+        userAction: 'pending',
+        srAction: 'pending',
+        eventPartics: [],
+      };
+      jest
+        .spyOn(notationRepository, 'findOne')
+        .mockResolvedValueOnce(mockEvent);
+      jest.spyOn(notationRepository, 'save').mockResolvedValueOnce(mockEvent);
+
+      const user = {
+        identity_provider: UserTypeEum.IDIR,
+      };
+      const result = await service.deleteSiteNotation(eventId, user);
+
+      expect(result).toBe(true);
+      expect(mockEvent.whenDeleted).toBeDefined();
+    });
+
+    it('should return false when event is not found', async () => {
+      const eventId = 'nonExistentEvent';
+      jest.spyOn(notationRepository, 'findOne').mockResolvedValueOnce(null);
+
+      const user = {
+        identity_provider: UserTypeEum.IDIR,
+      };
+      const result = await service.deleteSiteNotation(eventId, user);
+
+      expect(result).toBe(false);
+    });
+
+    it('should throw an error when repository throws an error', async () => {
+      const eventId = 'event1';
+      const mockError = new Error(
+        `Failed to delete site notation with event ID: ${eventId}`,
+      );
+      jest
+        .spyOn(notationRepository, 'findOne')
+        .mockRejectedValueOnce(mockError);
+
+      const user = {
+        identity_provider: UserTypeEum.IDIR,
+      };
+      await expect(service.deleteSiteNotation(eventId, user)).rejects.toThrow(
+        mockError,
+      );
     });
   });
 });

--- a/backend/src/app/services/notation/notation.service.ts
+++ b/backend/src/app/services/notation/notation.service.ts
@@ -126,6 +126,7 @@ export class NotationService {
             srAction: event?.srAction === SRApprovalStatusEnum.PUBLIC,
             whenCreated: event?.whenCreated,
             whenUpdated: event?.whenUpdated,
+            whenDeleted: event?.whenDeleted,
             notationParticipant: eventParticsForEvent?.map((partic) => ({
               eventParticId: partic?.id,
               eventId: partic?.eventId,
@@ -156,6 +157,49 @@ export class NotationService {
       throw new HttpException(
         `Failed to retrieve site notations by site ID: ${siteId}`,
         HttpStatus.NOT_FOUND,
+      );
+    }
+  }
+
+  /**
+   * Soft deletes a notation by updating the whenDeleted timestamp
+   *
+   * @param eventId - The ID of the event (notation) to delete
+   * @param user - The authenticated user performing the deletion
+   * @returns true if deletion was successful, false otherwise
+   * @throws Error if there's an issue with the deletion
+   */
+  async deleteSiteNotation(eventId: string, user: any): Promise<boolean> {
+    this.sitesLogger.log('NotationService.deleteSiteNotation() start');
+    this.sitesLogger.debug('NotationService.deleteSiteNotation() start');
+
+    try {
+      const eventToDelete = await this.notationRepository.findOne({
+        where: { id: eventId },
+      });
+
+      if (!eventToDelete) {
+        this.sitesLogger.log(
+          `NotationService.deleteSiteNotation() - Event not found: ${eventId}`,
+        );
+        return false;
+      }
+
+      eventToDelete.whenDeleted = new Date();
+
+      await this.notationRepository.save(eventToDelete);
+
+      this.sitesLogger.log('NotationService.deleteSiteNotation() end');
+      this.sitesLogger.debug('NotationService.deleteSiteNotation() end');
+      return true;
+    } catch (error) {
+      this.sitesLogger.error(
+        'Exception occurred in NotationService.deleteSiteNotation() end',
+        JSON.stringify(error),
+      );
+      throw new HttpException(
+        `Failed to delete site notation with event ID: ${eventId}`,
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }

--- a/backend/src/app/services/snapshot/snapshot.service.spec.ts
+++ b/backend/src/app/services/snapshot/snapshot.service.spec.ts
@@ -96,6 +96,7 @@ describe('SnapshotService', () => {
       regionDate: new Date(),
       whoCreated: 'creator123',
       whoUpdated: null,
+      whenDeleted: null,
       whenCreated: new Date(),
       whenUpdated: null,
       rwmFlag: 1,

--- a/backend/src/migrations/1768251167674-master-script.ts
+++ b/backend/src/migrations/1768251167674-master-script.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MasterScript1768251167674 implements MigrationInterface {
+  name = 'MasterScript1768251167674';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "sites"."events" ADD "when_deleted" TIMESTAMP`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "sites"."events" DROP COLUMN "when_deleted"`,
+    );
+  }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This introduces a new GraphQL endpoint to soft delete a notation. Since these
are still displayed on the front end, I did *not* update the
`getSiteNotationBySiteId` endpoint to filter these notations.

I expect that the front end will sort the notations and bin them into the
normal list and the archive list (collapsed by default).

Contributes to [SRS-1155](https://env-epd.atlassian.net/browse/SRS-1155)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

-[x] Unit testing passes
-[x] The following graphql queries behave as expected:

Delete a notation:
```graphql
mutation DeleteSiteNotation($eventId: String!) {
  deleteSiteNotation(eventId: $eventId) {
    message
    httpStatusCode
    success
  }
}
```
```json
{
  "eventId": "4829"
}
```

Query to ensure the notation returns the `deletedAt` property correctly:
```graphql
query GetSiteNotationBySiteId($siteId: String!, $pending: Boolean) {
  getSiteNotationBySiteId(siteId: $siteId, pending: $pending) {
    message
    httpStatusCode
    success
    data {
      id
      siteId
      note
      whenDeleted
    }
  }
}
```
```json
{
  "siteId": "411"
}
```



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-444-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-444-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)