### PR TITLE
chore: Temporarily Disable PDB

### DIFF
--- a/charts/app/values-prod.yaml
+++ b/charts/app/values-prod.yaml
@@ -9,8 +9,9 @@ global:
 
 backend:
   pdb:
-    enabled: true
-    # Trying to force replicaCount to 1 during deployment so we only run the seed data scripts once.
+    # Temporarily disabled until we can come up with a strategy for database seeding with multiple pods. See SRS-1559.
+    enabled: false
+
 
   # Temporarily going for 1 pod max, so that we only run the SEED_DATA import scripts once, instead of twice concurrently.
   replicaCount: 1

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -68,7 +68,7 @@ backend:
       route.openshift.io/termination: "edge"
   pdb:
     # Temporarily disabled until we can come up with a strategy for database seeding with multiple pods. See SRS-1559.
-    enabled: false # enable it in PRODUCTION for having pod disruption budget.
+    enabled: false
     minAvailable: 1 # the minimum number of pods that must be available during the disruption budget.
 frontend:
   # -- enable or disable a component deployment.

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -67,7 +67,8 @@ backend:
     annotations:
       route.openshift.io/termination: "edge"
   pdb:
-    enabled: true # enable it in PRODUCTION for having pod disruption budget.
+    # Temporarily disabled until we can come up with a strategy for database seeding with multiple pods. See SRS-1559.
+    enabled: false # enable it in PRODUCTION for having pod disruption budget.
     minAvailable: 1 # the minimum number of pods that must be available during the disruption budget.
 frontend:
   # -- enable or disable a component deployment.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

This disables our Pod Disruption Budget in Prod and Test. 

There is currently an issue where we can only have one backend pod running due to a race condition with the database. If we only have one pod with a minimum available of one, then it causes issues for operations because we can't scale down the service using a rolling restart for operations like infrastructure migrations.

A proper fix for this is being tracking in SRS-1559

Fixes # SRS-1469


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-517-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-517-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)