### PR TITLE
fix: Update migration sequence default value.

### DIFF
--- a/backend/src/migrations/1773695380136-FixSubdivisionsSequence.ts
+++ b/backend/src/migrations/1773695380136-FixSubdivisionsSequence.ts
@@ -18,13 +18,14 @@ export class FixSubdivisionsSequence1773695380136
         OWNED BY sites.subdivisions.id;
     `);
 
+    // Resync the sequence so the next ID is valid
     await queryRunner.query(`
-        SELECT setval(
-          'sites.subdivision_id_seq',
-          GREATEST((SELECT COALESCE(MAX(id), 0) FROM sites.subdivisions), 1),
-          (SELECT COUNT(*) > 0 FROM sites.subdivisions)
-        );
-      `);
+      SELECT setval(
+        'sites.subdivision_id_seq',
+        GREATEST((SELECT COALESCE(MAX(id), 0) FROM sites.subdivisions), 1),
+        (SELECT COUNT(*) > 0 FROM sites.subdivisions)
+      );
+    `);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/backend/src/migrations/1773695380136-FixSubdivisionsSequence.ts
+++ b/backend/src/migrations/1773695380136-FixSubdivisionsSequence.ts
@@ -1,10 +1,11 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class FixSubdivisionsSequence1773695380136 implements MigrationInterface {
+export class FixSubdivisionsSequence1773695380136
+  implements MigrationInterface
+{
   name = 'FixSubdivisionsSequence1773695380136';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-
     // Fix the DEFAULT so the ID column uses the correct sequence
     await queryRunner.query(`
       ALTER TABLE sites.subdivisions
@@ -17,13 +18,13 @@ export class FixSubdivisionsSequence1773695380136 implements MigrationInterface 
         OWNED BY sites.subdivisions.id;
     `);
 
-    // Resync the sequence so the next ID is valid
     await queryRunner.query(`
-      SELECT setval(
-        'sites.subdivision_id_seq',
-        (SELECT COALESCE(MAX(id), 0) FROM sites.subdivisions)
-      );
-    `);
+        SELECT setval(
+          'sites.subdivision_id_seq',
+          GREATEST((SELECT COALESCE(MAX(id), 0) FROM sites.subdivisions), 1),
+          (SELECT COUNT(*) > 0 FROM sites.subdivisions)
+        );
+      `);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/charts/crunchy/values.yaml
+++ b/charts/crunchy/values.yaml
@@ -1,4 +1,4 @@
-global:  # Trigger a db deploy.
+global:
   config:
     dbName: site #test
 crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single postgres

--- a/charts/crunchy/values.yaml
+++ b/charts/crunchy/values.yaml
@@ -1,4 +1,4 @@
-global:
+global:  # Trigger a db deploy.
   config:
     dbName: site #test
 crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single postgres


### PR DESCRIPTION
Update migration to default to a sequence value of 1 if there are no ids. 0 is an invalid value.

1. `GREATEST(..., 1)` ensures the value passed to `setval` is never `0`, which PostgreSQL rejects.
2. `is_called` flag; `(SELECT COUNT(*) > 0 FROM sites.subdivisions)` evaluates to false when empty, telling PostgreSQL the sequence hasn't been used yet, so the next `nextval` returns `1` rather than `2`. Not a big deal, but I like it.


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-487-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-487-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)