### PR TITLE
fix: Hide private sites from external and unaunthenticated users

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -58,7 +58,7 @@ jobs:
              -Dsonar.projectKey=bcgov-sonarcloud_nr-site-registry-${{ matrix.dir }}
              -Dsonar.sources=src
              -Dsonar.tests.inclusions=**/*spec.ts
-             -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
+             -Dsonar.javascript.lcov.reportPaths=./src/coverage/lcov.info,./coverage/lcov.info
              -Dsonar.cpd.exclusions=**/migrations/**
           sonar_token: ${{ secrets[matrix.token] }}
           

--- a/backend/src/app/resolvers/site/site.resolver.ts
+++ b/backend/src/app/resolvers/site/site.resolver.ts
@@ -250,6 +250,7 @@ export class SiteResolver {
   })
   @Query(() => FindSitesAndPlacesResponse, { name: 'findSitesAndPlaces' })
   async findSitesAndPlaces(
+    @AuthenticatedUser() userInfo: any,
     @Args('searchParam', { type: () => String })
     searchParam: string,
     @Args('limit', { type: () => Int, nullable: true })
@@ -260,6 +261,7 @@ export class SiteResolver {
       const data = await this.siteService.findSitesAndPlaces(
         searchParam,
         limit,
+        userInfo,
       );
 
       return this.sitesAndPlacesResponseProvider.createResponse(

--- a/backend/src/app/resolvers/site/sitePublic.resolver.ts
+++ b/backend/src/app/resolvers/site/sitePublic.resolver.ts
@@ -183,6 +183,7 @@ export class SitePublicResolver {
 
   @Query(() => MapSearchResponse, { name: 'mapSearch' })
   async mapSearch(
+    @AuthenticatedUser() userInfo,
     @Args('searchParam', { type: () => String, nullable: true })
     searchParam: string,
     @Args('polygon', { type: () => [LatLngTupleScalar], nullable: true })
@@ -196,6 +197,7 @@ export class SitePublicResolver {
         searchTerm: searchParam,
         polygon,
         circle,
+        userInfo,
       });
       return this.mapSearchGenericResponseProvider.createResponse(
         'Successfully fetched sites for map',

--- a/backend/src/app/services/site/site.service.spec.ts
+++ b/backend/src/app/services/site/site.service.spec.ts
@@ -1560,10 +1560,11 @@ describe('SiteService', () => {
   });
 
   describe('mapSearch', () => {
-    it('should fetch all sites if no search term is passed', () => {
+    it('should fetch all sites if no search term is passed for IDIR users', () => {
       const mockQueryBuilder: any = {
         where: jest.fn().mockImplementation(() => mockQueryBuilder),
         orWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
+        andWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
         getManyAndCount: jest.fn().mockReturnValue([]),
       };
 
@@ -1571,16 +1572,38 @@ describe('SiteService', () => {
         .spyOn(siteRepository, 'createQueryBuilder')
         .mockImplementation(() => mockQueryBuilder);
 
-      siteService.mapSearch({});
+      siteService.mapSearch({ userInfo: { identity_provider: 'idir' } });
 
       expect(mockQueryBuilder.getManyAndCount).toHaveBeenCalled();
       expect(mockQueryBuilder.where).not.toHaveBeenCalled();
+      expect(mockQueryBuilder.andWhere).not.toHaveBeenCalled();
+    });
+
+    it('should apply public-only visibility filter for non-IDIR users', () => {
+      const mockQueryBuilder: any = {
+        where: jest.fn().mockImplementation(() => mockQueryBuilder),
+        orWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
+        andWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
+        getManyAndCount: jest.fn().mockReturnValue([]),
+      };
+
+      jest
+        .spyOn(siteRepository, 'createQueryBuilder')
+        .mockImplementation(() => mockQueryBuilder);
+
+      siteService.mapSearch({ userInfo: { identity_provider: 'bceid' } });
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'sites.srAction = :srAction',
+        { srAction: 'public' },
+      );
     });
 
     it('should filter sites by trimmed lower-cased search term if provided', () => {
       const mockQueryBuilder: any = {
         where: jest.fn().mockImplementation(() => mockQueryBuilder),
         orWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
+        andWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
         getManyAndCount: jest.fn().mockReturnValue([]),
       };
 
@@ -1589,7 +1612,10 @@ describe('SiteService', () => {
         .mockImplementation(() => mockQueryBuilder);
 
       // Padding spaces are intentional here, do not remove
-      siteService.mapSearch({ searchTerm: '   TeSt   ' });
+      siteService.mapSearch({
+        searchTerm: '   TeSt   ',
+        userInfo: { identity_provider: 'idir' },
+      });
 
       expect(mockQueryBuilder.getManyAndCount).toHaveBeenCalled();
       expect(mockQueryBuilder.where).toHaveBeenCalledTimes(1);
@@ -1612,6 +1638,7 @@ describe('SiteService', () => {
       const mockQueryBuilder: any = {
         where: jest.fn().mockImplementation(() => mockQueryBuilder),
         orWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
+        andWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
         getManyAndCount: jest.fn().mockReturnValue([]),
       };
 
@@ -1625,6 +1652,7 @@ describe('SiteService', () => {
           [10, 20],
           [100, 200],
         ],
+        userInfo: { identity_provider: 'idir' },
       });
       expect(mockQueryBuilder.where).toHaveBeenCalledTimes(1);
       expect(mockQueryBuilder.where).toHaveBeenCalledWith(
@@ -1720,6 +1748,7 @@ describe('SiteService', () => {
       const mockQueryBuilder: any = {
         where: jest.fn().mockImplementation(() => mockQueryBuilder),
         orWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
+        andWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
         getManyAndCount: jest.fn().mockReturnValue([]),
       };
 
@@ -1732,7 +1761,10 @@ describe('SiteService', () => {
         radius: 1000,
       };
 
-      siteService.mapSearch({ circle });
+      siteService.mapSearch({
+        circle,
+        userInfo: { identity_provider: 'idir' },
+      });
 
       expect(mockQueryBuilder.where).toHaveBeenCalledTimes(1);
       expect(mockQueryBuilder.where).toHaveBeenCalledWith(
@@ -1746,6 +1778,7 @@ describe('SiteService', () => {
       const mockQueryBuilder: any = {
         where: jest.fn().mockImplementation(() => mockQueryBuilder),
         orWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
+        andWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
         limit: jest.fn().mockImplementation(() => mockQueryBuilder),
         orderBy: jest.fn().mockImplementation(() => mockQueryBuilder),
         addOrderBy: jest.fn().mockImplementation(() => mockQueryBuilder),
@@ -1760,7 +1793,9 @@ describe('SiteService', () => {
         .spyOn(placesRepo, 'createQueryBuilder')
         .mockImplementation(() => mockQueryBuilder);
 
-      await siteService.findSitesAndPlaces('test', 20);
+      await siteService.findSitesAndPlaces('test', 20, {
+        identity_provider: 'idir',
+      });
 
       expect(mockQueryBuilder.getManyAndCount).toHaveBeenCalledTimes(2);
       expect(mockQueryBuilder.where).toHaveBeenCalledWith(expect.anything(), {
@@ -1769,10 +1804,40 @@ describe('SiteService', () => {
       expect(mockQueryBuilder.limit).toHaveBeenCalledWith(20);
     });
 
+    it('should apply public-only visibility filter for non-IDIR users (sites only)', async () => {
+      const mockQueryBuilder: any = {
+        where: jest.fn().mockImplementation(() => mockQueryBuilder),
+        orWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
+        andWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
+        limit: jest.fn().mockImplementation(() => mockQueryBuilder),
+        orderBy: jest.fn().mockImplementation(() => mockQueryBuilder),
+        addOrderBy: jest.fn().mockImplementation(() => mockQueryBuilder),
+        getManyAndCount: jest.fn().mockReturnValue([]),
+      };
+
+      jest
+        .spyOn(siteRepository, 'createQueryBuilder')
+        .mockImplementation(() => mockQueryBuilder);
+
+      jest
+        .spyOn(placesRepo, 'createQueryBuilder')
+        .mockImplementation(() => mockQueryBuilder);
+
+      await siteService.findSitesAndPlaces('test', 20, {
+        identity_provider: 'bceid',
+      });
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'sites.srAction = :srAction',
+        { srAction: 'public' },
+      );
+    });
+
     it('should bypass DB calls if no search term provided', async () => {
       const mockQueryBuilder: any = {
         where: jest.fn().mockImplementation(() => mockQueryBuilder),
         orWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
+        andWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
         limit: jest.fn().mockImplementation(() => mockQueryBuilder),
         orderBy: jest.fn().mockImplementation(() => mockQueryBuilder),
         getManyAndCount: jest.fn().mockReturnValue([]),

--- a/backend/src/app/services/site/site.service.spec.ts
+++ b/backend/src/app/services/site/site.service.spec.ts
@@ -1599,6 +1599,26 @@ describe('SiteService', () => {
       );
     });
 
+    it('should apply public-only visibility filter when userInfo is missing (anonymous)', () => {
+      const mockQueryBuilder: any = {
+        where: jest.fn().mockImplementation(() => mockQueryBuilder),
+        orWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
+        andWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
+        getManyAndCount: jest.fn().mockReturnValue([]),
+      };
+
+      jest
+        .spyOn(siteRepository, 'createQueryBuilder')
+        .mockImplementation(() => mockQueryBuilder);
+
+      siteService.mapSearch({});
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'sites.srAction = :srAction',
+        { srAction: 'public' },
+      );
+    });
+
     it('should filter sites by trimmed lower-cased search term if provided', () => {
       const mockQueryBuilder: any = {
         where: jest.fn().mockImplementation(() => mockQueryBuilder),
@@ -1826,6 +1846,33 @@ describe('SiteService', () => {
       await siteService.findSitesAndPlaces('test', 20, {
         identity_provider: 'bceid',
       });
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'sites.srAction = :srAction',
+        { srAction: 'public' },
+      );
+    });
+
+    it('should apply public-only visibility filter when userInfo is missing (anonymous) (sites only)', async () => {
+      const mockQueryBuilder: any = {
+        where: jest.fn().mockImplementation(() => mockQueryBuilder),
+        orWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
+        andWhere: jest.fn().mockImplementation(() => mockQueryBuilder),
+        limit: jest.fn().mockImplementation(() => mockQueryBuilder),
+        orderBy: jest.fn().mockImplementation(() => mockQueryBuilder),
+        addOrderBy: jest.fn().mockImplementation(() => mockQueryBuilder),
+        getManyAndCount: jest.fn().mockReturnValue([]),
+      };
+
+      jest
+        .spyOn(siteRepository, 'createQueryBuilder')
+        .mockImplementation(() => mockQueryBuilder);
+
+      jest
+        .spyOn(placesRepo, 'createQueryBuilder')
+        .mockImplementation(() => mockQueryBuilder);
+
+      await siteService.findSitesAndPlaces('test', 20);
 
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
         'sites.srAction = :srAction',

--- a/backend/src/app/services/site/site.service.ts
+++ b/backend/src/app/services/site/site.service.ts
@@ -403,10 +403,12 @@ export class SiteService {
     searchTerm,
     polygon,
     circle,
+    userInfo,
   }: {
     searchTerm?: string;
     polygon?: LatLngTuple[];
     circle?: RadiusSearchParams;
+    userInfo?: any;
   }) {
     this.sitesLogger.log('SiteService.mapSearch() start');
 
@@ -507,12 +509,14 @@ export class SiteService {
       );
     }
 
+    this.applyPublicVisibilityFilterForNonIdirUsers(query, userInfo);
+
     const [result] = await query.getManyAndCount();
     this.sitesLogger.log('SiteService.mapSearch() end');
     return result;
   }
 
-  async findSitesAndPlaces(searchTerm = '', limit = 3) {
+  async findSitesAndPlaces(searchTerm = '', limit = 3, userInfo?: any) {
     this.sitesLogger.log('SiteService.findSitesAndPlaces() start');
 
     const searchTermClean = searchTerm.toLowerCase().trim();
@@ -543,6 +547,8 @@ export class SiteService {
         'ASC',
       )
       .addOrderBy('sites.id', 'ASC');
+
+    this.applyPublicVisibilityFilterForNonIdirUsers(sitesQuery, userInfo);
     placesQuery
       .where('LOWER(places.name) LIKE LOWER(:searchTerm)', {
         searchTerm: `%${searchTermClean}%`,
@@ -556,6 +562,19 @@ export class SiteService {
 
     this.sitesLogger.log('SiteService.findSitesAndPlaces() end');
     return { sites, places };
+  }
+
+  private applyPublicVisibilityFilterForNonIdirUsers(
+    query: any,
+    userInfo?: any,
+  ) {
+    // `sr_action` is a disclosure/visibility flag. Non-IDIR users must never receive non-public sites
+    // (e.g., private sites) from "list-style" endpoints like map pins or autocomplete.
+    if (!userInfo || userInfo?.identity_provider !== UserTypeEum.IDIR) {
+      query.andWhere('sites.srAction = :srAction', {
+        srAction: SRApprovalStatusEnum.PUBLIC,
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description (what this PR fixes)
This PR fixes the map discovery bug where private sites were visible to external (non‑IDIR) users on the map.

# Issue
The main registry search (searchSites) already restricts non‑IDIR / anonymous users to sr_action = public sites.
The map endpoints did not consistently apply the same rule:
mapSearch (pins: initial load, text search, polygon, radius) could return private sites.
findSitesAndPlaces (map autocomplete) could suggest private sites.

# Fix
mapSearch now applies the same disclosure filter as searchSites for non‑IDIR/anonymous users:
non‑IDIR / anonymous → only sr_action = public sites returned as pins/search results
IDIR → unchanged
findSitesAndPlaces now applies the same disclosure filter to the sites portion of autocomplete results for non‑IDIR/anonymous users (places unaffected).
This is implemented via a shared helper (applyPublicVisibilityFilterForNonIdirUsers) so the rule stays consistent across these “discovery/list” endpoints.


# Test coverage
Updated/added unit tests to verify:
mapSearch applies sr_action = public for non‑IDIR users and does not for IDIR.
findSitesAndPlaces applies the same sr_action = public restriction for non‑IDIR (sites list)


# Important note / known gap (not addressed in this PR)
Direct navigation by site ID is still possible because findSiteBySiteId currently fetches by { id } without enforcing public-only visibility for external/anonymous users:

If a site row is still in the DB with sr_action = private (or any state treated as non‑public), an external or anonymous user can still open /site/details/:id or /map?site=:id and potentially get full details, because findSiteBySiteId loads by id only (no public-only filter on that path for the normal non‑pending case).


Separate ticket: apply the same disclosure rule to findSiteBySiteId (details-by-id) and optionally implement a silent redirect to search when details are unavailable.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-495-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-495-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)