### PR TITLE
fix: Split public vs logged-in findSiteBySiteId and remove pending from public

### DIFF
--- a/backend/src/app/resolvers/site/sitePublic.resolver.spec.ts
+++ b/backend/src/app/resolvers/site/sitePublic.resolver.spec.ts
@@ -91,36 +91,33 @@ describe('SiteResolver', () => {
   describe('findSiteBySiteId', () => {
     it('should call siteService.findSiteBySiteId with the provided siteId', () => {
       const siteId = '123';
-      const userInfo = { sub: 'user', identity_provider: 'bceid' };
-      siteResolver.findSiteBySiteId(userInfo, siteId, false);
+      siteResolver.findSiteBySiteId(siteId);
       expect(siteService.findSiteBySiteId).toHaveBeenCalledWith(
         siteId,
         false,
-        userInfo,
+        null,
       );
     });
 
     it('finds a matching site id', async () => {
       const expectedResult = [sampleSites[0]];
       const siteId = '123';
-      const userInfo = { sub: 'user', identity_provider: 'bceid' };
 
       (siteService.findSiteBySiteId as jest.Mock).mockResolvedValue(
         expectedResult,
       );
-      const result = await siteResolver.findSiteBySiteId(userInfo, siteId, false);
+      const result = await siteResolver.findSiteBySiteId(siteId);
       expect(result).toEqual(expectedResult);
     });
 
     it('has no matches with the site Id parameter', async () => {
       const expectedResult = undefined;
       const siteId = '111';
-      const userInfo = { sub: 'user', identity_provider: 'bceid' };
 
       (siteService.findSiteBySiteId as jest.Mock).mockResolvedValue(
         expectedResult,
       );
-      const result = await siteResolver.findSiteBySiteId(userInfo, siteId, false);
+      const result = await siteResolver.findSiteBySiteId(siteId);
       expect(result).toEqual(expectedResult);
     });
   });

--- a/backend/src/app/resolvers/site/sitePublic.resolver.spec.ts
+++ b/backend/src/app/resolvers/site/sitePublic.resolver.spec.ts
@@ -91,33 +91,36 @@ describe('SiteResolver', () => {
   describe('findSiteBySiteId', () => {
     it('should call siteService.findSiteBySiteId with the provided siteId', () => {
       const siteId = '123';
-      siteResolver.findSiteBySiteId(siteId, false);
+      const userInfo = { sub: 'user', identity_provider: 'bceid' };
+      siteResolver.findSiteBySiteId(userInfo, siteId, false);
       expect(siteService.findSiteBySiteId).toHaveBeenCalledWith(
         siteId,
         false,
-        null,
+        userInfo,
       );
     });
 
     it('finds a matching site id', async () => {
       const expectedResult = [sampleSites[0]];
       const siteId = '123';
+      const userInfo = { sub: 'user', identity_provider: 'bceid' };
 
       (siteService.findSiteBySiteId as jest.Mock).mockResolvedValue(
         expectedResult,
       );
-      const result = await siteResolver.findSiteBySiteId(siteId, false);
+      const result = await siteResolver.findSiteBySiteId(userInfo, siteId, false);
       expect(result).toEqual(expectedResult);
     });
 
     it('has no matches with the site Id parameter', async () => {
       const expectedResult = undefined;
       const siteId = '111';
+      const userInfo = { sub: 'user', identity_provider: 'bceid' };
 
       (siteService.findSiteBySiteId as jest.Mock).mockResolvedValue(
         expectedResult,
       );
-      const result = await siteResolver.findSiteBySiteId(siteId, false);
+      const result = await siteResolver.findSiteBySiteId(userInfo, siteId, false);
       expect(result).toEqual(expectedResult);
     });
   });

--- a/backend/src/app/resolvers/site/sitePublic.resolver.ts
+++ b/backend/src/app/resolvers/site/sitePublic.resolver.ts
@@ -147,21 +147,12 @@ export class SitePublicResolver {
   }
 
   @Query(() => FetchSiteDetailsResponse, { name: 'findSiteBySiteId' })
-  findSiteBySiteId(
-    @AuthenticatedUser() userInfo,
-    @Args('siteId', { type: () => String }) siteId: string,
-    @Args('pending', { type: () => Boolean, nullable: true })
-    showPending: boolean,
-  ) {
+  findSiteBySiteId(@Args('siteId', { type: () => String }) siteId: string) {
     this.sitesLogger.log(
-      'SiteResolver.findSiteBySiteId() start siteId:' +
-        ' ' +
-        siteId +
-        ' showPending = ' +
-        showPending,
+      'SiteResolver.findSiteBySiteId() start siteId:' + ' ' + siteId,
     );
 
-    return this.siteService.findSiteBySiteId(siteId, showPending, userInfo);
+    return this.siteService.findSiteBySiteId(siteId, false, null);
   }
 
   @Query(() => FetchSiteInsights, { name: 'getSiteInsights' })

--- a/backend/src/app/resolvers/site/sitePublic.resolver.ts
+++ b/backend/src/app/resolvers/site/sitePublic.resolver.ts
@@ -148,6 +148,7 @@ export class SitePublicResolver {
 
   @Query(() => FetchSiteDetailsResponse, { name: 'findSiteBySiteId' })
   findSiteBySiteId(
+    @AuthenticatedUser() userInfo,
     @Args('siteId', { type: () => String }) siteId: string,
     @Args('pending', { type: () => Boolean, nullable: true })
     showPending: boolean,
@@ -160,7 +161,7 @@ export class SitePublicResolver {
         showPending,
     );
 
-    return this.siteService.findSiteBySiteId(siteId, showPending, null);
+    return this.siteService.findSiteBySiteId(siteId, showPending, userInfo);
   }
 
   @Query(() => FetchSiteInsights, { name: 'getSiteInsights' })

--- a/backend/src/app/services/site/site.service.spec.ts
+++ b/backend/src/app/services/site/site.service.spec.ts
@@ -663,6 +663,24 @@ describe('SiteService', () => {
         relations,
       });
     });
+
+    it('non-IDIR user cannot load pending site details (pending flag is ignored)', async () => {
+      const siteId = '8002';
+      // First call is the deletion-check; second is the actual site lookup
+      (siteRepository.findOne as jest.Mock)
+        .mockResolvedValueOnce({ id: siteId, whoDeleted: null })
+        .mockResolvedValueOnce(null);
+
+      await siteService.findSiteBySiteId(siteId, true, {
+        sub: 'external-user',
+        identity_provider: 'bceid',
+      });
+
+      expect(siteRepository.findOne).toHaveBeenCalledWith({
+        where: { id: siteId, srAction: SRApprovalStatusEnum.PUBLIC },
+        relations,
+      });
+    });
   });
 
   describe('updateSiteRegistryRecord', () => {

--- a/backend/src/app/services/site/site.service.ts
+++ b/backend/src/app/services/site/site.service.ts
@@ -620,11 +620,11 @@ export class SiteService {
     pending: boolean,
     userInfo: any,
   ) {
-    if (pending) {
+    const isIdir = userInfo?.identity_provider === UserTypeEum.IDIR;
+    if (pending && isIdir) {
       return { id: siteId, srAction: SRApprovalStatusEnum.PENDING };
     }
 
-    const isIdir = userInfo?.identity_provider === UserTypeEum.IDIR;
     return isIdir
       ? { id: siteId }
       : { id: siteId, srAction: SRApprovalStatusEnum.PUBLIC };

--- a/frontend/src/app/features/details/srUpdates/srUpdatesSlice.ts
+++ b/frontend/src/app/features/details/srUpdates/srUpdatesSlice.ts
@@ -2,7 +2,7 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { SRUpdatesState } from './srUpdatesState';
 import { getAxiosInstance } from '../../../helpers/utility';
 import { GRAPHQL } from '../../../helpers/endpoints';
-import { graphqlSiteDetailsQuery } from '../../site/graphql/Site';
+import { graphqlSiteDetailsQueryForLoggedIn } from '../../site/graphql/Site';
 import { print } from 'graphql';
 import { updateSiteDetails } from '../graphql/SaveSiteDetails';
 import { RequestStatus } from '../../../helpers/requests/status';
@@ -188,13 +188,13 @@ export const fetchPendingSitesDetailsForApproval = createAsyncThunk(
   async (args: { siteId: string; showPending: Boolean }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
-        query: print(graphqlSiteDetailsQuery()),
+        query: print(graphqlSiteDetailsQueryForLoggedIn()),
         variables: {
           siteId: args.siteId,
           pending: args.showPending,
         },
       });
-      return response.data.data.findSiteBySiteId;
+      return response.data.data.findSiteBySiteIdLoggedInUser;
     } catch (error) {
       throw error;
     }

--- a/frontend/src/app/features/site/dto/SiteSlice.ts
+++ b/frontend/src/app/features/site/dto/SiteSlice.ts
@@ -41,10 +41,12 @@ export const fetchSitesDetails = createAsyncThunk(
             ? graphqlSiteDetailsQueryForLoggedIn()
             : graphqlSiteDetailsQuery(),
         ),
-        variables: {
-          siteId: args.siteId,
-          pending: args.showPending,
-        },
+        variables: user
+          ? {
+              siteId: args.siteId,
+              pending: args.showPending,
+            }
+          : { siteId: args.siteId },
       });
       return user
         ? response.data?.data?.findSiteBySiteIdLoggedInUser?.data

--- a/frontend/src/app/features/site/graphql/Site.ts
+++ b/frontend/src/app/features/site/graphql/Site.ts
@@ -105,8 +105,8 @@ query searchSitesForAuthenticatedUsers($searchParam: String!,  $page: Int!, $pag
 
 export const graphqlSiteDetailsQuery = () => {
   return gql`
-    query findSiteBySiteId($siteId: String!, $pending: Boolean) {
-      findSiteBySiteId(siteId: $siteId, pending: $pending) {
+    query findSiteBySiteId($siteId: String!) {
+      findSiteBySiteId(siteId: $siteId) {
         data {
           id
           commonName

--- a/frontend/src/graphql/generated.ts
+++ b/frontend/src/graphql/generated.ts
@@ -856,7 +856,6 @@ export type Query = {
 
 
 export type QueryFindSiteBySiteIdArgs = {
-  pending?: InputMaybe<Scalars['Boolean']['input']>;
   siteId: Scalars['String']['input'];
 };
 


### PR DESCRIPTION
The public “site by id” API accepted a pending  flag, so any client—including external users—could send pending: true and ask the server for pending / not-yet-approved site data. That is an authorization issue: the GraphQL contract made pending reads look like a normal, client-controlled switch instead of a staff-only capability. We removed pending from the public field and route pending review through findSiteBySiteIdLoggedInUser, with the service still enforcing who may treat a site as pending (e.g. IDIR), so externals can’t drive pending access by tweaking query variables.

The public GraphQL field findSiteBySiteId no longer accepts pending and always loads non-pending/public behaviour; findSiteBySiteIdLoggedInUser is used when the app needs pending and a real user context (logged-in and SR flows).


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-520-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-520-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)