### PR TITLE
fix: Fixed SRS-1419 -Add to Cart and Add to Folio should not be available for staff users

### DIFF
--- a/frontend/src/app/features/map/siteDrawer/SiteDetailsDrawerContent.tsx
+++ b/frontend/src/app/features/map/siteDrawer/SiteDetailsDrawerContent.tsx
@@ -20,6 +20,8 @@ import { useMapSearchContext } from '../mapSearchContext/MapSearchContext';
 import { AppDispatch } from '../../../Store';
 import { fetchCartItems } from '../../cart/CartSlice';
 import { notifyError, notifySuccess } from '../../../components/alert/Alert';
+import { isUserOfType, getUser, UserRoleType } from '../../../helpers/utility';
+import { useAuth } from 'react-oidc-context';
 
 const SummaryItem = ({
   label,
@@ -65,6 +67,7 @@ export const SiteDetailsDrawerContent: FC<SiteDetailsDrawerContentProps> = ({
   const { selectedSiteId } = useMapSearchContext();
 
   const dispatch = useDispatch<AppDispatch>();
+  const auth = useAuth();
 
   const { data, loading: siteDetailsLoading } =
     useMapSearch_FindSiteBySiteIdQuery({
@@ -83,6 +86,12 @@ export const SiteDetailsDrawerContent: FC<SiteDetailsDrawerContentProps> = ({
 
   const handleAddCartItemClick = () => {
     if (!selectedSiteId) return;
+
+    const loggedInUser = getUser();
+    if (loggedInUser === null) {
+      auth.signinRedirect({ extraQueryParams: { kc_idp_hint: 'bceid' } });
+      return;
+    }
 
     addCartItem({
       variables: {
@@ -135,19 +144,23 @@ export const SiteDetailsDrawerContent: FC<SiteDetailsDrawerContentProps> = ({
               View Site Details
             </Button>
           </Link>
-          <AddToFolio
-            selectedSiteIds={[selectedSiteId || '']}
-            label="Add to Folio"
-            triggerClassName="justify-content-center"
-          />
-          <Button
-            onClick={handleAddCartItemClick}
-            disabled={addCartItemLoading}
-            className="justify-content-center"
-          >
-            <ShoppingCartIcon />
-            Add to Cart
-          </Button>
+          {!isUserOfType(UserRoleType.INTERNAL) && (
+            <>
+              <AddToFolio
+                selectedSiteIds={[selectedSiteId || '']}
+                label="Add to Folio"
+                triggerClassName="justify-content-center"
+              />
+              <Button
+                onClick={handleAddCartItemClick}
+                disabled={addCartItemLoading}
+                className="justify-content-center"
+              >
+                <ShoppingCartIcon />
+                Add to Cart
+              </Button>
+            </>
+          )}
         </div>
       </div>
       <div className="">


### PR DESCRIPTION
# Description

Hide "Add to Cart" and "Add to Folio" buttons from staff (internal/IDIR) users on the Map Site Details drawer. These actions are only relevant for client (BCeID) users.

Additionally, the "Add to Cart" button now redirects unauthenticated users to the BCeID login page instead of silently failing.

Fixes # (issue)
SRS-1419 - Add to Cart and Add to Folio should not be available for staff users

Changes:

SiteDetailsDrawerContent.tsx: Wrapped "Add to Folio" and "Add to Cart" in !isUserOfType(UserRoleType.INTERNAL) guard
SiteDetailsDrawerContent.tsx: Added login redirect check to handleAddCartItemClick using getUser() and auth.signinRedirect

## Type of change
- [X ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

 Manual testing: Logged in as IDIR user, confirmed "Add to Cart" and "Add to Folio" buttons are not visible in the map site drawer
 Manual testing: Logged in as BCeID user, confirmed both buttons are visible and functional
 Manual testing: Opened map drawer while not logged in, clicked "Add to Cart", confirmed redirect to BCeID login page


## Checklist

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-484-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-484-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)