### PR TITLE
feat: SRS-1431: Disable "View Document" buttons if we don't have the document in object storage

### DIFF
--- a/frontend/src/app/features/details/documents/Document.tsx
+++ b/frontend/src/app/features/details/documents/Document.tsx
@@ -59,11 +59,7 @@ const Document: React.FC<IDocumentProps> = ({
 
   approveRejectHandler = approveRejectHandler ?? (() => {});
 
-  const documentAvailable =
-    document?.objectId !== null && document?.objectId !== undefined
-      ? true
-      : Boolean(document?.file);
-
+  const documentAvailable =Boolean(document?.objectId) || Boolean(document?.file);
 
   const renderDocumentAction = (
     button: React.ReactElement,

--- a/frontend/src/app/features/details/documents/Document.tsx
+++ b/frontend/src/app/features/details/documents/Document.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../../components/common/icon';
 import { ApproveRejectButtons } from '../../../components/approve/ApproveReject';
 import { Button } from '../../../components/button/Button';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 interface IDocumentProps {
   userType: UserType;
@@ -34,6 +35,8 @@ interface IDocumentProps {
   showApproveRejectSection?: boolean;
 }
 
+const DOCUMENT_UNAVAILABLE_LABEL = 'Document is unavailable';
+
 const Document: React.FC<IDocumentProps> = ({
   userType,
   mode,
@@ -55,6 +58,30 @@ const Document: React.FC<IDocumentProps> = ({
   showApproveRejectSection = showApproveRejectSection ?? false;
 
   approveRejectHandler = approveRejectHandler ?? (() => {});
+
+  const documentAvailable =
+    document?.objectId !== null && document?.objectId !== undefined
+      ? true
+      : Boolean(document?.file);
+
+
+  const renderDocumentAction = (
+    button: React.ReactElement,
+    tooltipId: string,
+  ) => {
+    if (documentAvailable) {
+      return button;
+    }
+
+    return (
+      <OverlayTrigger
+        placement="top"
+        overlay={<Tooltip id={tooltipId}>{DOCUMENT_UNAVAILABLE_LABEL}</Tooltip>}
+      >
+        <span className="d-inline-flex">{button}</span>
+      </OverlayTrigger>
+    );
+  };
 
   return (
     <PanelWithUpDown
@@ -87,18 +114,29 @@ const Document: React.FC<IDocumentProps> = ({
             className="d-flex py-2 mb-3 gap-2 flex-wrap flex-column flex-sm-row"
             key={document?.id}
           >
-            <Button onClick={handleViewOnline}>
-              <ViewOnlyIcon />
-              View Document
-            </Button>
-            <Button
-              variant="secondary"
-              onClick={handleDownload}
-              disabled={viewMode === SiteDetailsMode.SRMode}
-            >
-              <DownloadPdfIcon />
-              Download (PDF)
-            </Button>
+              {renderDocumentAction(
+                <Button
+                  onClick={handleViewOnline}
+                  disabled={!documentAvailable}
+                  aria-label={!documentAvailable ? DOCUMENT_UNAVAILABLE_LABEL : undefined}
+                >
+                  <ViewOnlyIcon />
+                  View Document
+                </Button>,
+                `view-document-tooltip-${document?.id ?? uniqueId}`,
+              )}
+              {renderDocumentAction(
+                <Button
+                  variant="secondary"
+                  onClick={handleDownload}
+                  disabled={viewMode === SiteDetailsMode.SRMode || !documentAvailable}
+                  aria-label={!documentAvailable ? DOCUMENT_UNAVAILABLE_LABEL : undefined}
+                >
+                  <DownloadPdfIcon />
+                  Download (PDF)
+                </Button>,
+                `download-document-tooltip-${document?.id ?? uniqueId}`,
+              )}
             {viewMode === SiteDetailsMode.EditMode &&
               userType === UserType.Internal && (
                 <>

--- a/frontend/src/app/features/details/documents/Document.tsx
+++ b/frontend/src/app/features/details/documents/Document.tsx
@@ -59,7 +59,8 @@ const Document: React.FC<IDocumentProps> = ({
 
   approveRejectHandler = approveRejectHandler ?? (() => {});
 
-  const documentAvailable =Boolean(document?.objectId) || Boolean(document?.file);
+  const documentAvailable =
+    Boolean(document?.objectId) || Boolean(document?.file);
 
   const renderDocumentAction = (
     button: React.ReactElement,
@@ -110,29 +111,35 @@ const Document: React.FC<IDocumentProps> = ({
             className="d-flex py-2 mb-3 gap-2 flex-wrap flex-column flex-sm-row"
             key={document?.id}
           >
-              {renderDocumentAction(
-                <Button
-                  onClick={handleViewOnline}
-                  disabled={!documentAvailable}
-                  aria-label={!documentAvailable ? DOCUMENT_UNAVAILABLE_LABEL : undefined}
-                >
-                  <ViewOnlyIcon />
-                  View Document
-                </Button>,
-                `view-document-tooltip-${document?.id ?? uniqueId}`,
-              )}
-              {renderDocumentAction(
-                <Button
-                  variant="secondary"
-                  onClick={handleDownload}
-                  disabled={viewMode === SiteDetailsMode.SRMode || !documentAvailable}
-                  aria-label={!documentAvailable ? DOCUMENT_UNAVAILABLE_LABEL : undefined}
-                >
-                  <DownloadPdfIcon />
-                  Download (PDF)
-                </Button>,
-                `download-document-tooltip-${document?.id ?? uniqueId}`,
-              )}
+            {renderDocumentAction(
+              <Button
+                onClick={handleViewOnline}
+                disabled={!documentAvailable}
+                aria-label={
+                  !documentAvailable ? DOCUMENT_UNAVAILABLE_LABEL : undefined
+                }
+              >
+                <ViewOnlyIcon />
+                View Document
+              </Button>,
+              `view-document-tooltip-${document?.id ?? uniqueId}`,
+            )}
+            {renderDocumentAction(
+              <Button
+                variant="secondary"
+                onClick={handleDownload}
+                disabled={
+                  viewMode === SiteDetailsMode.SRMode || !documentAvailable
+                }
+                aria-label={
+                  !documentAvailable ? DOCUMENT_UNAVAILABLE_LABEL : undefined
+                }
+              >
+                <DownloadPdfIcon />
+                Download (PDF)
+              </Button>,
+              `download-document-tooltip-${document?.id ?? uniqueId}`,
+            )}
             {viewMode === SiteDetailsMode.EditMode &&
               userType === UserType.Internal && (
                 <>


### PR DESCRIPTION
In this PR:

- Disable the View / Download document buttons if we don't have the reference to the document in blob storage.

Demo:

<img width="1399" height="736" alt="image" src="https://github.com/user-attachments/assets/f457ed81-204a-4d76-81a9-7ca3654ccdcc" />


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-524-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-524-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)