### PR TITLE
feat:  SRS-1590 reset error state on toggle between edit and view modes; add max Length validation for note field

### DIFF
--- a/frontend/src/app/components/input-controls/InputControls.tsx
+++ b/frontend/src/app/components/input-controls/InputControls.tsx
@@ -158,6 +158,11 @@ export const TextInput: React.FC<InputProps> = ({
   const ContainerElement = tableMode ? 'td' : 'div';
   const [error, setError] = useState<string | null>(null);
 
+  // Reset error when toggling between edit and view modes
+  useEffect(() => {
+    setError(null);
+  }, [isEditing]);
+
   const validateInput = (inputValue: string) => {
     if (validation?.required && !inputValue.trim()) {
       setError(validation.customMessage || ' ');

--- a/frontend/src/app/features/details/participants/ParticipantConfig.tsx
+++ b/frontend/src/app/features/details/participants/ParticipantConfig.tsx
@@ -117,7 +117,7 @@ export const GetConfig = () => {
       columnSize: ColumnSize.Triple,
       displayType: {
         type: FormFieldType.Text,
-        label: '',
+        label: 'Note',
         placeholder: 'Note',
         graphQLPropertyName: 'note',
         value: '',
@@ -127,6 +127,9 @@ export const GetConfig = () => {
         customEditLabelCss: 'custom-participant-edit-label',
         customEditInputTextCss: 'custom-participant-edit-input',
         tableMode: true,
+        validation: {
+          maxLength: 255, // Set a maximum length for the note
+        },
       },
     },
     {


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-527-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-527-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)