### PR TITLE
fix: SRS 1420: Fix generic error when creating a site.

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -1,5 +1,8 @@
 name: PR
 
+# This comment triggers the db deploy workflow (or at least it should)
+# Trigger db deploy
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review] # ready for review is not included by default, More than one activity type triggers this event. For information about each activity type, see "Webhook events and payloads." By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened. To trigger workflows by different activity types, use the types keyword. For more information, see "Workflow syntax for GitHub Actions."

--- a/backend/src/app/dto/siteBase.dto.ts
+++ b/backend/src/app/dto/siteBase.dto.ts
@@ -1,5 +1,10 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { Transform } from 'class-transformer';
+import { IsIn, IsOptional, IsString } from 'class-validator';
 import { ChangeAuditType } from './changeAuditEntity.dto';
+
+// Keep this in sync with the frontend SummaryConfig addrType options.
+export const VALID_ADDR_TYPES = ['CIVIC', 'MAILING', 'LEGAL', 'RA'] as const;
 
 @InputType({ isAbstract: true })
 @ObjectType({ isAbstract: true })
@@ -16,7 +21,14 @@ export class SiteBaseDto extends ChangeAuditType {
   @Field({ nullable: true })
   commonName: string;
 
-  @Field({ nullable: true })
+  @Field()
+  @Transform(({ value }) =>
+    typeof value === 'string' ? value.trim().toUpperCase() : value,
+  )
+  @IsString()
+  @IsIn(VALID_ADDR_TYPES, {
+    message: `addrType must be one of ${VALID_ADDR_TYPES.join(', ')}`,
+  })
   addrType: string;
 
   @Field()

--- a/backend/src/app/dto/siteBase.dto.ts
+++ b/backend/src/app/dto/siteBase.dto.ts
@@ -1,6 +1,6 @@
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { Transform } from 'class-transformer';
-import { IsIn, IsOptional, IsString } from 'class-validator';
+import { IsIn, IsString } from 'class-validator';
 import { ChangeAuditType } from './changeAuditEntity.dto';
 
 // Keep this in sync with the frontend SummaryConfig addrType options.

--- a/backend/src/app/resolvers/site/site.resolver.ts
+++ b/backend/src/app/resolvers/site/site.resolver.ts
@@ -24,7 +24,7 @@ import { Sites } from '../../entities/sites.entity';
 import { SiteService } from '../../services/site/site.service';
 import { DropdownDto, DropdownResponse } from '../../dto/dropdown.dto';
 import { GenericResponseProvider } from '../../dto/response/genericResponseProvider';
-import { HttpStatus, UsePipes } from '@nestjs/common';
+import { HttpStatus, UsePipes, ValidationPipe } from '@nestjs/common';
 import { GenericValidationPipe } from '../../utils/validations/genericValidationPipe';
 import { SaveSiteDetailsDTO } from '../../dto/saveSiteDetails.dto';
 import { CustomRoles } from '../../common/role';
@@ -122,7 +122,11 @@ export class SiteResolver {
   })
   @Mutation(() => SaveSiteDetailsResponse, { name: 'updateSiteDetails' })
   async updateSiteDetails(
-    @Args('siteDetailsDTO', { type: () => SaveSiteDetailsDTO })
+    @Args(
+      'siteDetailsDTO',
+      { type: () => SaveSiteDetailsDTO },
+      new ValidationPipe(),
+    )
     siteDetailsDTO: SaveSiteDetailsDTO,
     @AuthenticatedUser()
     user: any,

--- a/frontend/src/app/features/details/summary/SummaryConfig.tsx
+++ b/frontend/src/app/features/details/summary/SummaryConfig.tsx
@@ -183,10 +183,17 @@ export const GetSummaryConfig = () => {
       },
     },
     addrType: {
-      type: FormFieldType.Text,
+      type: FormFieldType.DropDown,
       label: 'Address Type',
-      placeholder: 'Please enter address type...',
+      placeholder: 'Please select address type...',
       graphQLPropertyName: 'addrType',
+      // Keep this list in sync with the backend VALID_ADDR_TYPES constant.
+      options: [
+        { key: 'CIVIC', value: 'Civic' },
+        { key: 'MAILING', value: 'Mailing' },
+        { key: 'LEGAL', value: 'Legal' },
+        { key: 'RA', value: 'RA' },
+      ],
       value: '',
       customLabelCss: 'custom-summary-lbl-text',
       customInputTextCss: 'custom-summary-input-text',

--- a/frontend/src/graphql/generated.ts
+++ b/frontend/src/graphql/generated.ts
@@ -1459,7 +1459,7 @@ export type SiteSummaryDto = {
   addrLine_2?: InputMaybe<Scalars['String']['input']>;
   addrLine_3?: InputMaybe<Scalars['String']['input']>;
   addrLine_4?: InputMaybe<Scalars['String']['input']>;
-  addrType?: InputMaybe<Scalars['String']['input']>;
+  addrType: Scalars['String']['input'];
   apiAction?: InputMaybe<Scalars['String']['input']>;
   bcerCode?: InputMaybe<Scalars['String']['input']>;
   city: Scalars['String']['input'];


### PR DESCRIPTION
# Description

- Marked address type as not optional in the site base DTO to bring it in line with the database requirement.
- Added Address type select widget with hardcoded values.
- Added backend validation DTO pipe for address type.
- Added backend normalization DTO Pipe for address type.

Fixes # SRS-1420

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- I tested that I can create new sites with the new widget.
- I tested (using the graphql playground) that values are both normalized or rejected depending on if they are valid.

## Further comments

There are no new unit tests for this bug fix because the fix is to use the nestJS validation pipeline, which is (theoretically) tested by the nestJS project.

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-459-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-459-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)