### PR TITLE
fix: Show the selected site on Map

### DIFF
--- a/frontend/src/app/features/map/MapView.test.tsx
+++ b/frontend/src/app/features/map/MapView.test.tsx
@@ -1,0 +1,237 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { LatLngTuple, Map } from 'leaflet';
+
+const mockLeafletMap: Partial<Map> = {
+  flyToBounds: jest.fn(),
+  flyTo: jest.fn(),
+} as Partial<Map>;
+
+const siteData = [
+  {
+    id: 's1',
+    addrLine_1: '123',
+    latdeg: 49,
+    longdeg: -123,
+  },
+];
+
+jest.mock('react-leaflet', () => {
+  const React = require('react') as typeof import('react');
+  return {
+    __esModule: true,
+    MapContainer: React.forwardRef(
+      (
+        {
+          children,
+        }: {
+          children: React.ReactNode;
+        },
+        ref: { current: Partial<Map> | null },
+      ) => {
+        React.useLayoutEffect(() => {
+          if (ref && typeof ref === 'object') {
+            ref.current = mockLeafletMap;
+          }
+        }, [ref]);
+
+        return <div data-testid="map-container">{children}</div>;
+      },
+    ),
+    TileLayer: () => <div data-testid="tile-layer" />,
+  };
+});
+
+jest.mock('./mapSearchContext/MapSearchContext', () => ({
+  __esModule: true,
+  MapSearchQueryProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  useMapSearchContext: jest.fn(),
+}));
+
+jest.mock('./mapViewHelpers', () => {
+  const actual = jest.requireActual('./mapViewHelpers') as Record<
+    string,
+    unknown
+  >;
+  return {
+    __esModule: true,
+    ...actual,
+    flyToBoundsForTextSearch: jest.fn(),
+    sitesWhenMapToolCleared: jest.fn(
+      (activeTool: unknown, mapSearchData: unknown) =>
+        activeTool !== null ? null : (mapSearchData ?? []),
+    ),
+  };
+});
+
+jest.mock('../../../graphql/generated', () => {
+  return {
+    __esModule: true,
+    useMapSearchQuery: ({
+      onCompleted,
+    }: {
+      onCompleted?: (args: any) => void;
+    }) => {
+      // Trigger the callback after the initial render commit.
+      // This avoids "setState during render" issues and keeps the mocked
+      // hook return value stable for `MapView` to destructure.
+      if (onCompleted) {
+        setTimeout(() => {
+          onCompleted({ mapSearch: { data: siteData } });
+        }, 0);
+      }
+
+      return {
+        data: { mapSearch: { data: siteData } },
+        loading: false,
+      };
+    },
+    useMapSearch_FindSiteBySiteIdQuery: () => ({
+      data: undefined,
+    }),
+  };
+});
+
+jest.mock('./useFlyToSelectedSite', () => ({
+  __esModule: true,
+  useFlyToSelectedSite: jest.fn(),
+}));
+
+jest.mock('./siteMarkers/SiteMarkers', () => ({
+  __esModule: true,
+  SiteMarkers: ({ sites }: { sites: unknown[] }) => (
+    <div data-testid="site-markers">{(sites ?? []).length}</div>
+  ),
+}));
+
+jest.mock('./MapControls', () => ({
+  __esModule: true,
+  MapControls: () => <div data-testid="map-controls" />,
+}));
+
+jest.mock('./MyLocationMarker', () => ({
+  __esModule: true,
+  MyLocationMarker: () => <div data-testid="my-location-marker" />,
+}));
+
+jest.mock('./MapSearch', () => ({
+  __esModule: true,
+  MapSearch: () => <div data-testid="map-search" />,
+}));
+
+jest.mock('./siteDrawer/MapSearchDrawer', () => ({
+  __esModule: true,
+  MapSearchDrawer: () => <div data-testid="map-search-drawer" />,
+}));
+
+jest.mock('./layers/RadiusSearchLayer', () => ({
+  __esModule: true,
+  RadiusSearchLayer: () => <div data-testid="radius-search-layer" />,
+}));
+
+jest.mock('./layers/PolygonSearchLayer', () => ({
+  __esModule: true,
+  PolygonSearchLayer: () => <div data-testid="polygon-search-layer" />,
+}));
+
+jest.mock('./dataLayers/MapDataLayers', () => ({
+  __esModule: true,
+  MapDataLayers: () => <div data-testid="map-data-layers" />,
+}));
+
+describe('MapView', () => {
+  it('renders and flies to text-search bounds onCompleted', async () => {
+    const { default: MapView } = require('./MapView') as {
+      default: React.ComponentType;
+    };
+    const { useMapSearchContext } =
+      require('./mapSearchContext/MapSearchContext') as {
+        useMapSearchContext: jest.Mock;
+      };
+    const { flyToBoundsForTextSearch } = require('./mapViewHelpers') as {
+      flyToBoundsForTextSearch: jest.Mock;
+    };
+
+    (useMapSearchContext as jest.Mock).mockReturnValue({
+      searchTerm: 'victoria',
+      activeTool: null,
+      polygonVertices: [] as LatLngTuple[],
+      center: null,
+      radius: 1000,
+      selectedSiteId: null,
+    });
+
+    // Sanity check: the mocked GraphQL hook must return the shape that
+    // MapView destructures.
+    const generated = require('../../../graphql/generated') as {
+      useMapSearchQuery: (opts: any) => any;
+    };
+    const hookResult = generated.useMapSearchQuery({ onCompleted: jest.fn() });
+    expect(hookResult).toEqual(
+      expect.objectContaining({
+        data: { mapSearch: { data: siteData } },
+        loading: false,
+      }),
+    );
+
+    render(<MapView />);
+
+    await waitFor(() => {
+      expect(flyToBoundsForTextSearch).toHaveBeenCalled();
+    });
+
+    expect(flyToBoundsForTextSearch).toHaveBeenCalledWith(
+      'victoria',
+      siteData,
+      mockLeafletMap,
+    );
+
+    expect(screen.getByTestId('site-markers').textContent).toBe('1');
+  });
+
+  it('does not call sitesWhenMapToolCleared-setState when tool is active', async () => {
+    const { default: MapView } = require('./MapView') as {
+      default: React.ComponentType;
+    };
+    const { useMapSearchContext } =
+      require('./mapSearchContext/MapSearchContext') as {
+        useMapSearchContext: jest.Mock;
+      };
+    const { flyToBoundsForTextSearch } = require('./mapViewHelpers') as {
+      flyToBoundsForTextSearch: jest.Mock;
+    };
+
+    // Sanity check: the mocked GraphQL hook must still return the shape that
+    // MapView destructures.
+    const generated = require('../../../graphql/generated') as {
+      useMapSearchQuery: (opts: any) => any;
+    };
+    const hookResult = generated.useMapSearchQuery({ onCompleted: jest.fn() });
+    expect(hookResult).toEqual(
+      expect.objectContaining({
+        data: { mapSearch: { data: siteData } },
+        loading: false,
+      }),
+    );
+
+    (useMapSearchContext as jest.Mock).mockReturnValue({
+      searchTerm: 'victoria',
+      activeTool: 'polygon',
+      polygonVertices: [] as LatLngTuple[],
+      center: null,
+      radius: 1000,
+      selectedSiteId: null,
+    });
+
+    render(<MapView />);
+
+    await waitFor(() => {
+      // onCompleted still runs and sets sites; this is about the useEffect guard branch.
+      expect(flyToBoundsForTextSearch).toHaveBeenCalled();
+    });
+
+    expect(screen.getByTestId('site-markers').textContent).toBe('1');
+  });
+});

