### PR TITLE
fix: Add toaster message to notify users about the private sites

### DIFF
--- a/frontend/src/app/components/alert/Alert.css
+++ b/frontend/src/app/components/alert/Alert.css
@@ -6,6 +6,10 @@
   width: 100%;
 }
 
+.toast-info {
+  width: 500px;
+}
+
 .Toastify__toast-container--bottom-right {
   right: 5em;
 }

--- a/frontend/src/app/components/alert/Alert.tsx
+++ b/frontend/src/app/components/alert/Alert.tsx
@@ -9,11 +9,14 @@ interface ErrorMsgProps {
   customFooterMessage?: string;
 }
 
-const createToastOptions = (type: 'error' | 'success'): ToastOptions => ({
+const createToastOptions = (
+  type: 'error' | 'success' | 'info',
+): ToastOptions => ({
   className: `toast-${type}`,
   type,
   closeButton: true,
   position: 'top-center',
+  autoClose: type === 'info' ? 2500 : undefined,
 });
 
 const ErrorMsg: React.FC<ErrorMsgProps> = ({
@@ -55,6 +58,20 @@ const SuccessMsg: React.FC<SuccessMsgProps> = ({ customMessage }: any) => (
   </div>
 );
 
+interface InfoMsgProps {
+  customMessage?: string;
+  customHeading?: string;
+}
+
+const InfoMsg: React.FC<InfoMsgProps> = ({ customMessage, customHeading }) => (
+  <div className="custom" role="alert">
+    {customHeading ? (
+      <span className="error-heading">{customHeading}</span>
+    ) : null}
+    <span className="error-text">{customMessage ?? ''}</span>
+  </div>
+);
+
 export const notifyError = (
   message?: string,
   headerText?: string,
@@ -72,4 +89,11 @@ export const notifyError = (
 
 export const notifySuccess = (message?: string) => {
   toast(<SuccessMsg customMessage={message} />, createToastOptions('success'));
+};
+
+export const notifyInfo = (message?: string, heading?: string) => {
+  toast(
+    <InfoMsg customMessage={message} customHeading={heading} />,
+    createToastOptions('info'),
+  );
 };

--- a/frontend/src/app/features/details/SiteDetails.tsx
+++ b/frontend/src/app/features/details/SiteDetails.tsx
@@ -69,6 +69,7 @@ import {
 } from './disclosure/DisclosureSlice';
 import { addCartItem, resetCartItemAddedStatus } from '../cart/CartSlice';
 import { useAuth } from 'react-oidc-context';
+import { notifyInfo } from '../../components/alert/Alert';
 import {
   fetchNotationParticipants,
   updateSiteNotation,
@@ -176,6 +177,7 @@ const SiteDetails = () => {
   const fromScreen = location.state?.fromLabel || 'Search'; // Default to "Unknown Screen" if no state is passed
   const fromPathRef = useRef(fromPath);
   const fromScreenRef = useRef(fromScreen);
+  const lastUnavailableToastSiteIdRef = useRef<string | null>(null);
   const loggedInUser = getUser();
   // TODO: this is for future use when we support automatic flow of creating new site for specific application.
   // We need applicationid and newly created siteId to fill cats db  in order to keep both application in sync.
@@ -400,6 +402,13 @@ const SiteDetails = () => {
     // Cart details: do not auto-redirect (user can use back / cart UI).
     if (location.pathname.includes('/site/cart/site/details/')) return;
 
+    if (lastUnavailableToastSiteIdRef.current !== id) {
+      notifyInfo(
+        'This site is private or unavailable. You have been returned to Search.',
+        'Site unavailable',
+      );
+      lastUnavailableToastSiteIdRef.current = id;
+    }
     navigate('/search', { replace: true });
   }, [
     id,

--- a/frontend/src/app/features/map/MapView.test.tsx
+++ b/frontend/src/app/features/map/MapView.test.tsx
@@ -100,6 +100,12 @@ jest.mock('react-oidc-context', () => ({
   useAuth: () => ({ user: null }),
 }));
 
+jest.mock('../../components/alert/Alert', () => ({
+  __esModule: true,
+  notifyInfo: jest.fn(),
+  notifySuccess: jest.fn(),
+}));
+
 jest.mock('./useFlyToSelectedSite', () => ({
   __esModule: true,
   useFlyToSelectedSite: jest.fn(),
@@ -241,5 +247,39 @@ describe('MapView', () => {
     });
 
     expect(screen.getByTestId('site-markers').textContent).toBe('1');
+  });
+
+  it('clears selected site query and notifies when site not found', async () => {
+    const { default: MapView } = require('./MapView') as {
+      default: React.ComponentType;
+    };
+    const { useMapSearchContext } =
+      require('./mapSearchContext/MapSearchContext') as {
+        useMapSearchContext: jest.Mock;
+      };
+    const { notifyInfo } = require('../../components/alert/Alert') as {
+      notifyInfo: jest.Mock;
+    };
+
+    const setQuery = jest.fn();
+    (useMapSearchContext as jest.Mock).mockReturnValue({
+      searchTerm: null,
+      activeTool: null,
+      polygonVertices: [] as LatLngTuple[],
+      center: null,
+      radius: 1000,
+      selectedSiteId: '77',
+      setQuery,
+    });
+
+    render(<MapView />);
+
+    await waitFor(() => {
+      expect(setQuery).toHaveBeenCalledWith({ site: undefined }, 'replace');
+    });
+    expect(notifyInfo).toHaveBeenCalledWith(
+      'This site is private or unavailable. The map selection has been cleared.',
+      'Site unavailable',
+    );
   });
 });

--- a/frontend/src/app/features/map/MapView.tsx
+++ b/frontend/src/app/features/map/MapView.tsx
@@ -5,6 +5,7 @@ import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import clsx from 'clsx';
 import { useAuth } from 'react-oidc-context';
+import { notifyInfo } from '../../components/alert/Alert';
 
 import { MyLocationMarker } from './MyLocationMarker'; // Import the MyLocationMarker component
 
@@ -46,6 +47,7 @@ export type Site = MapSearchQuery['mapSearch']['data'][number];
  */
 function MapView() {
   const auth = useAuth();
+  const lastUnavailableToastSiteIdRef = useRef<string | null>(null);
   const theme = useTheme();
   const isSmall = useMediaQuery(theme.breakpoints.down('md'));
   // Feature flag for turning OpenStreetMap tiles gray
@@ -109,6 +111,13 @@ function MapView() {
   useEffect(() => {
     if (!selectedSiteId || selectedSiteLoading) return;
     if (selectedSite) return;
+    if (lastUnavailableToastSiteIdRef.current !== selectedSiteId) {
+      notifyInfo(
+        'This site is private or unavailable. The map selection has been cleared.',
+        'Site unavailable',
+      );
+      lastUnavailableToastSiteIdRef.current = selectedSiteId;
+    }
     setQuery({ site: undefined }, 'replace');
   }, [selectedSiteId, selectedSiteLoading, selectedSite, setQuery]);
 


### PR DESCRIPTION
# Description

When someone opens a site that they are not allowed to see, the app sends them back to Search. Without a message, that feels broken (“why did nothing load?”).

So we show a short info message when they land to search page.

<img width="763" height="223" alt="Screenshot 2026-04-22 at 10 44 26 AM" src="https://github.com/user-attachments/assets/2315e3c3-027c-44d1-ba7b-aab5b6b908a7" />

<img width="593" height="266" alt="Screenshot 2026-04-22 at 10 45 27 AM" src="https://github.com/user-attachments/assets/5ae575f2-c8ba-4d75-89e3-109f74db5e5a" />



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-514-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-514-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)