### PR TITLE
fix: Changes to fix participant count in displayed in site summary section

### DIFF
--- a/backend/src/app/dto/siteInsights.dto.ts
+++ b/backend/src/app/dto/siteInsights.dto.ts
@@ -19,4 +19,7 @@ export class SiteInsightsDto {
 
   @Field(() => Int)
   siteSubdivCount: number;
+
+  @Field(() => Int)
+  siteParticsCount: number;
 }

--- a/backend/src/app/resolvers/site/sitePublic.resolver.spec.ts
+++ b/backend/src/app/resolvers/site/sitePublic.resolver.spec.ts
@@ -46,6 +46,7 @@ describe('SiteResolver', () => {
               return result;
             }),
             searchSiteIds: jest.fn(),
+            getSiteInsights: jest.fn(),
           },
         },
         {
@@ -118,6 +119,38 @@ describe('SiteResolver', () => {
       );
       const result = await siteResolver.findSiteBySiteId(siteId, false);
       expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe('getSiteInsights', () => {
+    const mockInsights = {
+      eventCount: 5,
+      siteDocCount: 3,
+      eventParticCount: 10,
+      landHistoryCount: 2,
+      siteAssocCount: 1,
+      siteSubdivCount: 0,
+      siteParticsCount: 4,
+    };
+
+    it('should call siteService.getSiteInsights with siteId and showPending true', async () => {
+      (siteService.getSiteInsights as jest.Mock).mockResolvedValue(
+        mockInsights,
+      );
+
+      await siteResolver.getSiteInsights('123', true);
+
+      expect(siteService.getSiteInsights).toHaveBeenCalledWith('123', true);
+    });
+
+    it('should call siteService.getSiteInsights with showPending false', async () => {
+      (siteService.getSiteInsights as jest.Mock).mockResolvedValue(
+        mockInsights,
+      );
+
+      await siteResolver.getSiteInsights('123', false);
+
+      expect(siteService.getSiteInsights).toHaveBeenCalledWith('123', false);
     });
   });
 });

