### PR TITLE
feat:  Site Disclosure contents to PDF report

### DIFF
--- a/frontend/src/app/features/details/pdf/sections/PdfDisclosure.test.tsx
+++ b/frontend/src/app/features/details/pdf/sections/PdfDisclosure.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+jest.mock('@react-pdf/renderer', () => ({
+  View: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  Text: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+  StyleSheet: { create: (s: any) => s },
+  Font: { register: jest.fn() },
+}));
+
+jest.mock('../PdfStyles', () => ({
+  pdfStyles: {
+    subSectionTitle: {},
+    label: {},
+    value: {},
+    noData: {},
+    row: {},
+    section: {},
+    sectionTitle: {},
+    tableHeader: {},
+    tableHeaderCell: {},
+    tableRow: {},
+    tableRowAlt: {},
+    tableCell: {},
+  },
+}));
+
+jest.mock('../../../../helpers/utility', () => ({
+  formatDate: (val: any) => (val ? String(val) : '—'),
+}));
+
+import PdfDisclosure from './PdfDisclosure';
+
+const mockDisclosure = {
+  id: '1',
+  siteRegDateRecd: '2024-01-15',
+  dateCompleted: '2024-02-01',
+  localAuthDateRecd: '2024-01-20',
+  rwmDateDecision: '2024-03-01',
+  siteRegDateEntered: '2024-01-16',
+  plannedActivityComment: 'Residential development planned.',
+  siteDisclosureComment: 'Records searched at city hall.',
+  govDocumentsComment: 'No government orders found.',
+  siteProfileSchedule2Refs: [
+    {
+      id: 'ref-1',
+      schedule2ReferenceCode: 'C0',
+      description: 'Metal smelting',
+    },
+    {
+      id: 'ref-2',
+      schedule2ReferenceCode: 'F2',
+      description: 'Wood treatment',
+    },
+  ],
+  siteProfileQA: [
+    { question: 'Is there contamination?', category: 'Environmental' },
+    { question: 'Was soil tested?', category: 'Testing' },
+  ],
+};
+
+describe('PdfDisclosure', () => {
+  describe('empty state', () => {
+    test('renders empty message when disclosure is null', () => {
+      render(<PdfDisclosure disclosure={null} />);
+      expect(
+        screen.getByText('No disclosure information recorded.'),
+      ).toBeInTheDocument();
+    });
+
+    test('renders empty message when disclosure is undefined', () => {
+      render(<PdfDisclosure disclosure={undefined} />);
+      expect(
+        screen.getByText('No disclosure information recorded.'),
+      ).toBeInTheDocument();
+    });
+
+    test('renders empty message when disclosure is empty array', () => {
+      render(<PdfDisclosure disclosure={[]} />);
+      expect(
+        screen.getByText('No disclosure information recorded.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('single disclosure', () => {
+    test('renders date fields', () => {
+      render(<PdfDisclosure disclosure={[mockDisclosure]} />);
+      expect(screen.getByText('Date Received')).toBeInTheDocument();
+      expect(screen.getByText('Date Completed')).toBeInTheDocument();
+      expect(screen.getByText('Local Authority Received')).toBeInTheDocument();
+      expect(screen.getByText('Date Registrar Received')).toBeInTheDocument();
+      expect(screen.getByText('Date Entered')).toBeInTheDocument();
+    });
+
+    test('does not render numbered heading for single disclosure', () => {
+      render(<PdfDisclosure disclosure={[mockDisclosure]} />);
+      expect(
+        screen.queryByText('Disclosure Statement 1'),
+      ).not.toBeInTheDocument();
+    });
+
+    test('renders Schedule 2 References table', () => {
+      render(<PdfDisclosure disclosure={[mockDisclosure]} />);
+      expect(
+        screen.getByText(
+          'III Commercial and Industrial Purposes or Activities on Site',
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText('C0')).toBeInTheDocument();
+      expect(screen.getByText('Metal smelting')).toBeInTheDocument();
+      expect(screen.getByText('F2')).toBeInTheDocument();
+      expect(screen.getByText('Wood treatment')).toBeInTheDocument();
+    });
+
+    test('renders Q&A section with data', () => {
+      render(<PdfDisclosure disclosure={[mockDisclosure]} />);
+      expect(
+        screen.getByText('Site Disclosure Questions Answered with Yes'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Is there contamination?')).toBeInTheDocument();
+      expect(screen.getByText('Environmental')).toBeInTheDocument();
+      expect(screen.getByText('Was soil tested?')).toBeInTheDocument();
+      expect(screen.getByText('Testing')).toBeInTheDocument();
+    });
+
+    test('renders Q&A empty message when no questions', () => {
+      const disclosureNoQA = { ...mockDisclosure, siteProfileQA: [] };
+      render(<PdfDisclosure disclosure={[disclosureNoQA]} />);
+      expect(
+        screen.getByText('Site Disclosure Questions Answered with Yes'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'There are no questions and categories found for this site disclosure.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    test('renders comments section with values', () => {
+      render(<PdfDisclosure disclosure={[mockDisclosure]} />);
+      expect(
+        screen.getByText('IV Additional Comments and Explanations'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('Residential development planned.'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('Records searched at city hall.'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('No government orders found.'),
+      ).toBeInTheDocument();
+    });
+
+    test('renders dash for null comment values', () => {
+      const disclosureNoComments = {
+        ...mockDisclosure,
+        plannedActivityComment: null,
+        siteDisclosureComment: null,
+        govDocumentsComment: null,
+      };
+      render(<PdfDisclosure disclosure={[disclosureNoComments]} />);
+      const dashes = screen.getAllByText('—');
+      expect(dashes.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe('multiple disclosures', () => {
+    test('renders numbered headings', () => {
+      const disclosures = [
+        { ...mockDisclosure, id: '1' },
+        { ...mockDisclosure, id: '2' },
+      ];
+      render(<PdfDisclosure disclosure={disclosures} />);
+      expect(screen.getByText('Disclosure Statement 1')).toBeInTheDocument();
+      expect(screen.getByText('Disclosure Statement 2')).toBeInTheDocument();
+    });
+  });
+
+  describe('Schedule 2 hidden when empty', () => {
+    test('does not render Schedule 2 section when refs are empty', () => {
+      const disclosureNoRefs = {
+        ...mockDisclosure,
+        siteProfileSchedule2Refs: [],
+      };
+      render(<PdfDisclosure disclosure={[disclosureNoRefs]} />);
+      expect(
+        screen.queryByText(
+          'III Commercial and Industrial Purposes or Activities on Site',
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/app/features/details/pdf/sections/PdfDisclosure.tsx
+++ b/frontend/src/app/features/details/pdf/sections/PdfDisclosure.tsx
@@ -1,14 +1,73 @@
 import React from 'react';
+import { View, Text } from '@react-pdf/renderer';
 import PdfField from '../components/PdfField';
 import PdfSection from '../components/PdfSection';
+import PdfTable, { PdfTableColumn } from '../components/PdfTable';
 import { formatDate } from '../../../../helpers/utility';
+import { pdfStyles } from '../PdfStyles';
 
-interface PdfDisclosureProps {
-  disclosure: any;
+interface Schedule2Ref {
+  id?: string;
+  schedule2ReferenceCode?: string | null;
+  description?: string | null;
 }
 
+interface ProfileQA {
+  question?: string | null;
+  category?: string | null;
+}
+
+interface DisclosureItem {
+  id?: string;
+  siteRegDateRecd?: string | Date | null;
+  dateCompleted?: string | Date | null;
+  localAuthDateRecd?: string | Date | null;
+  rwmDateDecision?: string | Date | null;
+  siteRegDateEntered?: string | Date | null;
+  plannedActivityComment?: string | null;
+  siteDisclosureComment?: string | null;
+  govDocumentsComment?: string | null;
+  siteProfileSchedule2Refs?: Schedule2Ref[] | null;
+  siteProfileQA?: ProfileQA[] | null;
+}
+
+interface PdfDisclosureProps {
+  disclosure: DisclosureItem[] | DisclosureItem | null | undefined;
+}
+
+const schedule2Columns: PdfTableColumn[] = [
+  {
+    label: 'Schedule 2 Reference',
+    width: '40%',
+    getValue: (row) => row.schedule2ReferenceCode ?? null,
+  },
+  {
+    label: 'Description',
+    width: '60%',
+    getValue: (row) => row.description ?? null,
+  },
+];
+
+const qaColumns: PdfTableColumn[] = [
+  {
+    label: 'Question',
+    width: '50%',
+    getValue: (row) => row.question ?? null,
+  },
+  {
+    label: 'Category',
+    width: '50%',
+    getValue: (row) => row.category ?? null,
+  },
+];
+
 const PdfDisclosure: React.FC<PdfDisclosureProps> = ({ disclosure }) => {
-  const isEmpty = !disclosure || Object.keys(disclosure).length === 0;
+  const disclosures: DisclosureItem[] = Array.isArray(disclosure)
+    ? disclosure
+    : disclosure && typeof disclosure === 'object'
+      ? [disclosure as DisclosureItem]
+      : [];
+  const isEmpty = disclosures.length === 0;
 
   return (
     <PdfSection
@@ -16,53 +75,102 @@ const PdfDisclosure: React.FC<PdfDisclosureProps> = ({ disclosure }) => {
       isEmpty={isEmpty}
       emptyMessage="No disclosure information recorded."
     >
-      <PdfField
-        label="Date Completed"
-        value={formatDate(disclosure?.dateCompleted ?? null)}
-      />
-      <PdfField
-        label="Site Registry Date Received"
-        value={formatDate(disclosure?.siteRegDateRecd ?? null)}
-      />
-      <PdfField
-        label="Site Registry Date Entered"
-        value={formatDate(disclosure?.siteRegDateEntered ?? null)}
-      />
-      <PdfField
-        label="Local Authority Name"
-        value={disclosure?.localAuthName}
-      />
-      <PdfField
-        label="Local Authority Agency"
-        value={disclosure?.localAuthAgency}
-      />
-      <PdfField
-        label="Local Authority Address"
-        value={disclosure?.localAuthAddress1}
-      />
-      <PdfField
-        label="Local Authority Date Submitted"
-        value={formatDate(disclosure?.localAuthDateSubmitted ?? null)}
-      />
-      <PdfField
-        label="Investigation Required"
-        value={disclosure?.investigationRequired}
-      />
-      <PdfField label="Site Address" value={disclosure?.siteAddress} />
-      <PdfField label="Site City" value={disclosure?.siteCity} />
-      <PdfField label="Comments" value={disclosure?.comments} />
-      <PdfField
-        label="Planned Activity Comment"
-        value={disclosure?.plannedActivityComment}
-      />
-      <PdfField
-        label="Site Disclosure Comment"
-        value={disclosure?.siteDisclosureComment}
-      />
-      <PdfField
-        label="Government Documents Comment"
-        value={disclosure?.govDocumentsComment}
-      />
+      {disclosures.map((item: DisclosureItem, index: number) => (
+        <View key={item.id ?? index} style={{ marginBottom: 15 }}>
+          {disclosures.length > 1 && (
+            <Text style={pdfStyles.subSectionTitle}>
+              Disclosure Statement {index + 1}
+            </Text>
+          )}
+
+          <PdfField
+            label="Date Received"
+            value={formatDate(item.siteRegDateRecd ?? null)}
+          />
+          <PdfField
+            label="Date Completed"
+            value={formatDate(item.dateCompleted ?? null)}
+          />
+          <PdfField
+            label="Local Authority Received"
+            value={formatDate(item.localAuthDateRecd ?? null)}
+          />
+          <PdfField
+            label="Date Registrar Received"
+            value={formatDate(item.rwmDateDecision ?? null)}
+          />
+          <PdfField
+            label="Date Entered"
+            value={formatDate(item.siteRegDateEntered ?? null)}
+          />
+
+          {item.siteProfileSchedule2Refs &&
+            item.siteProfileSchedule2Refs.length > 0 && (
+              <View style={{ marginTop: 8 }}>
+                <Text style={pdfStyles.subSectionTitle}>
+                  III Commercial and Industrial Purposes or Activities on Site
+                </Text>
+                <PdfTable
+                  columns={schedule2Columns}
+                  rows={item.siteProfileSchedule2Refs}
+                  rowKey={(row, i) => row.id ?? String(i)}
+                />
+              </View>
+            )}
+
+          <View style={{ marginTop: 8 }}>
+            <Text style={pdfStyles.subSectionTitle}>
+              Site Disclosure Questions Answered with Yes
+            </Text>
+            {item.siteProfileQA && item.siteProfileQA.length > 0 ? (
+              <PdfTable
+                columns={qaColumns}
+                rows={item.siteProfileQA}
+                rowKey={(_row, i) => String(i)}
+              />
+            ) : (
+              <Text style={pdfStyles.noData}>
+                There are no questions and categories found for this site
+                disclosure.
+              </Text>
+            )}
+          </View>
+
+          <View style={{ marginTop: 8 }}>
+            <Text style={pdfStyles.subSectionTitle}>
+              IV Additional Comments and Explanations
+            </Text>
+            <View style={{ marginTop: 4 }}>
+              <Text style={[pdfStyles.label, { width: '100%' }]}>
+                Provide a brief summary of the planned activity and proposed
+                land use at the site.
+              </Text>
+              <Text style={pdfStyles.value}>
+                {item.plannedActivityComment ?? '—'}
+              </Text>
+            </View>
+            <View style={{ marginTop: 4 }}>
+              <Text style={[pdfStyles.label, { width: '100%' }]}>
+                Indicate the information used to complete this site disclosure
+                statement including a list of record searches completed.
+              </Text>
+              <Text style={pdfStyles.value}>
+                {item.siteDisclosureComment ?? '—'}
+              </Text>
+            </View>
+            <View style={{ marginTop: 4 }}>
+              <Text style={[pdfStyles.label, { width: '100%' }]}>
+                List any past or present government orders, permits, approvals,
+                certificates or notifications pertaining to the environmental
+                condition of the site.
+              </Text>
+              <Text style={pdfStyles.value}>
+                {item.govDocumentsComment ?? '—'}
+              </Text>
+            </View>
+          </View>
+        </View>
+      ))}
     </PdfSection>
   );
 };

--- a/frontend/src/app/features/details/pdf/useSiteDetailsPdfData.test.ts
+++ b/frontend/src/app/features/details/pdf/useSiteDetailsPdfData.test.ts
@@ -59,7 +59,7 @@ const createStore = (overrides: any = {}) =>
     notationParticipant: { siteNotation: [], status: RequestStatus.success },
     siteParticipant: { siteParticipants: [], status: RequestStatus.success },
     documents: { siteDocuments: [], status: RequestStatus.success },
-    siteDisclosure: { siteDisclosure: {}, status: RequestStatus.success },
+    siteDisclosure: { siteDisclosure: [], status: RequestStatus.success },
     associatedSites: { siteAssociate: [], status: RequestStatus.success },
     landUses: {
       landUses: [],
@@ -73,6 +73,7 @@ const createStore = (overrides: any = {}) =>
         ministryContact: { getPeopleOrgsCd: { data: [] } },
         notationParticipantRole: { getNotationParticipantRoleCd: { data: [] } },
         participantRoles: { getParticipantRoleCd: { data: [] } },
+        schedule2Ref: { getSchedule2Ref: { data: [] } },
       },
     },
   });

--- a/frontend/src/app/features/details/pdf/useSiteDetailsPdfData.ts
+++ b/frontend/src/app/features/details/pdf/useSiteDetailsPdfData.ts
@@ -25,6 +25,7 @@ import {
   ministryContactDrpdown,
   notationParticipantRoleDrpdown,
   participantRoleDrpdown,
+  schedule2ReferenceCdDrpdown,
 } from '../dropdowns/DropdownSlice';
 
 export interface SiteDetailsPdfData {
@@ -32,7 +33,7 @@ export interface SiteDetailsPdfData {
   notations: any[];
   participants: any[];
   documents: any[];
-  disclosure: any;
+  disclosure: any[];
   associatedSites: any[];
   landUses: any[];
   parcelDescriptions: any[];
@@ -109,6 +110,7 @@ export const useSiteDetailsPdfData = () => {
   const ministryContactState = useSelector(ministryContactDrpdown);
   const notationParticRoleState = useSelector(notationParticipantRoleDrpdown);
   const participantRoleState = useSelector(participantRoleDrpdown);
+  const schedule2RefState = useSelector(schedule2ReferenceCdDrpdown);
 
   const hasPurchasedSnapshot = useSelector(hasUserPurchasedSnapshot);
 
@@ -132,7 +134,7 @@ export const useSiteDetailsPdfData = () => {
       notations: notationState?.siteNotation ?? [],
       participants: participantState?.siteParticipants ?? [],
       documents: documentState?.siteDocuments ?? [],
-      disclosure: disclosureState?.siteDisclosure ?? {},
+      disclosure: disclosureState?.siteDisclosure ?? [],
       associatedSites: associateState?.siteAssociate ?? [],
       landUses: landUsesState?.landUses ?? [],
       parcelDescriptions: parcelState?.data ?? [],
@@ -153,10 +155,26 @@ export const useSiteDetailsPdfData = () => {
       fetchAllParcelDescriptions(siteId, false),
       fetchAllLandUses(siteId, false),
     ]);
+
+    const schedule2Refs = schedule2RefState?.data ?? [];
+    const rawDisclosures = disclosureState?.siteDisclosure ?? [];
+    const disclosureArray = Array.isArray(rawDisclosures) ? rawDisclosures : [];
+    const enrichedDisclosures = disclosureArray.map((item: any) => ({
+      ...item,
+      siteProfileSchedule2Refs:
+        item?.siteProfileSchedule2Refs?.map((ref: any) => ({
+          ...ref,
+          description:
+            schedule2Refs.find((s: any) => s.key === ref.schedule2ReferenceCode)
+              ?.metaData ?? null,
+        })) ?? [],
+    }));
+
     return {
       ...base,
       parcelDescriptions: allParcelDescriptions,
       landUses: allLandUses,
+      disclosure: enrichedDisclosures,
     };
   };
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Adding Site Disclosure contents to Site Details PDF report

Fixes # (issue) SRS-1639

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X]  Manually tested and ensured PDF report include the new disclosure changes 


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-548-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-548-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)