### PR TITLE
fix: red asterix for edit mode and external users

### DIFF
--- a/frontend/src/app/components/form/Form.tsx
+++ b/frontend/src/app/components/form/Form.tsx
@@ -104,7 +104,7 @@ const Form: React.FC<IFormRendererProps> = ({
                     handleInputChange(field.graphQLPropertyName, value)
                   }
                   type={field.type}
-                  validation={(editMode || srMode) ? field.validation: undefined}
+                  validation={(editMode || srMode) ? field.validation : undefined}
                   allowNumbersOnly={field.allowNumbersOnly}
                   isEditing={editMode ?? true}
                   srMode={srMode ?? false}

--- a/frontend/src/app/components/form/Form.tsx
+++ b/frontend/src/app/components/form/Form.tsx
@@ -247,7 +247,7 @@ const Form: React.FC<IFormRendererProps> = ({
                     handleInputChange(field.graphQLPropertyName, value)
                   }
                   srMode={srMode}
-                  validation={(editMode || srMode) ? field.validation: undefined}
+                  validation={(editMode || srMode) ? field.validation : undefined}
                 />
               )}
             </div>

--- a/frontend/src/app/components/form/Form.tsx
+++ b/frontend/src/app/components/form/Form.tsx
@@ -196,7 +196,7 @@ const Form: React.FC<IFormRendererProps> = ({
                   isEditing={editMode ?? true}
                   srMode={srMode ?? false}
                   isDisabled={field.isDisabled ?? false}
-                  validation={(editMode || srMode) ? field.validation: undefined}
+                  validation={(editMode || srMode) ? field.validation : undefined}
                 />
               )}
               {field.type === FormFieldType.Group && (

--- a/frontend/src/app/components/form/Form.tsx
+++ b/frontend/src/app/components/form/Form.tsx
@@ -228,7 +228,7 @@ const Form: React.FC<IFormRendererProps> = ({
                   customEditInputTextCss={field.customEditInputTextCss}
                   customPlaceholderCss={field.customPlaceholderCss}
                   customInfoMessage={field.customInfoMessage}
-                  validation={(editMode || srMode) ? field.validation: undefined}
+                  validation={(editMode || srMode) ? field.validation : undefined}
                   isDisabled={field.isDisabled}
                 />
               )}

--- a/frontend/src/app/components/form/Form.tsx
+++ b/frontend/src/app/components/form/Form.tsx
@@ -56,7 +56,7 @@ const Form: React.FC<IFormRendererProps> = ({
                     handleInputChange(field.graphQLPropertyName, value)
                   }
                   type={field.type}
-                  validation={field.validation}
+                  validation={(editMode || srMode) ? field.validation: undefined}
                   allowNumbersOnly={field.allowNumbersOnly}
                   isEditing={editMode ?? true}
                   srMode={srMode ?? false}
@@ -80,7 +80,7 @@ const Form: React.FC<IFormRendererProps> = ({
                   }
                   options={field.options || []}
                   type={FormFieldType.Text}
-                  validation={field.validation}
+                  validation={(editMode || srMode) ? field.validation: undefined}
                   allowNumbersOnly={field.allowNumbersOnly}
                   isEditing={editMode ?? true}
                   srMode={srMode ?? false}
@@ -104,7 +104,7 @@ const Form: React.FC<IFormRendererProps> = ({
                     handleInputChange(field.graphQLPropertyName, value)
                   }
                   type={field.type}
-                  validation={field.validation}
+                  validation={(editMode || srMode) ? field.validation: undefined}
                   allowNumbersOnly={field.allowNumbersOnly}
                   isEditing={editMode ?? true}
                   srMode={srMode ?? false}
@@ -131,7 +131,7 @@ const Form: React.FC<IFormRendererProps> = ({
                   isEditing={editMode ?? true}
                   isImage={field.isImage}
                   srMode={srMode ?? false}
-                  validation={field.validation}
+                  validation={(editMode || srMode) ? field.validation: undefined}
                   isDisabled={field.isDisabled}
                 />
               )}
@@ -157,7 +157,7 @@ const Form: React.FC<IFormRendererProps> = ({
                   isLoading={field.isLoading}
                   customInfoMessage={field.customInfoMessage}
                   isDisabled={field.isDisabled}
-                  validation={field.validation}
+                  validation={(editMode || srMode) ? field.validation: undefined}
                 />
               )}
               {field.type === FormFieldType.DateRange && (
@@ -176,7 +176,7 @@ const Form: React.FC<IFormRendererProps> = ({
                   type={field.type}
                   isEditing={editMode ?? true}
                   srMode={srMode ?? false}
-                  validation={field.validation}
+                  validation={(editMode || srMode) ? field.validation: undefined}
                 />
               )}
               {field.type === FormFieldType.Date && (
@@ -196,7 +196,7 @@ const Form: React.FC<IFormRendererProps> = ({
                   isEditing={editMode ?? true}
                   srMode={srMode ?? false}
                   isDisabled={field.isDisabled ?? false}
-                  validation={field.validation}
+                  validation={(editMode || srMode) ? field.validation: undefined}
                 />
               )}
               {field.type === FormFieldType.Group && (
@@ -228,7 +228,7 @@ const Form: React.FC<IFormRendererProps> = ({
                   customEditInputTextCss={field.customEditInputTextCss}
                   customPlaceholderCss={field.customPlaceholderCss}
                   customInfoMessage={field.customInfoMessage}
-                  validation={field.validation}
+                  validation={(editMode || srMode) ? field.validation: undefined}
                   isDisabled={field.isDisabled}
                 />
               )}
@@ -247,7 +247,7 @@ const Form: React.FC<IFormRendererProps> = ({
                     handleInputChange(field.graphQLPropertyName, value)
                   }
                   srMode={srMode}
-                  validation={field.validation}
+                  validation={(editMode || srMode) ? field.validation: undefined}
                 />
               )}
             </div>

--- a/frontend/src/app/components/form/Form.tsx
+++ b/frontend/src/app/components/form/Form.tsx
@@ -157,7 +157,7 @@ const Form: React.FC<IFormRendererProps> = ({
                   isLoading={field.isLoading}
                   customInfoMessage={field.customInfoMessage}
                   isDisabled={field.isDisabled}
-                  validation={(editMode || srMode) ? field.validation: undefined}
+                  validation={(editMode || srMode) ? field.validation : undefined}
                 />
               )}
               {field.type === FormFieldType.DateRange && (

--- a/frontend/src/app/components/form/Form.tsx
+++ b/frontend/src/app/components/form/Form.tsx
@@ -80,7 +80,7 @@ const Form: React.FC<IFormRendererProps> = ({
                   }
                   options={field.options || []}
                   type={FormFieldType.Text}
-                  validation={(editMode || srMode) ? field.validation: undefined}
+                  validation={(editMode || srMode) ? field.validation : undefined}
                   allowNumbersOnly={field.allowNumbersOnly}
                   isEditing={editMode ?? true}
                   srMode={srMode ?? false}

--- a/frontend/src/app/components/form/Form.tsx
+++ b/frontend/src/app/components/form/Form.tsx
@@ -56,7 +56,7 @@ const Form: React.FC<IFormRendererProps> = ({
                     handleInputChange(field.graphQLPropertyName, value)
                   }
                   type={field.type}
-                  validation={(editMode || srMode) ? field.validation: undefined}
+                  validation={(editMode || srMode) ? field.validation : undefined}
                   allowNumbersOnly={field.allowNumbersOnly}
                   isEditing={editMode ?? true}
                   srMode={srMode ?? false}

--- a/frontend/src/app/components/form/Form.tsx
+++ b/frontend/src/app/components/form/Form.tsx
@@ -131,7 +131,7 @@ const Form: React.FC<IFormRendererProps> = ({
                   isEditing={editMode ?? true}
                   isImage={field.isImage}
                   srMode={srMode ?? false}
-                  validation={(editMode || srMode) ? field.validation: undefined}
+                  validation={(editMode || srMode) ? field.validation : undefined}
                   isDisabled={field.isDisabled}
                 />
               )}

--- a/frontend/src/app/components/form/Form.tsx
+++ b/frontend/src/app/components/form/Form.tsx
@@ -176,7 +176,7 @@ const Form: React.FC<IFormRendererProps> = ({
                   type={field.type}
                   isEditing={editMode ?? true}
                   srMode={srMode ?? false}
-                  validation={(editMode || srMode) ? field.validation: undefined}
+                  validation={(editMode || srMode) ? field.validation : undefined}
                 />
               )}
               {field.type === FormFieldType.Date && (


### PR DESCRIPTION
Bug fix 
Asterisk is showing in view mode (should appear only in edit mode).

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-466-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-466-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)