--- a/backend/src/app/resolvers/site/sitePublic.resolver.ts
+++ b/backend/src/app/resolvers/site/sitePublic.resolver.ts
@@ -166,11 +166,13 @@ export class SitePublicResolver {
   @Query(() => FetchSiteInsights, { name: 'getSiteInsights' })
   async getSiteInsights(
     @Args('siteId', { type: () => String }) siteId: string,
+    @Args('pending', { type: () => Boolean, nullable: true })
+    showPending: boolean,
   ) {
     this.sitesLogger.log(
       'SiteResolver.getSiteInsights() start siteId:' + ' ' + siteId,
     );
-    const result = await this.siteService.getSiteInsights(siteId);
+    const result = await this.siteService.getSiteInsights(siteId, showPending);
     return this.genericResponseProviderForInsights.createResponse(
       'Success',
       200,

--- a/backend/src/app/services/site/site.service.spec.ts
+++ b/backend/src/app/services/site/site.service.spec.ts
@@ -76,6 +76,7 @@ describe('SiteService', () => {
         {
           provide: getRepositoryToken(Sites),
           useValue: {
+            query: jest.fn(),
             find: jest.fn(() => {
               return [
                 { id: '123', commonName: 'victoria' },
@@ -1791,6 +1792,63 @@ describe('SiteService', () => {
       });
 
       expect(mockQueryBuilder.getManyAndCount).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getSiteInsights', () => {
+    const mockQueryResult = [
+      {
+        event_count: '5',
+        site_doc_count: '3',
+        event_partic_count: '10',
+        site_participants: '4',
+        land_history_count: '2',
+        site_assoc_count: '1',
+        site_subdiv_count: '0',
+      },
+    ];
+
+    it('should return site insights with counts', async () => {
+      jest.spyOn(siteRepository, 'query').mockResolvedValue(mockQueryResult);
+
+      const result = await siteService.getSiteInsights('123');
+
+      expect(result.eventCount).toBe(5);
+      expect(result.siteDocCount).toBe(3);
+      expect(result.eventParticCount).toBe(10);
+      expect(result.landHistoryCount).toBe(2);
+      expect(result.siteAssocCount).toBe(1);
+      expect(result.siteSubdivCount).toBe(0);
+    });
+
+    it('should include sr_action filter for non-pending (public) view', async () => {
+      jest.spyOn(siteRepository, 'query').mockResolvedValue(mockQueryResult);
+
+      await siteService.getSiteInsights('123', false);
+
+      expect(siteRepository.query).toHaveBeenCalledWith(
+        expect.stringContaining("sr_action != 'pending'"),
+        ['123'],
+      );
+    });
+
+    it('should not include sr_action filter for pending view (returns all)', async () => {
+      jest.spyOn(siteRepository, 'query').mockResolvedValue(mockQueryResult);
+
+      await siteService.getSiteInsights('123', true);
+
+      expect(siteRepository.query).toHaveBeenCalledWith(
+        expect.not.stringContaining('sr_action'),
+        ['123'],
+      );
+    });
+
+    it('should return null when query returns empty result', async () => {
+      jest.spyOn(siteRepository, 'query').mockResolvedValue([]);
+
+      const result = await siteService.getSiteInsights('999');
+
+      expect(result).toBeNull();
     });
   });
 

--- a/backend/src/app/services/site/site.service.ts
+++ b/backend/src/app/services/site/site.service.ts
@@ -2627,20 +2627,32 @@ export class SiteService {
     }
   }
 
-  async getSiteInsights(siteId: string): Promise<SiteInsightsDto> {
+  async getSiteInsights(
+    siteId: string,
+    showPending?: boolean,
+  ): Promise<SiteInsightsDto> {
     try {
+      const srFilter = showPending
+        ? ''
+        : `AND (sr_action IS NULL OR sr_action != '${SRApprovalStatusEnum.PENDING}')`;
+
+      const sdSrFilter = showPending
+        ? ''
+        : `AND (sd.sr_action IS NULL OR sd.sr_action != '${SRApprovalStatusEnum.PENDING}')`;
+
       const result = await this.siteRepository.query(
         `
         SELECT
-          (SELECT COUNT(id) FROM sites.events WHERE site_id = $1) AS event_count,
+          (SELECT COUNT(id) FROM sites.events WHERE site_id = $1 ${srFilter}) AS event_count,
           (SELECT COUNT(sd.id) FROM sites.site_docs sd
-		  join sites.site_doc_partics  spr on sdoc_id = sd.id
-		  where site_id = $1) AS site_doc_count,
+		  join sites.site_doc_partics spr on sdoc_id = sd.id
+		  where site_id = $1 ${sdSrFilter}) AS site_doc_count,
           (SELECT COUNT(id) FROM sites.event_partics WHERE event_id IN (
-              SELECT id FROM sites.events WHERE site_id = $1
+              SELECT id FROM sites.events WHERE site_id = $1 ${srFilter}
           )) AS event_partic_count,
-          (SELECT COUNT(Lut_code) FROM sites.land_histories WHERE site_id = $1) AS land_history_count,
-          (SELECT COUNT(id) FROM sites.site_assocs WHERE site_id = $1) AS site_assoc_count,
+           (SELECT COUNT(id) FROM sites.site_partics WHERE site_id = $1 ${srFilter}) AS site_participants,
+          (SELECT COUNT(Lut_code) FROM sites.land_histories WHERE site_id = $1 ${srFilter}) AS land_history_count,
+          (SELECT COUNT(id) FROM sites.site_assocs WHERE site_id = $1 ${srFilter}) AS site_assoc_count,
           (SELECT COUNT(subdiv_id) FROM sites.site_subdivisions WHERE site_id = $1) AS site_subdiv_count
         `,
         [siteId],
@@ -2658,6 +2670,7 @@ export class SiteService {
         landHistoryCount: Number(raw.land_history_count),
         siteAssocCount: Number(raw.site_assoc_count),
         siteSubdivCount: Number(raw.site_subdiv_count),
+        siteParticsCount: Number(raw.site_participants),
       };
 
       return dto;

--- a/frontend/src/app/features/details/SiteDetails.tsx
+++ b/frontend/src/app/features/details/SiteDetails.tsx
@@ -244,7 +244,12 @@ const SiteDetails = () => {
       saveSiteDetailsRequestStatus === RequestStatus.failed
     ) {
       if (saveSiteDetailsRequestStatus === RequestStatus.success) {
-        dispatch(fetchSitesInsights({ siteId: id ?? '' }));
+        dispatch(
+          fetchSitesInsights({
+            siteId: id ?? '',
+            showPending: userType === UserType.Internal,
+          }),
+        );
         dispatch(fetchSitesDetails({ siteId: id ?? '', showPending: false }));
         dispatch(resetSaveSiteDetails(null));
         dispatch(clearTrackChanges(null));
@@ -394,7 +399,12 @@ const SiteDetails = () => {
     if (!!id?.trim()) {
       checkForRecordsPendingReview(id);
       dispatch(setupSiteIdForSaving(id));
-      dispatch(fetchSitesInsights({ siteId: id ?? '' }));
+      dispatch(
+        fetchSitesInsights({
+          siteId: id ?? '',
+          showPending: userType === UserType.Internal,
+        }),
+      );
       if (auth.user !== null) {
         Promise.all([
           dispatch(fetchSnapshots(id ?? '')),
@@ -830,7 +840,8 @@ const SiteDetails = () => {
         // Exclude deleted notations from validation, but keep them for saving
         const notationsForValidation = Array.isArray(updatedSiteNotations)
           ? updatedSiteNotations.filter(
-              (notation: any) => notation?.userAction !== UserActionEnum.deleted,
+              (notation: any) =>
+                notation?.userAction !== UserActionEnum.deleted,
             )
           : updatedSiteNotations;
         const [notationErrors, notationParticipantErrors] = await Promise.all([

--- a/frontend/src/app/features/details/summary/SummaryConfig.tsx
+++ b/frontend/src/app/features/details/summary/SummaryConfig.tsx
@@ -413,12 +413,12 @@ export const GetSummaryConfig = () => {
       id: 5,
       displayName: 'Participants',
       active: true,
-      graphQLPropertyName: 'eventParticCount',
+      graphQLPropertyName: 'siteParticsCount',
       displayType: {
         type: FormFieldType.Text,
         label: 'Site ID',
         placeholder: 'Separate IDs by a comma (",")',
-        graphQLPropertyName: 'eventParticCount',
+        graphQLPropertyName: 'siteParticsCount',
         value: '',
         validation: {
           pattern: /^[0-9,\s]*$/,

--- a/frontend/src/app/features/site/dto/SiteSlice.ts
+++ b/frontend/src/app/features/site/dto/SiteSlice.ts
@@ -56,12 +56,13 @@ export const fetchSitesDetails = createAsyncThunk(
 
 export const fetchSitesInsights = createAsyncThunk(
   'sites/fetchSitesInsights',
-  async (args: { siteId: string }) => {
+  async (args: { siteId: string; showPending?: boolean }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
         query: print(getSiteInsightsQL()),
         variables: {
           siteId: args.siteId,
+          pending: args.showPending ?? false,
         },
       });
       return response.data?.data?.getSiteInsights?.data;

--- a/frontend/src/app/features/site/graphql/Site.ts
+++ b/frontend/src/app/features/site/graphql/Site.ts
@@ -93,6 +93,7 @@ query searchSitesForAuthenticatedUsers($searchParam: String!,  $page: Int!, $pag
         whenCreated
         whenCreated
         consultantSubmitted
+        addrType
        }
        count
        page
@@ -126,6 +127,7 @@ export const graphqlSiteDetailsQuery = () => {
           siteRiskCode
           whenUpdated
           srAction
+          addrType
         }
         httpStatusCode
       }
@@ -211,8 +213,8 @@ export const bulkAproveRejectChangesQL = () => gql`
 `;
 
 export const getSiteInsightsQL = () => gql`
-  query getSiteInsights($siteId: String!) {
-    getSiteInsights(siteId: $siteId) {
+  query getSiteInsights($siteId: String!, $pending: Boolean) {
+    getSiteInsights(siteId: $siteId, pending: $pending) {
       data {
         eventCount
         eventParticCount
@@ -220,6 +222,7 @@ export const getSiteInsightsQL = () => gql`
         siteDocCount
         siteSubdivCount
         siteAssocCount
+        siteParticsCount
       }
     }
   }

--- a/frontend/src/graphql/generated.ts
+++ b/frontend/src/graphql/generated.ts
@@ -898,6 +898,7 @@ export type QueryGetSiteDocumentsBySiteIdArgs = {
 
 
 export type QueryGetSiteInsightsArgs = {
+  pending?: InputMaybe<Scalars['Boolean']['input']>;
   siteId: Scalars['String']['input'];
 };
 
@@ -1171,6 +1172,7 @@ export type SiteInsightsDto = {
   landHistoryCount: Scalars['Int']['output'];
   siteAssocCount: Scalars['Int']['output'];
   siteDocCount: Scalars['Int']['output'];
+  siteParticsCount: Scalars['Int']['output'];
   siteSubdivCount: Scalars['Int']['output'];
 };
 


### PR DESCRIPTION
# Description

Updated SQL to fetch site participant from the site_partics table . Also added sr_action filtering to the getSiteInsights query so that site counts respect the SR approval status. Previously, getSiteInsights returned counts for all records regardless of their approval state. Now:

Internal users see all records (no sr_action filter applied)
External/public users see only non-pending records (sr_action IS NULL OR sr_action != 'pending')

This is achieved by adding an optional pending argument to the getSiteInsights GraphQL query. The frontend passes showPending: true for internal users and showPending: false for external users based on userType.

Fixes # SRS-1492

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

-  Backend unit tests for getSiteInsights in site.service.spec.ts - verifies counts are returned, no filter applied when showPending=true, sr_action filter applied when showPending=false, and null returned for empty results

-  Backend unit tests for getSiteInsights in sitePublic.resolver.spec.ts — verifies resolver passes showPending correctly to the service for both true and false

-  Manual testing — verified internal user sees all counts, external user sees only public counts


## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-481-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-481-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)