### PR TITLE
fix: SRS-1428: hide Updates tab for internal user by default, add `intent` prop to Button component

### DIFF
--- a/frontend/src/app/components/approve/ApproveReject.css
+++ b/frontend/src/app/components/approve/ApproveReject.css
@@ -32,27 +32,3 @@
   display: flex;
   justify-content: space-between;
 }
-
-.not-public-btn {
-  padding: var(--layout-padding-small) var(--layout-padding-medium)
-    var(--layout-padding-small) var(--layout-padding-medium);
-  gap: var(--layout-margin-small);
-  border-radius: var(--layout-border-radius-medium);
-  border: 1px 0px 0px 0px;
-  display: flex;
-  background-color: var(--support-surface-color-danger, #f4e1e2);
-  border: 1px solid var(--support-border-color-danger, #ce3e39);
-  cursor: pointer;
-}
-
-.approve-btn {
-  padding: var(--layout-padding-small) var(--layout-padding-medium)
-    var(--layout-padding-small) var(--layout-padding-medium);
-  gap: var(--layout-margin-small);
-  border-radius: var(--layout-border-radius-medium);
-  border: 1px 0px 0px 0px;
-  display: flex;
-  border: 1px solid var(--support-border-color-success, #42814a);
-  background-color: var(--support-surface-color-success, #f6fff8);
-  cursor: pointer;
-}

--- a/frontend/src/app/components/approve/ApproveReject.tsx
+++ b/frontend/src/app/components/approve/ApproveReject.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import './ApproveReject.css';
 import { CaretRightIcon, DropdownIcon } from '../common/icon';
 import { Link } from 'react-router-dom';
+import { Button } from '../button/Button';
 
 export interface IApproveReject {
   name: string;
@@ -59,7 +60,6 @@ export interface IApproveRejectButtons {
   rejectLabel?: string;
   approveRejectHandler: (approved: boolean) => void;
 }
-
 export const ApproveRejectButtons: React.FC<IApproveRejectButtons> = ({
   approveLabel,
   rejectLabel,
@@ -73,22 +73,20 @@ export const ApproveRejectButtons: React.FC<IApproveRejectButtons> = ({
       className="approve-reject-actions"
       data-testid="approve-reject-actions-div"
     >
-      <div
-        className="not-public-btn"
+      <Button
+        intent="danger"
         data-testid="not-public-btn"
         onClick={() => approveRejectHandler(false)}
       >
-        {' '}
         {rejectLabel}
-      </div>
-      <div
-        className="approve-btn"
+      </Button>
+      <Button
+        intent="success"
         data-testid="approve-btn"
         onClick={() => approveRejectHandler(true)}
       >
-        {' '}
         {approveLabel}
-      </div>
+      </Button>
     </div>
   );
 };

--- a/frontend/src/app/components/button/Button.css
+++ b/frontend/src/app/components/button/Button.css
@@ -100,3 +100,67 @@
 .SITE-Button.btn-icon.btn-active:hover {
   background: var(--surface-color-primary-default);
 }
+
+/* Intent - Danger */
+.SITE-Button.primary.danger {
+  background-color: var(--surface-color-primary-danger-button-default);
+  border-color: var(--surface-color-primary-danger-button-default);
+  color: var(--typography-color-primary-invert);
+}
+.SITE-Button.primary.danger:disabled {
+  background-color: var(--surface-color-primary-danger-button-disabled);
+  border-color: var(--surface-color-primary-danger-button-disabled);
+  color: var(--typography-color-disabled);
+}
+.SITE-Button.primary.danger:hover:not(:disabled),
+.SITE-Button.primary.danger:focus {
+  background-color: var(--surface-color-primary-danger-button-hover);
+  border-color: var(--surface-color-primary-danger-button-hover);
+}
+
+.SITE-Button.secondary.danger {
+  border-color: var(--support-border-color-danger);
+  color: var(--typography-color-danger);
+}
+.SITE-Button.secondary.danger:hover:not(:disabled) {
+  background-color: var(--support-surface-color-danger);
+}
+
+.SITE-Button.tertiary.danger {
+  color: var(--typography-color-danger);
+}
+.SITE-Button.tertiary.danger:hover:not(:disabled) {
+  background-color: var(--support-surface-color-danger);
+}
+
+/* Intent - Success */
+.SITE-Button.primary.success {
+  background-color: var(--support-border-color-success);
+  border-color: var(--support-border-color-success);
+  color: var(--typography-color-primary-invert);
+}
+.SITE-Button.primary.success:disabled {
+  background-color: var(--surface-color-primary-disabled);
+  border-color: var(--surface-color-primary-disabled);
+  color: var(--typography-color-disabled);
+}
+.SITE-Button.primary.success:hover:not(:disabled),
+.SITE-Button.primary.success:focus {
+  background-color: #35673c; /* ~20% darker than --support-border-color-success (#42814A) */
+  border-color: #35673c;
+}
+
+.SITE-Button.secondary.success {
+  border-color: var(--support-border-color-success);
+  color: var(--icons-color-success);
+}
+.SITE-Button.secondary.success:hover:not(:disabled) {
+  background-color: var(--support-surface-color-success);
+}
+
+.SITE-Button.tertiary.success {
+  color: var(--icons-color-success);
+}
+.SITE-Button.tertiary.success:hover:not(:disabled) {
+  background-color: var(--support-surface-color-success);
+}

--- a/frontend/src/app/components/button/Button.tsx
+++ b/frontend/src/app/components/button/Button.tsx
@@ -4,11 +4,13 @@ import clsx from 'clsx';
 import './Button.css';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'icon';
+export type ButtonIntent = 'default' | 'danger' | 'success';
 export type ButtonSize = 'small' | 'medium' | 'large';
 
 type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   size?: ButtonSize;
   variant?: ButtonVariant;
+  intent?: ButtonIntent;
   active?: boolean;
 };
 
@@ -17,6 +19,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     {
       variant = 'primary',
       size = 'medium',
+      intent = 'default',
       className,
       active = false,
       ...props
@@ -31,6 +34,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           'SITE-Button',
           variantCssClass,
           size,
+          intent !== 'default' && intent,
           active && 'btn-active',
           className,
         ])}

--- a/frontend/src/app/features/details/SiteDetails.tsx
+++ b/frontend/src/app/features/details/SiteDetails.tsx
@@ -232,7 +232,9 @@ const SiteDetails = () => {
     if (
       isUserOfType(UserRoleType.SR) &&
       !hasNoPendingUpdatesFromState &&
-      viewMode !== SiteDetailsMode.EditMode
+      viewMode !== SiteDetailsMode.EditMode &&
+      (!isUserOfType(UserRoleType.INTERNAL) ||
+        viewMode === SiteDetailsMode.SRMode)
     ) {
       SetNavComponents(getNavComponents(true));
     } else {
@@ -372,7 +374,8 @@ const SiteDetails = () => {
     if (
       isUserOfType(UserRoleType.SR) &&
       !hasNoPendingUpdatesFromState &&
-      mode !== SiteDetailsMode.EditMode
+      mode !== SiteDetailsMode.EditMode &&
+      (!isUserOfType(UserRoleType.INTERNAL) || mode === SiteDetailsMode.SRMode)
     ) {
       SetNavComponents(getNavComponents(true));
     } else {


### PR DESCRIPTION
In this PR:

- Hide "Updates" tab by default if internal user has SR role - they need to enter SR mode to see it.
- Add `intent` prop to Button component. Possible values: `default | success | danger`
- Replace "clickable div-as-buttons" in SR approval section with the new implementation.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-500-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-500-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)