### PR TITLE
fix: SRS-1432 external user documents banner

### DIFF
--- a/frontend/src/app/features/details/documents/Documents.tsx
+++ b/frontend/src/app/features/details/documents/Documents.tsx
@@ -741,8 +741,11 @@ const Documents: React.FC<IComponentProps> = ({ showPending = false }) => {
     return (
       <Alert variant={hasDocuments ? 'info' : 'warning'} data-testid="no-site">
         {hasDocuments
-          ? 'No documents found for this site. Please add documents to it.'
-          : 'Please create a site before adding documents. Once the site is created, you can add documents to it.'}
+          ? userType === UserType.Internal ?
+            'No documents found for this site. To inquire about documents, submit a Site Information Request form, or contact Advisor.SiteInformation@gov.bc.ca' :
+            'No documents found for this site. Please add documents to it.'
+          : 'Please create a site before adding documents. Once the site is created, you can add documents to it.'
+        }
       </Alert>
     );
   }


### PR DESCRIPTION
External User Documents Banner

Update banner to state “No documents found for this site. To inquire about documents, submit a Site Information Request form, or contact [Advisor.SiteInformation@gov.bc.ca](mailto:Advisor.SiteInformation@gov.bc.ca)”



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-458-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-458-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)