--- a/frontend/src/app/features/map/MapView.test.tsx
+++ b/frontend/src/app/features/map/MapView.test.tsx
@@ -20,21 +20,17 @@ jest.mock('react-leaflet', () => {
   const React = require('react') as typeof import('react');
   return {
     __esModule: true,
-    MapContainer: React.forwardRef(
-      (
-        {
-          children,
-        }: {
-          children: React.ReactNode;
-        },
-        ref: { current: Partial<Map> | null },
-      ) => {
+    MapContainer: React.forwardRef<Partial<Map>, { children: React.ReactNode }>(
+      ({ children }, ref) => {
         React.useLayoutEffect(() => {
-          if (ref && typeof ref === 'object') {
-            ref.current = mockLeafletMap;
+          if (!ref) return;
+          const map = mockLeafletMap as Partial<Map>;
+          if (typeof ref !== 'function') {
+            (ref as React.MutableRefObject<Partial<Map> | null>).current = map;
+          } else {
+            ref(map);
           }
         }, [ref]);
-
         return <div data-testid="map-container">{children}</div>;
       },
     ),

--- a/frontend/src/app/features/map/MapView.tsx
+++ b/frontend/src/app/features/map/MapView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { LatLngBounds, LatLngTuple, Map } from 'leaflet';
+import { LatLngTuple, Map } from 'leaflet';
 import { MapContainer, TileLayer } from 'react-leaflet';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -18,7 +18,7 @@ import {
 } from '../../../graphql/generated';
 import { SiteMarkers } from './siteMarkers/SiteMarkers';
 import { MapControls } from './MapControls';
-import { MAP_FLY_OPTIONS, getZoom } from './mapOptions';
+import { MAP_FLY_OPTIONS } from './mapOptions';
 import {
   MapSearchQueryProvider,
   useMapSearchContext,
@@ -30,6 +30,10 @@ import { MIN_CIRCLE_RADIUS } from '../../constants/Constant';
 import { MapDataLayers } from './dataLayers/MapDataLayers';
 import { buildSitesToShow } from './buildSitesToShow';
 import { useFlyToSelectedSite } from './useFlyToSelectedSite';
+import {
+  extendSearchResultBounds,
+  sitesWhenMapToolCleared,
+} from './mapViewHelpers';
 
 // Set the position of the marker for center of BC
 const CENTER_OF_BC: LatLngTuple = [53.7267, -127.6476];
@@ -71,16 +75,11 @@ function MapView() {
     },
   });
 
-  const flyToSiteBounds = (sites: Site[]) => {
-    if (!searchTerm || !mapRef.current) return;
-
-    const bounds = new LatLngBounds([]);
-    sites.forEach((site) => {
-      if (!site.latdeg || !site.longdeg) return;
-      const lat = site.latdeg;
-      const lng = site.longdeg;
-      bounds.extend({ lat, lng });
-    });
+  const flyToSiteBounds = (siteList: Site[]) => {
+    if (!searchTerm || !mapRef.current) {
+      return;
+    }
+    const bounds = extendSearchResultBounds(siteList);
     if (bounds.isValid()) {
       mapRef.current.flyToBounds(bounds, MAP_FLY_OPTIONS);
     }
@@ -111,8 +110,9 @@ function MapView() {
   );
 
   useEffect(() => {
-    if (activeTool === null) {
-      setSites(data?.mapSearch.data || []);
+    const next = sitesWhenMapToolCleared(activeTool, data?.mapSearch.data);
+    if (next !== null) {
+      setSites(next);
     }
   }, [activeTool]);
 

--- a/frontend/src/app/features/map/MapView.tsx
+++ b/frontend/src/app/features/map/MapView.tsx
@@ -14,10 +14,11 @@ import {
   MapSearchQuery,
   MapSearchQueryVariables,
   useMapSearchQuery,
+  useMapSearch_FindSiteBySiteIdQuery,
 } from '../../../graphql/generated';
 import { SiteMarkers } from './siteMarkers/SiteMarkers';
 import { MapControls } from './MapControls';
-import { MAP_FLY_OPTIONS } from './mapOptions';
+import { MAP_FLY_OPTIONS, getZoom } from './mapOptions';
 import {
   MapSearchQueryProvider,
   useMapSearchContext,
@@ -42,8 +43,14 @@ function MapView() {
   // Feature flag for turning OpenStreetMap tiles gray
   const osmGrayscale = false;
 
-  const { searchTerm, activeTool, polygonVertices, center, radius } =
-    useMapSearchContext();
+  const {
+    searchTerm,
+    activeTool,
+    polygonVertices,
+    center,
+    radius,
+    selectedSiteId,
+  } = useMapSearchContext();
 
   const variables: MapSearchQueryVariables = {
     searchParam: searchTerm || '',
@@ -82,6 +89,40 @@ function MapView() {
   const [sites, setSites] = useState<Site[]>([]);
   const clearSites = () => setSites([]);
 
+  const { data: selectedSiteData } = useMapSearch_FindSiteBySiteIdQuery({
+    variables: { siteId: selectedSiteId ?? '' },
+    skip: !selectedSiteId,
+  });
+  const selectedSite = selectedSiteData?.findSiteBySiteId?.data;
+
+  const sitesToShow: Site[] = (() => {
+    if (!selectedSiteId || !selectedSite?.latdeg || !selectedSite?.longdeg)
+      return sites;
+    const alreadyInList = sites.some(
+      (s) => String(s.id) === String(selectedSiteId),
+    );
+    return alreadyInList
+      ? sites
+      : [...sites, { ...selectedSite, id: selectedSiteId } as Site];
+  })();
+
+  const hasFlownToSelectedSiteRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!selectedSiteId) {
+      hasFlownToSelectedSiteRef.current = null;
+      return;
+    }
+    if (!selectedSite?.latdeg || !selectedSite?.longdeg || !mapRef.current)
+      return;
+    if (hasFlownToSelectedSiteRef.current === selectedSiteId) return;
+    hasFlownToSelectedSiteRef.current = selectedSiteId;
+    mapRef.current.flyTo(
+      { lat: selectedSite.latdeg, lng: selectedSite.longdeg },
+      getZoom(mapRef.current),
+      MAP_FLY_OPTIONS,
+    );
+  }, [selectedSiteId, selectedSite?.latdeg, selectedSite?.longdeg]);
+
   useEffect(() => {
     if (activeTool === null) {
       setSites(data?.mapSearch.data || []);
@@ -110,7 +151,7 @@ function MapView() {
           setLocationVisible={setLocationVisible}
         />
         {<MyLocationMarker isLocationVisible={isLocationVisible} />}
-        <SiteMarkers sites={sites} />
+        <SiteMarkers sites={sitesToShow} />
         <RadiusSearchLayer
           onCrossHairClick={clearSites}
           sites={sites}

--- a/frontend/src/app/features/map/MapView.tsx
+++ b/frontend/src/app/features/map/MapView.tsx
@@ -12,13 +12,11 @@ import './MapView.css';
 import { MapSearch } from './MapSearch';
 import {
   MapSearchQuery,
-  MapSearchQueryVariables,
   useMapSearchQuery,
   useMapSearch_FindSiteBySiteIdQuery,
 } from '../../../graphql/generated';
 import { SiteMarkers } from './siteMarkers/SiteMarkers';
 import { MapControls } from './MapControls';
-import { MAP_FLY_OPTIONS } from './mapOptions';
 import {
   MapSearchQueryProvider,
   useMapSearchContext,
@@ -31,9 +29,10 @@ import { MapDataLayers } from './dataLayers/MapDataLayers';
 import { buildSitesToShow } from './buildSitesToShow';
 import { useFlyToSelectedSite } from './useFlyToSelectedSite';
 import {
-  extendSearchResultBounds,
+  flyToBoundsForTextSearch,
   sitesWhenMapToolCleared,
 } from './mapViewHelpers';
+import { buildMapSearchQueryVariables } from './mapSearchVariables';
 
 // Set the position of the marker for center of BC
 const CENTER_OF_BC: LatLngTuple = [53.7267, -127.6476];
@@ -58,36 +57,28 @@ function MapView() {
     selectedSiteId,
   } = useMapSearchContext();
 
-  const variables: MapSearchQueryVariables = {
-    searchParam: searchTerm || '',
-    ...(polygonVertices.length > 0 && { polygon: polygonVertices }),
-  };
+  const mapRef = useRef<Map>(null);
+  const [sites, setSites] = useState<Site[]>([]);
 
-  if (center && radius >= MIN_CIRCLE_RADIUS) {
-    variables.circle = { center, radius };
-  }
+  const searchParam = searchTerm ?? '';
+
+  const variables = buildMapSearchQueryVariables(
+    searchParam,
+    polygonVertices,
+    center,
+    radius,
+    MIN_CIRCLE_RADIUS,
+  );
 
   const { data, loading: sitesLoading } = useMapSearchQuery({
     variables,
-    onCompleted: ({ mapSearch: { data } }) => {
-      flyToSiteBounds(data);
-      setSites(data);
+    onCompleted: ({ mapSearch: { data: siteData } }) => {
+      flyToBoundsForTextSearch(searchParam, siteData, mapRef.current);
+      setSites(siteData);
     },
   });
 
-  const flyToSiteBounds = (siteList: Site[]) => {
-    if (!searchTerm || !mapRef.current) {
-      return;
-    }
-    const bounds = extendSearchResultBounds(siteList);
-    if (bounds.isValid()) {
-      mapRef.current.flyToBounds(bounds, MAP_FLY_OPTIONS);
-    }
-  };
-
-  const mapRef = useRef<Map>(null);
   const [isLocationVisible, setLocationVisible] = useState(false);
-  const [sites, setSites] = useState<Site[]>([]);
   const clearSites = () => setSites([]);
 
   const { data: selectedSiteData } = useMapSearch_FindSiteBySiteIdQuery({

--- a/frontend/src/app/features/map/MapView.tsx
+++ b/frontend/src/app/features/map/MapView.tsx
@@ -28,6 +28,8 @@ import { RadiusSearchLayer } from './layers/RadiusSearchLayer';
 import { PolygonSearchLayer } from './layers/PolygonSearchLayer';
 import { MIN_CIRCLE_RADIUS } from '../../constants/Constant';
 import { MapDataLayers } from './dataLayers/MapDataLayers';
+import { buildSitesToShow } from './buildSitesToShow';
+import { useFlyToSelectedSite } from './useFlyToSelectedSite';
 
 // Set the position of the marker for center of BC
 const CENTER_OF_BC: LatLngTuple = [53.7267, -127.6476];
@@ -95,33 +97,18 @@ function MapView() {
   });
   const selectedSite = selectedSiteData?.findSiteBySiteId?.data;
 
-  const sitesToShow: Site[] = (() => {
-    if (!selectedSiteId || !selectedSite?.latdeg || !selectedSite?.longdeg)
-      return sites;
-    const alreadyInList = sites.some(
-      (s) => String(s.id) === String(selectedSiteId),
-    );
-    return alreadyInList
-      ? sites
-      : [...sites, { ...selectedSite, id: selectedSiteId } as Site];
-  })();
+  const sitesToShow = buildSitesToShow(
+    sites,
+    selectedSiteId,
+    selectedSite ?? undefined,
+  );
 
-  const hasFlownToSelectedSiteRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (!selectedSiteId) {
-      hasFlownToSelectedSiteRef.current = null;
-      return;
-    }
-    if (!selectedSite?.latdeg || !selectedSite?.longdeg || !mapRef.current)
-      return;
-    if (hasFlownToSelectedSiteRef.current === selectedSiteId) return;
-    hasFlownToSelectedSiteRef.current = selectedSiteId;
-    mapRef.current.flyTo(
-      { lat: selectedSite.latdeg, lng: selectedSite.longdeg },
-      getZoom(mapRef.current),
-      MAP_FLY_OPTIONS,
-    );
-  }, [selectedSiteId, selectedSite?.latdeg, selectedSite?.longdeg]);
+  useFlyToSelectedSite(
+    mapRef,
+    selectedSiteId,
+    selectedSite?.latdeg ?? undefined,
+    selectedSite?.longdeg ?? undefined,
+  );
 
   useEffect(() => {
     if (activeTool === null) {

--- a/frontend/src/app/features/map/buildSitesToShow.test.ts
+++ b/frontend/src/app/features/map/buildSitesToShow.test.ts
@@ -1,0 +1,53 @@
+import { buildSitesToShow } from './buildSitesToShow';
+
+type Row = {
+  id: number | string;
+  latdeg?: number | null;
+  longdeg?: number | null;
+};
+
+describe('buildSitesToShow', () => {
+  const sites: Row[] = [
+    { id: 1, latdeg: 49, longdeg: -123 },
+    { id: 2, latdeg: 50, longdeg: -124 },
+  ];
+
+  it('returns sites unchanged when no selectedSiteId', () => {
+    expect(
+      buildSitesToShow(sites, null, { id: 99, latdeg: 49, longdeg: -123 }),
+    ).toBe(sites);
+    expect(
+      buildSitesToShow(sites, undefined, { id: 99, latdeg: 49, longdeg: -123 }),
+    ).toBe(sites);
+  });
+
+  it('returns sites unchanged when selected site has no coordinates', () => {
+    expect(buildSitesToShow(sites, '99', { id: 99 })).toBe(sites);
+    expect(
+      buildSitesToShow(sites, '99', { id: 99, latdeg: null, longdeg: -123 }),
+    ).toBe(sites);
+  });
+
+  it('returns sites unchanged when selected id already in list (string vs number)', () => {
+    expect(
+      buildSitesToShow(sites, '1', { id: 1, latdeg: 49, longdeg: -123 }),
+    ).toBe(sites);
+  });
+
+  it('appends selected site with id forced to selectedSiteId string', () => {
+    const selected = {
+      id: 999,
+      latdeg: 48.5,
+      longdeg: -125.2,
+      extra: 'x',
+    } as Row & { extra: string };
+    const out = buildSitesToShow(sites, '42', selected);
+    expect(out).toHaveLength(3);
+    expect(out[2]).toMatchObject({
+      id: '42',
+      latdeg: 48.5,
+      longdeg: -125.2,
+      extra: 'x',
+    });
+  });
+});

--- a/frontend/src/app/features/map/buildSitesToShow.ts
+++ b/frontend/src/app/features/map/buildSitesToShow.ts
@@ -1,0 +1,23 @@
+/**
+ * Ensures the URL-selected site appears in the marker list when it is not
+ * returned by mapSearch (e.g. "View on Map" from site details).
+ */
+export function buildSitesToShow<T extends { id: string | number }>(
+  sites: T[],
+  selectedSiteId: string | null | undefined,
+  selectedSite:
+    | (T & { latdeg?: number | null; longdeg?: number | null })
+    | null
+    | undefined,
+): T[] {
+  if (!selectedSiteId || !selectedSite?.latdeg || !selectedSite?.longdeg) {
+    return sites;
+  }
+  const alreadyInList = sites.some(
+    (s) => String(s.id) === String(selectedSiteId),
+  );
+  if (alreadyInList) {
+    return sites;
+  }
+  return [...sites, { ...selectedSite, id: selectedSiteId } as T];
+}

--- a/frontend/src/app/features/map/mapSearchVariables.test.ts
+++ b/frontend/src/app/features/map/mapSearchVariables.test.ts
@@ -1,0 +1,48 @@
+import { buildMapSearchQueryVariables } from './mapSearchVariables';
+
+describe('buildMapSearchQueryVariables', () => {
+  it('sets searchParam from search term', () => {
+    expect(buildMapSearchQueryVariables('foo', [], null, 0, 500)).toEqual({
+      searchParam: 'foo',
+    });
+  });
+
+  it('uses empty string when search term empty', () => {
+    expect(buildMapSearchQueryVariables('', [], null, 0, 500)).toEqual({
+      searchParam: '',
+    });
+  });
+
+  it('includes polygon when vertices present', () => {
+    const poly: [number, number][] = [
+      [1, 2],
+      [3, 4],
+    ];
+    const v = buildMapSearchQueryVariables('', poly, null, 0, 500);
+    expect(v.polygon).toEqual(poly);
+  });
+
+  it('adds circle when center and radius meet minimum', () => {
+    const v = buildMapSearchQueryVariables('', [], [49, -123], 1000, 500);
+    expect(v.circle).toEqual({ center: [49, -123], radius: 1000 });
+  });
+
+  it('omits circle when radius below minimum', () => {
+    const v = buildMapSearchQueryVariables('', [], [49, -123], 100, 500);
+    expect(v.circle).toBeUndefined();
+  });
+
+  it('omits circle when center is null', () => {
+    const v = buildMapSearchQueryVariables('', [], null, 5000, 500);
+    expect(v.circle).toBeUndefined();
+  });
+
+  it('combines search param polygon and circle', () => {
+    const v = buildMapSearchQueryVariables('x', [[0, 0]], [1, 1], 600, 500);
+    expect(v).toMatchObject({
+      searchParam: 'x',
+      polygon: [[0, 0]],
+      circle: { center: [1, 1], radius: 600 },
+    });
+  });
+});

--- a/frontend/src/app/features/map/mapSearchVariables.ts
+++ b/frontend/src/app/features/map/mapSearchVariables.ts
@@ -1,0 +1,24 @@
+import type { LatLngTuple } from 'leaflet';
+import type { MapSearchQueryVariables } from '../../../graphql/generated';
+import { MIN_CIRCLE_RADIUS } from '../../constants/Constant';
+
+export type MapCircleCenter = [number, number];
+
+/** Builds GraphQL variables for mapSearch from URL/context state. */
+export function buildMapSearchQueryVariables(
+  searchTerm: string,
+  polygonVertices: LatLngTuple[],
+  center: LatLngTuple | null,
+  radius: number,
+  minCircleRadius: number = MIN_CIRCLE_RADIUS,
+): MapSearchQueryVariables {
+  const variables: MapSearchQueryVariables = {
+    searchParam: searchTerm || '',
+    ...(polygonVertices.length > 0 && { polygon: polygonVertices }),
+  };
+  if (center && radius >= minCircleRadius) {
+    const circleCenter: MapCircleCenter = [center[0], center[1]];
+    variables.circle = { center: circleCenter, radius };
+  }
+  return variables;
+}

--- a/frontend/src/app/features/map/mapViewHelpers.test.ts
+++ b/frontend/src/app/features/map/mapViewHelpers.test.ts
@@ -1,0 +1,54 @@
+import {
+  extendSearchResultBounds,
+  sitesWhenMapToolCleared,
+} from './mapViewHelpers';
+
+describe('extendSearchResultBounds', () => {
+  it('returns invalid bounds for empty sites', () => {
+    const b = extendSearchResultBounds([]);
+    expect(b.isValid()).toBe(false);
+  });
+
+  it('skips sites without coordinates', () => {
+    const b = extendSearchResultBounds([
+      { latdeg: null, longdeg: -123 },
+      { latdeg: 49, longdeg: null },
+    ]);
+    expect(b.isValid()).toBe(false);
+  });
+
+  it('extends bounds for valid sites', () => {
+    const b = extendSearchResultBounds([
+      { latdeg: 49, longdeg: -123 },
+      { latdeg: 50, longdeg: -124 },
+    ]);
+    expect(b.isValid()).toBe(true);
+    expect(b.getSouthWest().lat).toBeLessThanOrEqual(49);
+    expect(b.getNorthEast().lat).toBeGreaterThanOrEqual(50);
+  });
+
+  it('handles single site', () => {
+    const b = extendSearchResultBounds([{ latdeg: 48.5, longdeg: -125 }]);
+    expect(b.isValid()).toBe(true);
+  });
+});
+
+describe('sitesWhenMapToolCleared', () => {
+  it('returns map search data when activeTool is null', () => {
+    const data = [{ id: 1 }];
+    expect(sitesWhenMapToolCleared(null, data)).toEqual(data);
+  });
+
+  it('returns empty array when data undefined and tool cleared', () => {
+    expect(sitesWhenMapToolCleared(null, undefined)).toEqual([]);
+  });
+
+  it('returns null when a draw tool is active', () => {
+    expect(sitesWhenMapToolCleared('polygon', [{ id: 1 }])).toBeNull();
+    expect(sitesWhenMapToolCleared('radius', undefined)).toBeNull();
+  });
+
+  it('returns null when activeTool is undefined', () => {
+    expect(sitesWhenMapToolCleared(undefined, [{ id: 1 }])).toBeNull();
+  });
+});

--- a/frontend/src/app/features/map/mapViewHelpers.test.ts
+++ b/frontend/src/app/features/map/mapViewHelpers.test.ts
@@ -1,5 +1,6 @@
 import {
   extendSearchResultBounds,
+  flyToBoundsForTextSearch,
   sitesWhenMapToolCleared,
 } from './mapViewHelpers';
 
@@ -50,5 +51,36 @@ describe('sitesWhenMapToolCleared', () => {
 
   it('returns null when activeTool is undefined', () => {
     expect(sitesWhenMapToolCleared(undefined, [{ id: 1 }])).toBeNull();
+  });
+});
+
+describe('flyToBoundsForTextSearch', () => {
+  it('does nothing when searchTerm empty', () => {
+    const flyToBounds = jest.fn();
+    flyToBoundsForTextSearch('', [{ latdeg: 49, longdeg: -123 }], {
+      flyToBounds,
+    });
+    expect(flyToBounds).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when map is null', () => {
+    flyToBoundsForTextSearch('x', [{ latdeg: 49, longdeg: -123 }], null);
+  });
+
+  it('does nothing when bounds invalid', () => {
+    const flyToBounds = jest.fn();
+    flyToBoundsForTextSearch('x', [], { flyToBounds });
+    expect(flyToBounds).not.toHaveBeenCalled();
+  });
+
+  it('calls flyToBounds when search term and valid sites and map', () => {
+    const flyToBounds = jest.fn();
+    flyToBoundsForTextSearch('victoria', [{ latdeg: 48.4, longdeg: -123.4 }], {
+      flyToBounds,
+    });
+    expect(flyToBounds).toHaveBeenCalledTimes(1);
+    const [bounds, opts] = flyToBounds.mock.calls[0];
+    expect(bounds.isValid()).toBe(true);
+    expect(opts).toBeDefined();
   });
 });

--- a/frontend/src/app/features/map/mapViewHelpers.ts
+++ b/frontend/src/app/features/map/mapViewHelpers.ts
@@ -1,4 +1,5 @@
 import { LatLngBounds } from 'leaflet';
+import { MAP_FLY_OPTIONS } from './mapOptions';
 
 /** Build bounds from site coordinates (for text search fly-to-bounds). */
 export function extendSearchResultBounds(
@@ -26,4 +27,23 @@ export function sitesWhenMapToolCleared<T>(
     return null;
   }
   return mapSearchData || [];
+}
+
+export interface LeafletMapFlyToBounds {
+  flyToBounds(bounds: LatLngBounds, options: typeof MAP_FLY_OPTIONS): void;
+}
+
+/** After text search results load, fit map bounds when search term is set. */
+export function flyToBoundsForTextSearch(
+  searchTerm: string,
+  siteList: { latdeg?: number | null; longdeg?: number | null }[],
+  map: LeafletMapFlyToBounds | null,
+): void {
+  if (!searchTerm || !map) {
+    return;
+  }
+  const bounds = extendSearchResultBounds(siteList);
+  if (bounds.isValid()) {
+    map.flyToBounds(bounds, MAP_FLY_OPTIONS);
+  }
 }

--- a/frontend/src/app/features/map/mapViewHelpers.ts
+++ b/frontend/src/app/features/map/mapViewHelpers.ts
@@ -1,0 +1,29 @@
+import { LatLngBounds } from 'leaflet';
+
+/** Build bounds from site coordinates (for text search fly-to-bounds). */
+export function extendSearchResultBounds(
+  sites: { latdeg?: number | null; longdeg?: number | null }[],
+): LatLngBounds {
+  const bounds = new LatLngBounds([]);
+  for (const site of sites) {
+    if (!site.latdeg || !site.longdeg) {
+      continue;
+    }
+    bounds.extend({ lat: site.latdeg, lng: site.longdeg });
+  }
+  return bounds;
+}
+
+/**
+ * When no draw tool is active (activeTool === null), map list should mirror mapSearch.
+ * Returns null when a tool is active so callers skip setState.
+ */
+export function sitesWhenMapToolCleared<T>(
+  activeTool: unknown,
+  mapSearchData: T[] | undefined,
+): T[] | null {
+  if (activeTool !== null) {
+    return null;
+  }
+  return mapSearchData || [];
+}

--- a/frontend/src/app/features/map/siteMarkers/SiteMarkers.test.tsx
+++ b/frontend/src/app/features/map/siteMarkers/SiteMarkers.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SiteMarkers } from './SiteMarkers';
+import { useMapSearchContext } from '../mapSearchContext/MapSearchContext';
+
+const mockFlyTo = jest.fn();
+
+jest.mock('react-leaflet', () => ({
+  useMap: () => ({
+    flyTo: mockFlyTo,
+    getZoom: () => 10,
+  }),
+}));
+
+jest.mock('../mapSearchContext/MapSearchContext');
+
+jest.mock('react-leaflet-cluster', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="cluster">{children}</div>
+  ),
+}));
+
+jest.mock('./SiteMarker', () => ({
+  SiteMarker: ({
+    isSelected,
+    onClick,
+  }: {
+    isSelected?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="site-marker"
+      data-selected={String(!!isSelected)}
+      onClick={onClick}
+    />
+  ),
+}));
+
+describe('SiteMarkers', () => {
+  const mockSetQuery = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useMapSearchContext as jest.Mock).mockReturnValue({
+      selectedSiteId: null,
+      setQuery: mockSetQuery,
+    });
+  });
+
+  it('selects site when id is number and selectedSiteId is string', () => {
+    (useMapSearchContext as jest.Mock).mockReturnValue({
+      selectedSiteId: '99',
+      setQuery: mockSetQuery,
+    });
+    render(
+      <SiteMarkers
+        sites={[
+          { id: 99, latdeg: 49, longdeg: -123, addrLine_1: 'a' },
+          { id: 100, latdeg: 50, longdeg: -124, addrLine_1: 'b' },
+        ]}
+      />,
+    );
+    const markers = screen.getAllByTestId('site-marker');
+    expect(markers.filter((m) => m.dataset.selected === 'true')).toHaveLength(
+      1,
+    );
+    expect(markers.filter((m) => m.dataset.selected === 'false')).toHaveLength(
+      1,
+    );
+  });
+
+  it('renders only non-selected markers in cluster when none selected', () => {
+    render(
+      <SiteMarkers
+        sites={[{ id: 1, latdeg: 49, longdeg: -123, addrLine_1: 'x' }]}
+      />,
+    );
+    expect(screen.getAllByTestId('site-marker')).toHaveLength(1);
+    expect(screen.getByTestId('site-marker').dataset.selected).toBe('false');
+  });
+
+  it('skips rendering markers when site has no coordinates for selection', () => {
+    (useMapSearchContext as jest.Mock).mockReturnValue({
+      selectedSiteId: '1',
+      setQuery: mockSetQuery,
+    });
+    render(
+      <SiteMarkers
+        sites={[{ id: 1, latdeg: null, longdeg: -123, addrLine_1: '' }]}
+      />,
+    );
+    expect(screen.queryAllByTestId('site-marker')).toHaveLength(0);
+  });
+
+  it('calls setQuery and flyTo on marker click', () => {
+    render(
+      <SiteMarkers
+        sites={[{ id: 55, latdeg: 48, longdeg: -122, addrLine_1: 'z' }]}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('site-marker'));
+    expect(mockSetQuery).toHaveBeenCalledWith({ site: 55 });
+    expect(mockFlyTo).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/features/map/siteMarkers/SiteMarkers.test.tsx
+++ b/frontend/src/app/features/map/siteMarkers/SiteMarkers.test.tsx
@@ -56,8 +56,8 @@ describe('SiteMarkers', () => {
     render(
       <SiteMarkers
         sites={[
-          { id: 99, latdeg: 49, longdeg: -123, addrLine_1: 'a' },
-          { id: 100, latdeg: 50, longdeg: -124, addrLine_1: 'b' },
+          { id: '99', latdeg: 49, longdeg: -123, addrLine_1: 'a' },
+          { id: '100', latdeg: 50, longdeg: -124, addrLine_1: 'b' },
         ]}
       />,
     );
@@ -73,7 +73,7 @@ describe('SiteMarkers', () => {
   it('renders only non-selected markers in cluster when none selected', () => {
     render(
       <SiteMarkers
-        sites={[{ id: 1, latdeg: 49, longdeg: -123, addrLine_1: 'x' }]}
+        sites={[{ id: '1', latdeg: 49, longdeg: -123, addrLine_1: 'x' }]}
       />,
     );
     expect(screen.getAllByTestId('site-marker')).toHaveLength(1);
@@ -87,7 +87,7 @@ describe('SiteMarkers', () => {
     });
     render(
       <SiteMarkers
-        sites={[{ id: 1, latdeg: null, longdeg: -123, addrLine_1: '' }]}
+        sites={[{ id: '1', latdeg: null, longdeg: -123, addrLine_1: '' }]}
       />,
     );
     expect(screen.queryAllByTestId('site-marker')).toHaveLength(0);
@@ -96,11 +96,33 @@ describe('SiteMarkers', () => {
   it('calls setQuery and flyTo on marker click', () => {
     render(
       <SiteMarkers
-        sites={[{ id: 55, latdeg: 48, longdeg: -122, addrLine_1: 'z' }]}
+        sites={[{ id: '55', latdeg: 48, longdeg: -122, addrLine_1: 'z' }]}
       />,
     );
     fireEvent.click(screen.getByTestId('site-marker'));
-    expect(mockSetQuery).toHaveBeenCalledWith({ site: 55 });
+    expect(mockSetQuery).toHaveBeenCalledWith({ site: '55' });
+    expect(mockFlyTo).toHaveBeenCalled();
+  });
+
+  it('calls setQuery and flyTo when clicking selected marker', () => {
+    (useMapSearchContext as jest.Mock).mockReturnValue({
+      selectedSiteId: '77',
+      setQuery: mockSetQuery,
+    });
+    render(
+      <SiteMarkers
+        sites={[
+          { id: '77', latdeg: 49, longdeg: -123, addrLine_1: 'sel' },
+          { id: '78', latdeg: 50, longdeg: -124, addrLine_1: 'other' },
+        ]}
+      />,
+    );
+    const selected = screen
+      .getAllByTestId('site-marker')
+      .find((m) => m.dataset.selected === 'true');
+    expect(selected).toBeTruthy();
+    fireEvent.click(selected!);
+    expect(mockSetQuery).toHaveBeenCalledWith({ site: '77' });
     expect(mockFlyTo).toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/features/map/siteMarkers/SiteMarkers.tsx
+++ b/frontend/src/app/features/map/siteMarkers/SiteMarkers.tsx
@@ -39,31 +39,60 @@ export const SiteMarkers: FC<SiteMarkersProps> = ({ sites }) => {
     [moveToSiteLocation, setQuery],
   );
 
-  const markers = useMemo(() => {
-    return sites.map((site) => {
-      if (!site.latdeg || !site.longdeg) return null;
-      return (
-        <SiteMarker
-          key={site.id}
-          isSelected={site.id === selectedSiteId}
-          position={{
-            lat: site.latdeg,
-            lng: site.longdeg,
-          }}
-          onClick={() => onSiteMarkerClick(site)}
-        />
-      );
+  const { selectedMarker, clusterMarkers } = useMemo(() => {
+    const restMarkers: React.ReactNode[] = [];
+    const selectedSite = sites.find(
+      (site) =>
+        site.latdeg != null &&
+        site.longdeg != null &&
+        String(site.id) === String(selectedSiteId),
+    );
+    sites.forEach((site) => {
+      if (!site.latdeg || !site.longdeg) return;
+      const isSelected = String(site.id) === String(selectedSiteId);
+      if (!isSelected) {
+        restMarkers.push(
+          <SiteMarker
+            key={site.id}
+            isSelected={false}
+            position={{
+              lat: site.latdeg,
+              lng: site.longdeg,
+            }}
+            onClick={() => onSiteMarkerClick(site)}
+          />,
+        );
+      }
     });
+    const selectedMarkerNode =
+      selectedSite != null ? (
+        <SiteMarker
+          key={selectedSite.id}
+          isSelected={true}
+          position={{
+            lat: selectedSite.latdeg ?? 0,
+            lng: selectedSite.longdeg ?? 0,
+          }}
+          onClick={() => onSiteMarkerClick(selectedSite)}
+        />
+      ) : null;
+    return {
+      selectedMarker: selectedMarkerNode,
+      clusterMarkers: restMarkers,
+    };
   }, [onSiteMarkerClick, selectedSiteId, sites]);
 
   return (
-    <MarkerClusterGroup
-      chunkedLoading
-      maxClusterRadius={80}
-      spiderfyOnMaxZoom={false}
-      showCoverageOnHover={false}
-    >
-      {markers}
-    </MarkerClusterGroup>
+    <>
+      {selectedMarker}
+      <MarkerClusterGroup
+        chunkedLoading
+        maxClusterRadius={80}
+        spiderfyOnMaxZoom={false}
+        showCoverageOnHover={false}
+      >
+        {clusterMarkers}
+      </MarkerClusterGroup>
+    </>
   );
 };

--- a/frontend/src/app/features/map/siteMarkers/SiteMarkers.tsx
+++ b/frontend/src/app/features/map/siteMarkers/SiteMarkers.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useMemo } from 'react';
+import { FC, useCallback, useMemo, type ReactNode } from 'react';
 import MarkerClusterGroup from 'react-leaflet-cluster';
 import { SiteMarker } from './SiteMarker';
 import { useMap } from 'react-leaflet';
@@ -64,8 +64,9 @@ export const SiteMarkers: FC<SiteMarkersProps> = ({ sites }) => {
         );
       }
     });
-    const selectedMarkerNode =
-      selectedSite != null ? (
+    let selectedMarkerNode: ReactNode = null;
+    if (selectedSite) {
+      selectedMarkerNode = (
         <SiteMarker
           key={selectedSite.id}
           isSelected={true}
@@ -75,7 +76,8 @@ export const SiteMarkers: FC<SiteMarkersProps> = ({ sites }) => {
           }}
           onClick={() => onSiteMarkerClick(selectedSite)}
         />
-      ) : null;
+      );
+    }
     return {
       selectedMarker: selectedMarkerNode,
       clusterMarkers: restMarkers,

--- a/frontend/src/app/features/map/useFlyToSelectedSite.test.tsx
+++ b/frontend/src/app/features/map/useFlyToSelectedSite.test.tsx
@@ -24,7 +24,7 @@ describe('useFlyToSelectedSite', () => {
     expect(flyTo).toHaveBeenCalledWith({ lat: 49, lng: -123 }, 12, {});
 
     flyTo.mockClear();
-    rerender({ id: null, lat: undefined, lng: undefined });
+    rerender({ id: null, lat: 0, lng: 0 });
     rerender({ id: '5', lat: 49, lng: -123 });
     expect(flyTo).toHaveBeenCalledTimes(1);
     expect(flyTo).toHaveBeenCalledWith({ lat: 49, lng: -123 }, 12, {});

--- a/frontend/src/app/features/map/useFlyToSelectedSite.test.tsx
+++ b/frontend/src/app/features/map/useFlyToSelectedSite.test.tsx
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react';
+import { useRef } from 'react';
+import { useFlyToSelectedSite } from './useFlyToSelectedSite';
+
+jest.mock('./mapOptions', () => ({
+  getZoom: () => 12,
+  MAP_FLY_OPTIONS: {},
+}));
+
+describe('useFlyToSelectedSite', () => {
+  it('flies once then resets and flies again after selectedSiteId cleared', () => {
+    const flyTo = jest.fn();
+    const map = { flyTo, getZoom: () => 10 };
+
+    const { rerender } = renderHook(
+      ({ id, lat, lng }: { id: string | null; lat?: number; lng?: number }) => {
+        const ref = useRef(map as any);
+        ref.current = map as any;
+        useFlyToSelectedSite(ref, id, lat, lng);
+      },
+      { initialProps: { id: '5' as string | null, lat: 49, lng: -123 } },
+    );
+
+    expect(flyTo).toHaveBeenCalledWith({ lat: 49, lng: -123 }, 12, {});
+
+    flyTo.mockClear();
+    rerender({ id: null, lat: undefined, lng: undefined });
+    rerender({ id: '5', lat: 49, lng: -123 });
+    expect(flyTo).toHaveBeenCalledTimes(1);
+    expect(flyTo).toHaveBeenCalledWith({ lat: 49, lng: -123 }, 12, {});
+  });
+
+  it('does not fly twice for same selectedSiteId when only lat changes', () => {
+    const flyTo = jest.fn();
+    const map = { flyTo, getZoom: () => 10 };
+
+    const { rerender } = renderHook(
+      ({ lat }: { lat: number }) => {
+        const ref = useRef(map as any);
+        ref.current = map as any;
+        useFlyToSelectedSite(ref, '7', lat, -120);
+      },
+      { initialProps: { lat: 50 } },
+    );
+
+    expect(flyTo).toHaveBeenCalledTimes(1);
+    rerender({ lat: 51 });
+    expect(flyTo).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fly when map ref is null', () => {
+    const flyTo = jest.fn();
+    renderHook(() => {
+      const ref = useRef(null);
+      useFlyToSelectedSite(ref, '1', 49, -123);
+    });
+    expect(flyTo).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/features/map/useFlyToSelectedSite.ts
+++ b/frontend/src/app/features/map/useFlyToSelectedSite.ts
@@ -1,0 +1,33 @@
+import { RefObject, useEffect, useRef } from 'react';
+import { Map } from 'leaflet';
+import { MAP_FLY_OPTIONS, getZoom } from './mapOptions';
+
+/**
+ * Fly the map to the selected site once per selectedSiteId when coords load.
+ */
+export function useFlyToSelectedSite(
+  mapRef: RefObject<Map | null>,
+  selectedSiteId: string | null | undefined,
+  latdeg: number | null | undefined,
+  longdeg: number | null | undefined,
+): void {
+  const hasFlownToSelectedSiteRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!selectedSiteId) {
+      hasFlownToSelectedSiteRef.current = null;
+      return;
+    }
+    if (!latdeg || !longdeg || !mapRef.current) {
+      return;
+    }
+    if (hasFlownToSelectedSiteRef.current === selectedSiteId) {
+      return;
+    }
+    hasFlownToSelectedSiteRef.current = selectedSiteId;
+    mapRef.current.flyTo(
+      { lat: latdeg, lng: longdeg },
+      getZoom(mapRef.current),
+      MAP_FLY_OPTIONS,
+    );
+  }, [mapRef, selectedSiteId, latdeg, longdeg]);
+}


### PR DESCRIPTION
#Issue
When you click “View on Map” for a site:

it navigates to Map Search and opens the details drawer for that siteId
but the site doesn’t appear on the map (no marker/zoom), so the drawer is showing a site that isn’t represented visually.


#Root cause
The map pins come from the mapSearch query (returns a list of sites to render as markers).
The selected site in the drawer comes from URL state (?site=<id>) and triggers findSiteBySiteId to load drawer details.
If the selected site is not included in the current mapSearch results (common when arriving from a details page, or when map search params don’t include that site), SiteMarkers never receives it → no marker to highlight or zoom to.

#Fix 
Ensure the selected site is present in the marker list:
- In MapView.tsx, when selectedSiteId exists, fetch it via findSiteBySiteId and merge that site into the sites list used for markers (e.g., sitesToShow).
- Auto-pan/zoom to the selected site once it loads:
- Add an effect in MapView.tsx that calls flyTo/fitBounds when the selected site’s lat/long becomes available.
- Make the selected marker reliably “yellow” even with clustering:
- 
Before Fix:
<img width="1625" height="928" alt="Before" src="https://github.com/user-attachments/assets/39e7afa9-1bcd-4af6-b547-ca85259794c9" />

After fix:
<img width="1619" height="899" alt="After" src="https://github.com/user-attachments/assets/3a454ba6-05dc-444f-acff-3725879e0252" />


In SiteMarkers.tsx, compare IDs using String(site.id) === String(selectedSiteId) (API may return numeric IDs).
Render the selected marker outside MarkerClusterGroup so it can’t be hidden inside a cluster icon.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-472-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-472-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-472-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-472-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)