### PR TITLE
fix: Returns all sites issue when user enters 3+ blank spaces

### DIFF
--- a/backend/src/app/services/site/site.service.ts
+++ b/backend/src/app/services/site/site.service.ts
@@ -163,212 +163,223 @@ export class SiteService {
     const siteUtil: SiteUtil = new SiteUtil();
     const response = new SearchSiteResponse();
 
-    const query = this.siteRepository.createQueryBuilder('sites');
+    if (!searchParam?.trim()) {
+      response.sites = [];
+      response.count = 0;
+      response.page = page;
+      response.pageSize = pageSize;
+      return response;
+    } else {
+      const query = this.siteRepository.createQueryBuilder('sites');
 
-    if (siteIds && siteIds.length === 0) {
-      throw new HttpException(
-        `If provided, siteIds filter array must not be empty`,
-        HttpStatus.BAD_REQUEST,
-      );
-    } else if (siteIds && siteIds.length > 0) {
-      query.whereInIds(siteIds);
+      if (siteIds && siteIds.length === 0) {
+        throw new HttpException(
+          `If provided, siteIds filter array must not be empty`,
+          HttpStatus.BAD_REQUEST,
+        );
+      } else if (siteIds && siteIds.length > 0) {
+        query.whereInIds(siteIds);
+      }
+
+      let pid;
+      if (searchParam?.length === 11 || searchParam?.length === 9) {
+        pid = searchParam.replace(/-/g, '');
+      }
+
+      if (pid) {
+        query
+          .innerJoin('sites.siteSubdivisions', 'siteSubdivisions')
+          .innerJoin('siteSubdivisions.subdivision', 'subdivision');
+      }
+
+      if (searchParam?.trim()) {
+        const keywords = searchParam.trim().toLowerCase().split(/\s+/);
+        query.andWhere(
+          new Brackets((qb) => {
+            for (const word of keywords) {
+              qb.andWhere(
+                new Brackets((subQb) => {
+                  subQb
+                    .orWhere('LOWER(sites.addr_line_1) LIKE :word', {
+                      word: `%${word}%`,
+                    })
+                    .orWhere('LOWER(sites.addr_line_2) LIKE :word', {
+                      word: `%${word}%`,
+                    })
+                    .orWhere('LOWER(sites.addr_line_3) LIKE :word', {
+                      word: `%${word}%`,
+                    })
+                    .orWhere('LOWER(sites.addr_line_4) LIKE :word', {
+                      word: `%${word}%`,
+                    })
+                    .orWhere('LOWER(sites.city) LIKE :word', {
+                      word: `%${word}%`,
+                    })
+                    .orWhere('LOWER(sites.common_name) LIKE :word', {
+                      word: `%${word}%`,
+                    })
+                    .orWhere('LOWER(sites.provState) LIKE :word', {
+                      word: `%${word}%`,
+                    })
+                    .orWhere('LOWER(sites.postalCode) LIKE :word', {
+                      word: `%${word}%`,
+                    })
+                    .orWhere('CAST(sites.id AS TEXT) LIKE :word', {
+                      word: `%${word}%`,
+                    });
+                }),
+              );
+            }
+            if (pid) {
+              qb.orWhere('subdivision.pid = :pid', { pid });
+              qb.orWhere('subdivision.pin = :pin', { pin: pid });
+            }
+          }),
+        );
+      }
+
+      if (!userInfo || userInfo?.identity_provider !== UserTypeEum.IDIR) {
+        query.andWhere('sites.srAction = :srAction', {
+          srAction: SRApprovalStatusEnum.PUBLIC,
+        });
+      }
+
+      if (id) {
+        const ids = id.split(',').map((v) => v.trim());
+        query.andWhere('sites.id IN (:...ids)', { ids });
+      }
+
+      if (srStatus) {
+        query.andWhere('sites.srStatus = :srStatus', { srStatus: srStatus });
+      }
+
+      if (siteRiskCode) {
+        query.andWhere('sites.site_risk_code = :siteRiskCode', {
+          siteRiskCode: siteRiskCode,
+        });
+      }
+
+      if (commonName) {
+        query.andWhere('sites.common_name = :commonName', {
+          commonName: commonName,
+        });
+      }
+
+      if (addrLine_1) {
+        const cleanedAddress = siteUtil.removeSpecialCharacters(addrLine_1);
+        query.andWhere(
+          `regexp_replace(concat_ws('', sites.addr_line_1, sites.addr_line_2, sites.addr_line_3, sites.addr_line_4), '[^a-zA-Z0-9]', '', 'g') LIKE :cleanedAddress`,
+          { cleanedAddress: `%${cleanedAddress}%` },
+        );
+      }
+
+      if (city) query.andWhere('sites.city = :city', { city });
+      if (whoCreated)
+        query.andWhere('sites.who_created = :whoCreated', { whoCreated });
+      if (latlongReliabilityFlag)
+        query.andWhere(
+          'sites.latlong_reliability_flag = :latlongReliabilityFlag',
+          { latlongReliabilityFlag },
+        );
+
+      if (latdeg) query.andWhere('sites.latdeg = :latdeg', { latdeg });
+      if (latDegrees)
+        query.andWhere('sites.lat_degrees = :latDegrees', { latDegrees });
+      if (latMinutes)
+        query.andWhere('sites.lat_minutes = :latMinutes', { latMinutes });
+      if (latSeconds)
+        query.andWhere('sites.lat_seconds = :latSeconds', { latSeconds });
+      if (longdeg) query.andWhere('sites.longdeg = :longdeg', { longdeg });
+      if (longDegrees)
+        query.andWhere('sites.long_degrees = :longDeg', {
+          longDeg: longDegrees,
+        });
+      if (longMinutes)
+        query.andWhere('sites.long_minutes = :longMinutes', { longMinutes });
+      if (longSeconds)
+        query.andWhere('sites.long_seconds = :longSeconds', { longSeconds });
+
+      if (
+        whenCreated?.length === 2 &&
+        whenCreated.every((date) => date instanceof Date)
+      ) {
+        query.andWhere('sites.whenCreated BETWEEN :start AND :end', {
+          start: whenCreated[0],
+          end: whenCreated[1],
+        });
+      }
+
+      if (
+        whenUpdated?.length === 2 &&
+        whenUpdated.every((date) => date instanceof Date)
+      ) {
+        query.andWhere('sites.whenUpdated BETWEEN :start AND :end', {
+          start: whenUpdated[0],
+          end: whenUpdated[1],
+        });
+      }
+
+      const sortFieldMap: Record<SiteSortBy, string> = {
+        [SiteSortBy.ID]: 'sites.id',
+        [SiteSortBy.SR_STATUS]: 'sites.srStatus',
+        [SiteSortBy.SITE_RISK_CODE]: 'sites.site_risk_code',
+        [SiteSortBy.COMMON_NAME]: 'sites.common_name',
+        [SiteSortBy.CITY]: 'sites.city',
+        [SiteSortBy.SITE_ADDRESS]: `
+        CASE
+          WHEN sites.addr_line_1 IS NOT NULL THEN sites.addr_line_1
+          WHEN sites.addr_line_2 IS NOT NULL THEN sites.addr_line_2
+          WHEN sites.addr_line_3 IS NOT NULL THEN sites.addr_line_3
+          ELSE ''
+        END
+      `,
+        [SiteSortBy.WHO_CREATED]: 'sites.who_created',
+        [SiteSortBy.LAT_DEGREES_MINUTES_SECONDS]: `
+        CASE
+          WHEN sites.lat_degrees IS NOT NULL THEN sites.lat_degrees
+          WHEN sites.lat_minutes IS NOT NULL THEN sites.lat_minutes
+          WHEN sites.lat_seconds IS NOT NULL THEN sites.lat_seconds
+          ELSE NULL
+        END
+      `,
+        [SiteSortBy.LONG_DEGREES_MINUTES_SECONDS]: `
+        CASE
+          WHEN sites.long_degrees IS NOT NULL THEN sites.long_degrees
+          WHEN sites.long_minutes IS NOT NULL THEN sites.long_minutes
+          WHEN sites.long_seconds IS NOT NULL THEN sites.long_seconds
+          ELSE NULL
+        END
+      `,
+        [SiteSortBy.WHEN_CREATED]: 'sites.whenCreated',
+        [SiteSortBy.WHEN_UPDATED]: 'sites.whenUpdated',
+        [SiteSortBy.GENERAL_DESCRIPTION]: 'sites.general_description',
+        [SiteSortBy.LAT_LONG_RELIABILITY_FLAG]:
+          'sites.latlong_reliability_flag',
+        [SiteSortBy.LAT_DEG]: 'sites.latdeg',
+        [SiteSortBy.LONG_DEG]: 'sites.longdeg',
+        [SiteSortBy.CONSULTANT_SUBMITTED]: 'sites.consultant_submitted',
+      };
+
+      if (sortBy && sortFieldMap[sortBy]) {
+        query.orderBy(
+          sortFieldMap[sortBy],
+          sortByDir === SortByDirection.DESC ? 'DESC' : 'ASC',
+        );
+      }
+
+      const result = await query
+        .skip((page - 1) * pageSize)
+        .take(pageSize)
+        .getManyAndCount();
+
+      response.sites = result[0] || [];
+      response.count = result[1] || 0;
+      response.page = page;
+      response.pageSize = pageSize;
+
+      this.sitesLogger.log('SiteService.searchSites() end');
+      return response;
     }
-
-    let pid;
-    if (searchParam?.length === 11 || searchParam?.length === 9) {
-      pid = searchParam.replace(/-/g, '');
-    }
-
-    if (pid) {
-      query
-        .innerJoin('sites.siteSubdivisions', 'siteSubdivisions')
-        .innerJoin('siteSubdivisions.subdivision', 'subdivision');
-    }
-
-    if (searchParam?.trim()) {
-      const keywords = searchParam.trim().toLowerCase().split(/\s+/);
-      query.andWhere(
-        new Brackets((qb) => {
-          for (const word of keywords) {
-            qb.andWhere(
-              new Brackets((subQb) => {
-                subQb
-                  .orWhere('LOWER(sites.addr_line_1) LIKE :word', {
-                    word: `%${word}%`,
-                  })
-                  .orWhere('LOWER(sites.addr_line_2) LIKE :word', {
-                    word: `%${word}%`,
-                  })
-                  .orWhere('LOWER(sites.addr_line_3) LIKE :word', {
-                    word: `%${word}%`,
-                  })
-                  .orWhere('LOWER(sites.addr_line_4) LIKE :word', {
-                    word: `%${word}%`,
-                  })
-                  .orWhere('LOWER(sites.city) LIKE :word', {
-                    word: `%${word}%`,
-                  })
-                  .orWhere('LOWER(sites.common_name) LIKE :word', {
-                    word: `%${word}%`,
-                  })
-                  .orWhere('LOWER(sites.provState) LIKE :word', {
-                    word: `%${word}%`,
-                  })
-                  .orWhere('LOWER(sites.postalCode) LIKE :word', {
-                    word: `%${word}%`,
-                  })
-                  .orWhere('CAST(sites.id AS TEXT) LIKE :word', {
-                    word: `%${word}%`,
-                  });
-              }),
-            );
-          }
-          if (pid) {
-            qb.orWhere('subdivision.pid = :pid', { pid });
-            qb.orWhere('subdivision.pin = :pin', { pin: pid });
-          }
-        }),
-      );
-    }
-
-    if (!userInfo || userInfo?.identity_provider !== UserTypeEum.IDIR) {
-      query.andWhere('sites.srAction = :srAction', {
-        srAction: SRApprovalStatusEnum.PUBLIC,
-      });
-    }
-
-    if (id) {
-      const ids = id.split(',').map((v) => v.trim());
-      query.andWhere('sites.id IN (:...ids)', { ids });
-    }
-
-    if (srStatus) {
-      query.andWhere('sites.srStatus = :srStatus', { srStatus: srStatus });
-    }
-
-    if (siteRiskCode) {
-      query.andWhere('sites.site_risk_code = :siteRiskCode', {
-        siteRiskCode: siteRiskCode,
-      });
-    }
-
-    if (commonName) {
-      query.andWhere('sites.common_name = :commonName', {
-        commonName: commonName,
-      });
-    }
-
-    if (addrLine_1) {
-      const cleanedAddress = siteUtil.removeSpecialCharacters(addrLine_1);
-      query.andWhere(
-        `regexp_replace(concat_ws('', sites.addr_line_1, sites.addr_line_2, sites.addr_line_3, sites.addr_line_4), '[^a-zA-Z0-9]', '', 'g') LIKE :cleanedAddress`,
-        { cleanedAddress: `%${cleanedAddress}%` },
-      );
-    }
-
-    if (city) query.andWhere('sites.city = :city', { city });
-    if (whoCreated)
-      query.andWhere('sites.who_created = :whoCreated', { whoCreated });
-    if (latlongReliabilityFlag)
-      query.andWhere(
-        'sites.latlong_reliability_flag = :latlongReliabilityFlag',
-        { latlongReliabilityFlag },
-      );
-
-    if (latdeg) query.andWhere('sites.latdeg = :latdeg', { latdeg });
-    if (latDegrees)
-      query.andWhere('sites.lat_degrees = :latDegrees', { latDegrees });
-    if (latMinutes)
-      query.andWhere('sites.lat_minutes = :latMinutes', { latMinutes });
-    if (latSeconds)
-      query.andWhere('sites.lat_seconds = :latSeconds', { latSeconds });
-    if (longdeg) query.andWhere('sites.longdeg = :longdeg', { longdeg });
-    if (longDegrees)
-      query.andWhere('sites.long_degrees = :longDeg', { longDeg: longDegrees });
-    if (longMinutes)
-      query.andWhere('sites.long_minutes = :longMinutes', { longMinutes });
-    if (longSeconds)
-      query.andWhere('sites.long_seconds = :longSeconds', { longSeconds });
-
-    if (
-      whenCreated?.length === 2 &&
-      whenCreated.every((date) => date instanceof Date)
-    ) {
-      query.andWhere('sites.whenCreated BETWEEN :start AND :end', {
-        start: whenCreated[0],
-        end: whenCreated[1],
-      });
-    }
-
-    if (
-      whenUpdated?.length === 2 &&
-      whenUpdated.every((date) => date instanceof Date)
-    ) {
-      query.andWhere('sites.whenUpdated BETWEEN :start AND :end', {
-        start: whenUpdated[0],
-        end: whenUpdated[1],
-      });
-    }
-
-    const sortFieldMap: Record<SiteSortBy, string> = {
-      [SiteSortBy.ID]: 'sites.id',
-      [SiteSortBy.SR_STATUS]: 'sites.srStatus',
-      [SiteSortBy.SITE_RISK_CODE]: 'sites.site_risk_code',
-      [SiteSortBy.COMMON_NAME]: 'sites.common_name',
-      [SiteSortBy.CITY]: 'sites.city',
-      [SiteSortBy.SITE_ADDRESS]: `
-      CASE
-        WHEN sites.addr_line_1 IS NOT NULL THEN sites.addr_line_1
-        WHEN sites.addr_line_2 IS NOT NULL THEN sites.addr_line_2
-        WHEN sites.addr_line_3 IS NOT NULL THEN sites.addr_line_3
-        ELSE ''
-      END
-    `,
-      [SiteSortBy.WHO_CREATED]: 'sites.who_created',
-      [SiteSortBy.LAT_DEGREES_MINUTES_SECONDS]: `
-      CASE
-        WHEN sites.lat_degrees IS NOT NULL THEN sites.lat_degrees
-        WHEN sites.lat_minutes IS NOT NULL THEN sites.lat_minutes
-        WHEN sites.lat_seconds IS NOT NULL THEN sites.lat_seconds
-        ELSE NULL
-      END
-    `,
-      [SiteSortBy.LONG_DEGREES_MINUTES_SECONDS]: `
-      CASE
-        WHEN sites.long_degrees IS NOT NULL THEN sites.long_degrees
-        WHEN sites.long_minutes IS NOT NULL THEN sites.long_minutes
-        WHEN sites.long_seconds IS NOT NULL THEN sites.long_seconds
-        ELSE NULL
-      END
-    `,
-      [SiteSortBy.WHEN_CREATED]: 'sites.whenCreated',
-      [SiteSortBy.WHEN_UPDATED]: 'sites.whenUpdated',
-      [SiteSortBy.GENERAL_DESCRIPTION]: 'sites.general_description',
-      [SiteSortBy.LAT_LONG_RELIABILITY_FLAG]: 'sites.latlong_reliability_flag',
-      [SiteSortBy.LAT_DEG]: 'sites.latdeg',
-      [SiteSortBy.LONG_DEG]: 'sites.longdeg',
-      [SiteSortBy.CONSULTANT_SUBMITTED]: 'sites.consultant_submitted',
-    };
-
-    if (sortBy && sortFieldMap[sortBy]) {
-      query.orderBy(
-        sortFieldMap[sortBy],
-        sortByDir === SortByDirection.DESC ? 'DESC' : 'ASC',
-      );
-    }
-
-    const result = await query
-      .skip((page - 1) * pageSize)
-      .take(pageSize)
-      .getManyAndCount();
-
-    response.sites = result[0] || [];
-    response.count = result[1] || 0;
-    response.page = page;
-    response.pageSize = pageSize;
-
-    this.sitesLogger.log('SiteService.searchSites() end');
-    return response;
   }
 
   async mapSearch({

--- a/frontend/src/app/features/site/Search.tsx
+++ b/frontend/src/app/features/site/Search.tsx
@@ -229,8 +229,6 @@ const Search = () => {
       setSearchText(searchParam);
       setUserAction(false);
     }
-
-    // dispatch(fetchSiteRiskCd());
   }, [dispatch, searchParam, sites.length, status]);
 
   useEffect(() => {

--- a/frontend/src/app/features/site/Search.tsx
+++ b/frontend/src/app/features/site/Search.tsx
@@ -230,8 +230,12 @@ const Search = () => {
       setUserAction(false);
     }
 
-    dispatch(fetchSiteRiskCd());
+    // dispatch(fetchSiteRiskCd());
   }, [dispatch, searchParam, sites.length, status]);
+
+  useEffect(() => {
+    dispatch(fetchSiteRiskCd());
+  }, []);
 
   const handleRemoveFilter = (filter: any) => {
     setFormData((prevData) => {

--- a/frontend/src/app/features/site/SiteSearchSlice.test.ts
+++ b/frontend/src/app/features/site/SiteSearchSlice.test.ts
@@ -1,4 +1,4 @@
-import reducer, { fetchSearchSites } from './SiteSearchSlice';
+import siteSearchReducer, { fetchSearchSites } from './SiteSearchSlice';
 import { RequestStatus } from '../../helpers/requests/status';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
@@ -21,17 +21,21 @@ describe('siteSearchSlice', () => {
     status: RequestStatus.idle,
   };
 
+  beforeEach(() => {
+    mock.reset();
+  });
+
   afterEach(() => {
     mock.reset();
   });
 
   it('should return the initial state', () => {
-    expect(reducer(undefined, { type: '' })).toEqual(initialState);
+    expect(siteSearchReducer(undefined, { type: '' })).toEqual(initialState);
   });
 
   it('should handle fetchSearchSites.pending', () => {
     const action = { type: fetchSearchSites.pending.type };
-    const state = reducer(initialState, action);
+    const state = siteSearchReducer(initialState, action);
     expect(state.status).toEqual(RequestStatus.loading);
   });
 
@@ -47,7 +51,7 @@ describe('siteSearchSlice', () => {
       payload,
       meta: { arg: { searchParam: 'test', filter: {} } },
     };
-    const state = reducer(initialState, action);
+    const state = siteSearchReducer(initialState, action);
     expect(state.status).toEqual(RequestStatus.success);
     expect(state.sites).toEqual(payload.sites);
     expect(state.count).toBe(1);
@@ -59,7 +63,7 @@ describe('siteSearchSlice', () => {
       type: fetchSearchSites.rejected.type,
       error: { message: 'Request failed' },
     };
-    const state = reducer(initialState, action);
+    const state = siteSearchReducer(initialState, action);
     expect(state.status).toEqual(RequestStatus.failed);
     expect(state.error).toEqual('Request failed');
   });
@@ -107,6 +111,84 @@ describe('siteSearchSlice', () => {
     );
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ type: fetchSearchSites.rejected.type }),
+    );
+  });
+
+  it('should handle search param with 3 or more blank spaces by returning empty results', async () => {
+    const dispatch = jest.fn();
+    const thunk = fetchSearchSites({ searchParam: '   ' }); // 3 spaces
+    await thunk(dispatch, () => ({}), undefined);
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: fetchSearchSites.pending.type }),
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: fetchSearchSites.fulfilled.type,
+        payload: {
+          sites: [],
+          count: 0,
+          page: 1,
+          pageSize: 5,
+        },
+      }),
+    );
+  });
+
+  it('should handle search param with multiple blank spaces by returning empty results', async () => {
+    const dispatch = jest.fn();
+    const thunk = fetchSearchSites({ searchParam: '     ' }); // 5 spaces
+    await thunk(dispatch, () => ({}), undefined);
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: fetchSearchSites.pending.type }),
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: fetchSearchSites.fulfilled.type,
+        payload: {
+          sites: [],
+          count: 0,
+          page: 1,
+          pageSize: 5,
+        },
+      }),
+    );
+  });
+
+  it('should trim search param with leading and trailing spaces before making API call', async () => {
+    const mockResponse = {
+      data: {
+        data: {
+          searchSites: {
+            sites: [{ id: 456, name: 'Trimmed Site' }],
+            count: 1,
+            page: 1,
+            pageSize: 5,
+          },
+        },
+      },
+    };
+
+    mock.onPost(GRAPHQL).reply((config) => {
+      const requestData = JSON.parse(config.data);
+      // Verify that the searchParam was trimmed
+      expect(requestData.variables.searchParam).toBe('test');
+      return [200, mockResponse.data];
+    });
+
+    const dispatch = jest.fn();
+    const thunk = fetchSearchSites({ searchParam: '  test  ' }); // spaces around 'test'
+    await thunk(dispatch, () => ({}), undefined);
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: fetchSearchSites.pending.type }),
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: fetchSearchSites.fulfilled.type,
+        payload: mockResponse.data.data.searchSites,
+      }),
     );
   });
 });

--- a/frontend/src/app/features/site/SiteSearchSlice.ts
+++ b/frontend/src/app/features/site/SiteSearchSlice.ts
@@ -31,10 +31,20 @@ export const fetchSearchSites = createAsyncThunk(
     filter?: {};
   }) => {
     try {
+      const trimmedSearch = args.searchParam?.trim();
+      if (!trimmedSearch) {
+        // early return empty results
+        return {
+          sites: [],
+          count: 0,
+          page: args.page ?? initialState.page,
+          pageSize: args.pageSize ?? initialState.pageSize,
+        };
+      }
       const response = await getAxiosInstance().post(GRAPHQL, {
         query: print(graphQlSiteQuery()),
         variables: {
-          searchParam: args.searchParam,
+          searchParam: args.searchParam?.trim(),
           page: args.page ?? initialState.page,
           pageSize: args.pageSize ?? initialState.pageSize,
           sortBy: args.sortBy ?? initialState.sortBy,


### PR DESCRIPTION
 Returns all sites issue when user enters 3+ blank spaces

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-454-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-454-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)