### PR TITLE
fix: SRS-1426 - Moving from session to local storage

### DIFF
--- a/frontend/src/app/auth/UserManagerSetting.ts
+++ b/frontend/src/app/auth/UserManagerSetting.ts
@@ -1,4 +1,4 @@
-import { UserManagerSettings } from 'oidc-client-ts';
+import { UserManagerSettings, WebStorageStateStore } from 'oidc-client-ts';
 
 export function getClientSettings(): UserManagerSettings {
   return {
@@ -31,6 +31,7 @@ export function getClientSettings(): UserManagerSettings {
       process.env.REACT_APP_AUTH_SCOPE ||
       ((window as any)._env_ && (window as any)._env_.REACT_APP_AUTH_SCOPE) ||
       '',
+    userStore: new WebStorageStateStore({ store: window.localStorage }),
     filterProtocolClaims:
       process.env.REACT_APP_AUTH_FILTER_PROTOCOL_CLAIMS === 'true' ||
       ((window as any)._env_ &&

--- a/frontend/src/app/helpers/utility.ts
+++ b/frontend/src/app/helpers/utility.ts
@@ -130,7 +130,7 @@ export const flattenFormRows = (arr: IFormField[][]): IFormField[] => {
 export function getUser() {
   const { authority, client_id } = getClientSettings();
   const storageKey = `oidc.user:${authority}:${client_id}`;
-  const oidcStorage = sessionStorage.getItem(storageKey);
+  const oidcStorage = localStorage.getItem(storageKey);
   if (!oidcStorage) {
     return null;
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Switched Keycloak OIDC user session storage from sessionStorage to localStorage to fix session not being shared across browser tabs.

Fixes # (issue)
SRS-1426

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

 - Logged in, opened a link in a new tab — user session is preserved, protected pages load correctly


## Checklist

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-488-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-488-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-488-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-488-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)