### PR TITLE
chore: SRS-1469: squelch PDB Alerts

### DIFF
--- a/charts/app/values-prod.yaml
+++ b/charts/app/values-prod.yaml
@@ -10,10 +10,8 @@ global:
 backend:
   pdb:
     enabled: true
-    # Trying to force replicaCount to 1 during deployment so we only run the seed data scripts once.
 
-  # Temporarily going for 1 pod max, so that we only run the SEED_DATA import scripts once, instead of twice concurrently.
-  replicaCount: 1
+  replicaCount: 2
   autoscaling:
     #-- enable or disable autoscaling.
     enabled: true

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -38,10 +38,7 @@ backend:
   #-- the deployment strategy, can be "Recreate" or "RollingUpdate"
   deploymentStrategy: RollingUpdate
 
-  # Temporarily going for 1 pod max, so that we only run the SEED_DATA import scripts once, instead of twice concurrently.
-  # Looks like we might need to fix initContainers running for multiple pods. Scaling up works as it only happens once.
-  # Otherwise initial deploy looks like it needs to just be 1 pods.
-  replicaCount: 1
+  replicaCount: 2
   #-- autoscaling for the component. it is optional and is an object.
   autoscaling:
     #-- enable or disable autoscaling.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Increase the backend replica count to 2. This will stop alerts telling us that the replica count and the disruption budget are the same.

It was temporarily lowered to run importing scripts but, if they are done, we can increase it back to an acceptable value.

Fixes # SRS-1469

## Type of change

Please delete options that are not relevant.

- [x] Devops chore

## Further comments

<img width="1101" height="176" alt="Screenshot 2026-03-17 at 10 27 09 AM" src="https://github.com/user-attachments/assets/a3f2005e-e539-41b7-8423-0f4e636c4b36" />

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-468-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-468-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-468-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-468-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)