### PR TITLE
fix: SRS-1602: Fix folio confirmation modal copy

### DIFF
--- a/frontend/src/app/features/folios/Folios.tsx
+++ b/frontend/src/app/features/folios/Folios.tsx
@@ -245,7 +245,7 @@ const Folios = () => {
 
       {addFolioConfirm && (
         <ModalDialog
-          label="Are you sure to create a new folio ?"
+          label="Are you sure you want to create a new folio?"
           closeHandler={(response) => {
             if (response) {
               const folio: Folio = {
@@ -293,7 +293,7 @@ const Folios = () => {
 
       {showDeleteConfirmModal && (
         <ModalDialog
-          label="Are you sure you to delete the folio?"
+          label="Are you sure you want to delete the folio?"
           closeHandler={(response) => {
             if (response) {
               dispatch(resetFolioItemDeleteStatus(null));
@@ -310,7 +310,7 @@ const Folios = () => {
 
       {blocker.state === 'blocked' ? (
         <ModalDialog
-          label="Are you sure you proceed?"
+          label="Are you sure you want to proceed?"
           saveBtnLabel="Save"
           cancelBtnLabel="Cancel"
           dicardBtnLabel="Discard Changes"


### PR DESCRIPTION
# Description

This pull request corrects grammar and wording on Folios confirmation dialogs so they read naturally and consistently.

# Changes

Delete folio: “Are you sure you to delete the folio?” → “Are you sure you want to delete the folio?”
Create folio: “Are you sure to create a new folio ?” → “Are you sure you want to create a new folio?”
Leave page with unsaved edits: “Are you sure you proceed?” → “Are you sure you want to proceed?”

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-534-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-534-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)