### PR TITLE
feat: SRS-1613-application operational metrics for GraphQL and HTTP((Prometheus / Sysdig))

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -40,6 +40,7 @@
         "multer-s3": "^3.0.1",
         "nest-keycloak-connect": "^1.10.0",
         "pg": "^8.13.0",
+        "prom-client": "^15.1.3",
         "reflect-metadata": "^0.2.2",
         "rimraf": "^5.0.5",
         "rxjs": "^7.8.1",
@@ -4397,6 +4398,15 @@
         "npm": ">=5.0.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -7070,6 +7080,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -12460,6 +12476,19 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -13763,6 +13792,15 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
     },
     "node_modules/terser": {
       "version": "5.44.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -58,6 +58,7 @@
     "multer-s3": "^3.0.1",
     "nest-keycloak-connect": "^1.10.0",
     "pg": "^8.13.0",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "rimraf": "^5.0.5",
     "rxjs": "^7.8.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -18,6 +18,8 @@ import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { CustomExceptionFilter } from './app/filters/customExceptionFilters';
 import { LatLngTupleScalar } from './app/scalars/latLngTuple';
+import { MetricsModule } from './app/metrics/metrics.module';
+import { GraphqlMetricsPlugin } from './app/metrics/graphql-metrics.plugin';
 
 /**
  * Application Module Wrapping All Functionality For User Micro Service
@@ -36,6 +38,7 @@ import { LatLngTupleScalar } from './app/scalars/latLngTuple';
       // Secret key of the client taken from keycloak server
     }),
     SiteModule,
+    MetricsModule, // prom-client registry + GraphqlMetricsPlugin provider
     TypeOrmModule.forRootAsync({
       inject: [ConfigService],
       useFactory: (config: ConfigService) => ({
@@ -51,14 +54,20 @@ import { LatLngTupleScalar } from './app/scalars/latLngTuple';
       }),
       // This changes the DB schema to match changes to entities, which we might not want.
     }),
-    GraphQLModule.forRoot<ApolloFederationDriverConfig>({
+    GraphQLModule.forRootAsync<ApolloFederationDriverConfig>({
       driver: ApolloFederationDriver,
-      // TODO - Experiment with using old files for localhsot if need be, and true for prod
-      autoSchemaFile: {
-        federation: 2,
-        path: process.env.GRAPHQL_SCHEMA_FILE_PATH || './schema.graphql',
-      },
-      context: () => {},
+      imports: [MetricsModule],
+      inject: [GraphqlMetricsPlugin],
+      // forRootAsync injects the plugin so every GraphQL operation is counted once on response.
+      useFactory: (graphqlMetricsPlugin: GraphqlMetricsPlugin) => ({
+        // TODO - Experiment with using old files for localhsot if need be, and true for prod
+        autoSchemaFile: {
+          federation: 2,
+          path: process.env.GRAPHQL_SCHEMA_FILE_PATH || './schema.graphql',
+        },
+        context: () => ({}),
+        plugins: [graphqlMetricsPlugin],
+      }),
     }),
   ],
   controllers: [AppController],

--- a/backend/src/app/metrics/classify-http-status.ts
+++ b/backend/src/app/metrics/classify-http-status.ts
@@ -1,4 +1,7 @@
-import type { GraphqlErrorClass, GraphqlOutcome } from './operational-metrics.service';
+import type {
+  GraphqlErrorClass,
+  GraphqlOutcome,
+} from './operational-metrics.service';
 
 /** Maps wire HTTP status codes to outcome/error_class for HTTP and GraphQL metrics. */
 

--- a/backend/src/app/metrics/classify-http-status.ts
+++ b/backend/src/app/metrics/classify-http-status.ts
@@ -1,0 +1,31 @@
+import type { GraphqlErrorClass, GraphqlOutcome } from './operational-metrics.service';
+
+/** Maps wire HTTP status codes to outcome/error_class for HTTP and GraphQL metrics. */
+
+export type HttpClassification = {
+  outcome: GraphqlOutcome;
+  errorClass: GraphqlErrorClass;
+};
+
+/**
+ * Wire HTTP status: 2xx success; 4xx client failure; 5xx server failure.
+ */
+export function classifyHttpStatus(status: number): HttpClassification {
+  if (status >= 500) {
+    return { outcome: 'failure', errorClass: 'server' };
+  }
+  if (status >= 400) {
+    return { outcome: 'failure', errorClass: 'client' };
+  }
+  return { outcome: 'success', errorClass: 'na' };
+}
+
+export function errorClassFromHttpStatus(status: number): GraphqlErrorClass {
+  if (status >= 500) {
+    return 'server';
+  }
+  if (status >= 400) {
+    return 'client';
+  }
+  return 'unknown';
+}

--- a/backend/src/app/metrics/evaluate-graphql-outcome.spec.ts
+++ b/backend/src/app/metrics/evaluate-graphql-outcome.spec.ts
@@ -1,0 +1,71 @@
+import { evaluateGraphqlOutcome } from './evaluate-graphql-outcome';
+
+describe('evaluateGraphqlOutcome', () => {
+  it('treats wire HTTP 401 as client failure', () => {
+    expect(evaluateGraphqlOutcome({ httpStatus: 401 })).toEqual({
+      outcome: 'failure',
+      errorClass: 'client',
+    });
+  });
+
+  it('treats wire HTTP 500 as server failure', () => {
+    expect(evaluateGraphqlOutcome({ httpStatus: 500 })).toEqual({
+      outcome: 'failure',
+      errorClass: 'server',
+    });
+  });
+
+  it('treats GraphQL errors as failure when HTTP is 200', () => {
+    expect(
+      evaluateGraphqlOutcome({
+        httpStatus: 200,
+        graphqlErrors: [{ message: 'bad' }],
+      }),
+    ).toEqual({
+      outcome: 'failure',
+      errorClass: 'unknown',
+    });
+  });
+
+  it('treats payload httpStatusCode >= 400 as failure when HTTP is 200', () => {
+    expect(
+      evaluateGraphqlOutcome({
+        httpStatus: 200,
+        responseData: {
+          searchSites: { httpStatusCode: 404, success: false },
+        },
+      }),
+    ).toEqual({
+      outcome: 'failure',
+      errorClass: 'client',
+    });
+  });
+
+  it('treats success false as client failure when HTTP is 200', () => {
+    expect(
+      evaluateGraphqlOutcome({
+        httpStatus: 200,
+        responseData: {
+          updateSiteDetails: { success: false, httpStatusCode: 200 },
+        },
+      }),
+    ).toEqual({
+      outcome: 'failure',
+      errorClass: 'client',
+    });
+  });
+
+  it('treats HTTP 200 without errors as success', () => {
+    expect(
+      evaluateGraphqlOutcome({
+        httpStatus: 200,
+        responseData: {
+          getCartItemsForUser: { httpStatusCode: 200, success: true },
+        },
+      }),
+    ).toEqual({
+      outcome: 'success',
+      errorClass: 'na',
+    });
+  });
+});

--- a/backend/src/app/metrics/evaluate-graphql-outcome.ts
+++ b/backend/src/app/metrics/evaluate-graphql-outcome.ts
@@ -2,7 +2,10 @@ import {
   classifyHttpStatus,
   errorClassFromHttpStatus,
 } from './classify-http-status';
-import type { GraphqlErrorClass, GraphqlOutcome } from './operational-metrics.service';
+import type {
+  GraphqlErrorClass,
+  GraphqlOutcome,
+} from './operational-metrics.service';
 
 /**
  * Classifies GraphQL operation success/failure for metrics.

--- a/backend/src/app/metrics/evaluate-graphql-outcome.ts
+++ b/backend/src/app/metrics/evaluate-graphql-outcome.ts
@@ -1,0 +1,100 @@
+import {
+  classifyHttpStatus,
+  errorClassFromHttpStatus,
+} from './classify-http-status';
+import type { GraphqlErrorClass, GraphqlOutcome } from './operational-metrics.service';
+
+/**
+ * Classifies GraphQL operation success/failure for metrics.
+ * Site Registry often returns HTTP 200 with failure in the JSON body (GenericResponse).
+ */
+
+export type GraphqlOutcomeEvaluation = {
+  outcome: GraphqlOutcome;
+  errorClass: GraphqlErrorClass;
+};
+
+/**
+ * Prefer wire HTTP status, then GraphQL errors, then payload success/httpStatusCode
+ * (BaseHttpResponse-style fields on operation result objects).
+ */
+export function evaluateGraphqlOutcome(args: {
+  httpStatus?: number;
+  graphqlErrors?: readonly unknown[] | null;
+  responseData?: Record<string, unknown> | null | undefined;
+}): GraphqlOutcomeEvaluation {
+  const httpStatus = args.httpStatus ?? 200;
+
+  if (httpStatus >= 400) {
+    return {
+      outcome: 'failure',
+      errorClass: errorClassFromHttpStatus(httpStatus),
+    };
+  }
+
+  if (Array.isArray(args.graphqlErrors) && args.graphqlErrors.length > 0) {
+    return { outcome: 'failure', errorClass: 'unknown' };
+  }
+
+  const payloadStatus = findPayloadHttpStatus(args.responseData);
+  if (payloadStatus !== undefined) {
+    if (payloadStatus >= 400) {
+      return {
+        outcome: 'failure',
+        errorClass: errorClassFromHttpStatus(payloadStatus),
+      };
+    }
+    if (hasExplicitPayloadFailure(args.responseData)) {
+      return { outcome: 'failure', errorClass: 'client' };
+    }
+  }
+
+  return classifyHttpStatus(httpStatus);
+}
+
+/** Any top-level field object with success: false (BaseHttpResponse pattern). */
+function hasExplicitPayloadFailure(
+  data: Record<string, unknown> | null | undefined,
+): boolean {
+  if (!data) {
+    return false;
+  }
+
+  for (const value of Object.values(data)) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      continue;
+    }
+    const record = value as Record<string, unknown>;
+    if (record.success === false) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/** Highest httpStatusCode among top-level result objects in GraphQL data. */
+function findPayloadHttpStatus(
+  data: Record<string, unknown> | null | undefined,
+): number | undefined {
+  if (!data) {
+    return undefined;
+  }
+
+  let maxStatus: number | undefined;
+
+  for (const value of Object.values(data)) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      continue;
+    }
+    const record = value as Record<string, unknown>;
+    if (typeof record.httpStatusCode === 'number') {
+      maxStatus =
+        maxStatus === undefined
+          ? record.httpStatusCode
+          : Math.max(maxStatus, record.httpStatusCode);
+    }
+  }
+
+  return maxStatus;
+}

--- a/backend/src/app/metrics/graphql-metrics.plugin.spec.ts
+++ b/backend/src/app/metrics/graphql-metrics.plugin.spec.ts
@@ -51,4 +51,3 @@ describe('GraphqlMetricsPlugin', () => {
     expect(output).toContain('error_class="unknown"');
   });
 });
-

--- a/backend/src/app/metrics/graphql-metrics.plugin.spec.ts
+++ b/backend/src/app/metrics/graphql-metrics.plugin.spec.ts
@@ -1,0 +1,54 @@
+import { OperationalMetricsService } from './operational-metrics.service';
+import { GraphqlMetricsPlugin } from './graphql-metrics.plugin';
+
+describe('GraphqlMetricsPlugin', () => {
+  it('increments success counter for GetSites operation', async () => {
+    const metrics = new OperationalMetricsService();
+    const plugin = new GraphqlMetricsPlugin(metrics);
+
+    const listener = await plugin.requestDidStart({} as any);
+
+    await listener?.willSendResponse?.({
+      request: { operationName: 'GetSites' },
+      response: { body: { kind: 'single', singleResult: {} } },
+    } as any);
+
+    const registry = metrics.getPromRegistry();
+    const output = await registry.getSingleMetricAsString(
+      'site_registry_graphql_operations_total',
+    );
+
+    expect(output).toContain('operation="GetSites"');
+    expect(output).toContain('outcome="success"');
+    expect(output).toContain('error_class="na"');
+  });
+
+  it('increments failure counter when GraphQL response has errors', async () => {
+    const metrics = new OperationalMetricsService();
+    const plugin = new GraphqlMetricsPlugin(metrics);
+
+    const listener = await plugin.requestDidStart({} as any);
+
+    await listener?.willSendResponse?.({
+      request: { operationName: 'GetSites' },
+      response: {
+        body: {
+          kind: 'single',
+          singleResult: {
+            errors: [{ message: 'nope' }],
+          },
+        },
+      },
+    } as any);
+
+    const registry = metrics.getPromRegistry();
+    const output = await registry.getSingleMetricAsString(
+      'site_registry_graphql_operations_total',
+    );
+
+    expect(output).toContain('operation="GetSites"');
+    expect(output).toContain('outcome="failure"');
+    expect(output).toContain('error_class="unknown"');
+  });
+});
+

--- a/backend/src/app/metrics/graphql-metrics.plugin.ts
+++ b/backend/src/app/metrics/graphql-metrics.plugin.ts
@@ -1,0 +1,61 @@
+import { Plugin } from '@nestjs/apollo';
+import type {
+  ApolloServerPlugin,
+  GraphQLRequestContext,
+  GraphQLRequestContextWillSendResponse,
+} from '@apollo/server';
+import { OperationalMetricsService } from './operational-metrics.service';
+import { evaluateGraphqlOutcome } from './evaluate-graphql-outcome';
+import { resolveGraphqlOperationName } from './resolve-graphql-operation-name';
+
+/**
+ * Apollo plugin: records one counter + one histogram sample per GraphQL operation.
+ * Registered in app.module.ts (GraphQLModule plugins). Does not change resolver behavior.
+ *
+ * Labels operation from client operationName (frontend) or parsed query name; otherwise "anonymous".
+ */
+@Plugin()
+export class GraphqlMetricsPlugin implements ApolloServerPlugin {
+  constructor(private readonly metrics: OperationalMetricsService) {}
+
+  async requestDidStart(_requestContext: GraphQLRequestContext<any>) {
+    const start = process.hrtime.bigint();
+
+    return {
+      // Fires after the response is built so we can read errors, data, and HTTP status.
+      willSendResponse: async (
+        requestContext: GraphQLRequestContextWillSendResponse<any>,
+      ) => {
+        const durationSeconds = Number(process.hrtime.bigint() - start) / 1e9;
+        const operation = resolveGraphqlOperationName(
+          requestContext.request.operationName,
+          requestContext.request.query,
+        );
+
+        const singleResult =
+          requestContext.response.body.kind === 'single'
+            ? requestContext.response.body.singleResult
+            : undefined;
+
+        const httpStatus =
+          (requestContext.response as { http?: { status?: number } }).http
+            ?.status ?? 200;
+
+        const evaluation = evaluateGraphqlOutcome({
+          httpStatus,
+          graphqlErrors: singleResult?.errors,
+          responseData: singleResult?.data as
+            | Record<string, unknown>
+            | undefined,
+        });
+
+        this.metrics.recordGraphqlOperation({
+          operation,
+          outcome: evaluation.outcome,
+          errorClass: evaluation.errorClass,
+          durationSeconds,
+        });
+      },
+    };
+  }
+}

--- a/backend/src/app/metrics/http-metrics.middleware.spec.ts
+++ b/backend/src/app/metrics/http-metrics.middleware.spec.ts
@@ -1,0 +1,48 @@
+import { EventEmitter } from 'events';
+import { OperationalMetricsService } from './operational-metrics.service';
+import { createHttpMetricsMiddleware } from './http-metrics.middleware';
+
+function createMockResponse(statusCode: number) {
+  const res = new EventEmitter() as EventEmitter & {
+    statusCode: number;
+    on: EventEmitter['on'];
+  };
+  res.statusCode = statusCode;
+  return res;
+}
+
+describe('createHttpMetricsMiddleware', () => {
+  it('records HTTP request and auth failure for 401', (done) => {
+    const metrics = new OperationalMetricsService();
+    const middleware = createHttpMetricsMiddleware(metrics);
+    const req = { method: 'POST', path: '/graphql' } as any;
+    const res = createMockResponse(401);
+
+    middleware(req, res as any, () => {
+      res.emit('finish');
+      setImmediate(async () => {
+        const output = await metrics.getPromRegistry().metrics();
+        expect(output).toContain('site_registry_http_requests_total');
+        expect(output).toContain('status="401"');
+        expect(output).toContain('site_registry_auth_failures_total');
+        expect(output).toContain('reason="unauthorized"');
+        done();
+      });
+    });
+  });
+
+  it('skips recording for /metrics', async () => {
+    const metrics = new OperationalMetricsService();
+    const middleware = createHttpMetricsMiddleware(metrics);
+    const req = { method: 'GET', path: '/metrics' } as any;
+    const res = createMockResponse(200);
+
+    await new Promise<void>((resolve) => {
+      middleware(req, res as any, () => resolve());
+    });
+
+    res.emit('finish');
+    const output = await metrics.getPromRegistry().metrics();
+    expect(output).not.toMatch(/site_registry_http_requests_total\{/);
+  });
+});

--- a/backend/src/app/metrics/http-metrics.middleware.ts
+++ b/backend/src/app/metrics/http-metrics.middleware.ts
@@ -1,0 +1,56 @@
+import type { Request, Response, NextFunction } from 'express';
+import { OperationalMetricsService } from './operational-metrics.service';
+
+/**
+ * Express middleware registered in main.ts on the underlying Express instance.
+ * Complements GraphQL metrics: counts HTTP requests (status code, route, duration).
+ * Use GraphQL metrics for per-operation health (searchSites, etc.).
+ */
+
+/** Keeps Prometheus label cardinality low (one series per route pattern, not per site id). */
+function normalizeRoute(path: string | undefined): string {
+  if (!path || path === '/') {
+    return '/';
+  }
+  // Collapse UUIDs and numeric ids for lower cardinality.
+  return path
+    .replace(
+      /\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+      '/:id',
+    )
+    .replace(/\/\d+(?=\/|$)/g, '/:id');
+}
+
+export function createHttpMetricsMiddleware(
+  metrics: OperationalMetricsService,
+) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // Do not count scraper traffic against http_requests_total.
+    if (req.path === '/metrics') {
+      next();
+      return;
+    }
+
+    const start = process.hrtime.bigint();
+
+    res.on('finish', () => {
+      const durationSeconds = Number(process.hrtime.bigint() - start) / 1e9;
+      const status = res.statusCode || 200;
+
+      metrics.recordHttpRequest({
+        method: req.method,
+        route: normalizeRoute(req.path),
+        status,
+        durationSeconds,
+      });
+
+      if (status === 401) {
+        metrics.recordAuthFailure({ reason: 'unauthorized', guard: 'http' });
+      } else if (status === 403) {
+        metrics.recordAuthFailure({ reason: 'forbidden', guard: 'http' });
+      }
+    });
+
+    next();
+  };
+}

--- a/backend/src/app/metrics/metrics.module.ts
+++ b/backend/src/app/metrics/metrics.module.ts
@@ -8,4 +8,3 @@ import { GraphqlMetricsPlugin } from './graphql-metrics.plugin';
   exports: [OperationalMetricsService, GraphqlMetricsPlugin],
 })
 export class MetricsModule {}
-

--- a/backend/src/app/metrics/metrics.module.ts
+++ b/backend/src/app/metrics/metrics.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { OperationalMetricsService } from './operational-metrics.service';
+import { GraphqlMetricsPlugin } from './graphql-metrics.plugin';
+
+/** Wires metrics service + Apollo plugin; imported by AppModule and GraphQLModule.forRootAsync. */
+@Module({
+  providers: [OperationalMetricsService, GraphqlMetricsPlugin],
+  exports: [OperationalMetricsService, GraphqlMetricsPlugin],
+})
+export class MetricsModule {}
+

--- a/backend/src/app/metrics/operational-metrics.service.ts
+++ b/backend/src/app/metrics/operational-metrics.service.ts
@@ -1,0 +1,147 @@
+import { Injectable } from '@nestjs/common';
+import { Counter, Histogram, Registry } from 'prom-client';
+import { classifyHttpStatus } from './classify-http-status';
+
+/**
+ * Central Prometheus registry for Site Registry operational metrics.
+ * Exposed at GET /metrics (see main.ts). Scraped in OpenShift via pod annotations.
+ *
+ * Five metric families (prefix site_registry_):
+ * - GraphQL: per operationName success/failure + latency (primary dashboards)
+ * - HTTP: per request method/route/status (health, REST, wire-level errors)
+ * - Auth: wire 401/403 only (guard label is "http" today)
+ */
+export type GraphqlOutcome = 'success' | 'failure';
+export type GraphqlErrorClass = 'na' | 'client' | 'server' | 'unknown';
+export type AuthFailureReason = 'unauthorized' | 'forbidden';
+export type AuthFailureGuard = 'http' | 'auth' | 'resource' | 'role' | 'unknown';
+
+const GRAPHQL_DURATION_BUCKETS = [
+  0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+];
+
+@Injectable()
+export class OperationalMetricsService {
+  private readonly registry: Registry;
+
+  private readonly graphqlOperationsTotal: Counter<
+    'operation' | 'outcome' | 'error_class'
+  >;
+
+  private readonly graphqlOperationDurationSeconds: Histogram<
+    'operation' | 'outcome'
+  >;
+
+  private readonly httpRequestsTotal: Counter<
+    'method' | 'route' | 'status' | 'outcome' | 'error_class'
+  >;
+
+  private readonly httpRequestDurationSeconds: Histogram<
+    'method' | 'route' | 'outcome'
+  >;
+
+  private readonly authFailuresTotal: Counter<'reason' | 'guard'>;
+
+  constructor() {
+    this.registry = new Registry();
+
+    this.graphqlOperationsTotal = new Counter({
+      name: 'site_registry_graphql_operations_total',
+      help: 'Count of GraphQL operations by operationName and outcome.',
+      labelNames: ['operation', 'outcome', 'error_class'],
+      registers: [this.registry],
+    });
+
+    this.graphqlOperationDurationSeconds = new Histogram({
+      name: 'site_registry_graphql_operation_duration_seconds',
+      help: 'GraphQL operation duration in seconds.',
+      labelNames: ['operation', 'outcome'],
+      buckets: GRAPHQL_DURATION_BUCKETS,
+      registers: [this.registry],
+    });
+
+    this.httpRequestsTotal = new Counter({
+      name: 'site_registry_http_requests_total',
+      help: 'HTTP requests by method, route, and status code.',
+      labelNames: ['method', 'route', 'status', 'outcome', 'error_class'],
+      registers: [this.registry],
+    });
+
+    this.httpRequestDurationSeconds = new Histogram({
+      name: 'site_registry_http_request_duration_seconds',
+      help: 'HTTP request duration in seconds.',
+      labelNames: ['method', 'route', 'outcome'],
+      buckets: GRAPHQL_DURATION_BUCKETS,
+      registers: [this.registry],
+    });
+
+    this.authFailuresTotal = new Counter({
+      name: 'site_registry_auth_failures_total',
+      help: 'Authentication and authorization failures.',
+      labelNames: ['reason', 'guard'],
+      registers: [this.registry],
+    });
+  }
+
+  getPromRegistry(): Registry {
+    return this.registry;
+  }
+
+  /** Called from GraphqlMetricsPlugin after each GraphQL response is sent. */
+  recordGraphqlOperation(args: {
+    operation: string;
+    outcome: GraphqlOutcome;
+    errorClass: GraphqlErrorClass;
+    durationSeconds: number;
+  }): void {
+    const operation = args.operation || 'anonymous';
+    const labels = {
+      operation,
+      outcome: args.outcome,
+      error_class: args.errorClass,
+    };
+
+    this.graphqlOperationsTotal.inc(labels);
+    this.graphqlOperationDurationSeconds.observe(
+      { operation, outcome: args.outcome },
+      args.durationSeconds,
+    );
+  }
+
+  /** Called from HTTP middleware on res.finish (see http-metrics.middleware.ts). */
+  recordHttpRequest(args: {
+    method: string;
+    route: string;
+    status: number;
+    durationSeconds: number;
+  }): void {
+    const { outcome, errorClass } = classifyHttpStatus(args.status);
+    const method = (args.method || 'GET').toUpperCase();
+    const route = args.route || '/';
+    const status = String(args.status);
+
+    this.httpRequestsTotal.inc({
+      method,
+      route,
+      status,
+      outcome,
+      error_class: errorClass,
+    });
+
+    this.httpRequestDurationSeconds.observe(
+      { method, route, outcome },
+      args.durationSeconds,
+    );
+  }
+
+  /** Wire-level 401/403 from HTTP middleware; GraphQL auth in body uses graphql_operations_total. */
+  recordAuthFailure(args: {
+    reason: AuthFailureReason;
+    guard: AuthFailureGuard;
+  }): void {
+    this.authFailuresTotal.inc({
+      reason: args.reason,
+      guard: args.guard,
+    });
+  }
+}

--- a/backend/src/app/metrics/operational-metrics.service.ts
+++ b/backend/src/app/metrics/operational-metrics.service.ts
@@ -14,7 +14,12 @@ import { classifyHttpStatus } from './classify-http-status';
 export type GraphqlOutcome = 'success' | 'failure';
 export type GraphqlErrorClass = 'na' | 'client' | 'server' | 'unknown';
 export type AuthFailureReason = 'unauthorized' | 'forbidden';
-export type AuthFailureGuard = 'http' | 'auth' | 'resource' | 'role' | 'unknown';
+export type AuthFailureGuard =
+  | 'http'
+  | 'auth'
+  | 'resource'
+  | 'role'
+  | 'unknown';
 
 const GRAPHQL_DURATION_BUCKETS = [
   0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,

--- a/backend/src/app/metrics/resolve-graphql-operation-name.spec.ts
+++ b/backend/src/app/metrics/resolve-graphql-operation-name.spec.ts
@@ -1,0 +1,21 @@
+import { resolveGraphqlOperationName } from './resolve-graphql-operation-name';
+
+describe('resolveGraphqlOperationName', () => {
+  it('uses client operationName when provided', () => {
+    expect(resolveGraphqlOperationName('searchSites', 'query other { x }')).toBe(
+      'searchSites',
+    );
+  });
+
+  it('parses operation name from query when operationName is missing', () => {
+    const query = `query searchSites { searchSites { count } }`;
+    expect(resolveGraphqlOperationName(undefined, query)).toBe('searchSites');
+  });
+
+  it('returns anonymous when name cannot be resolved', () => {
+    expect(resolveGraphqlOperationName(undefined, '')).toBe('anonymous');
+    expect(resolveGraphqlOperationName(undefined, 'not valid graphql')).toBe(
+      'anonymous',
+    );
+  });
+});

--- a/backend/src/app/metrics/resolve-graphql-operation-name.spec.ts
+++ b/backend/src/app/metrics/resolve-graphql-operation-name.spec.ts
@@ -2,9 +2,9 @@ import { resolveGraphqlOperationName } from './resolve-graphql-operation-name';
 
 describe('resolveGraphqlOperationName', () => {
   it('uses client operationName when provided', () => {
-    expect(resolveGraphqlOperationName('searchSites', 'query other { x }')).toBe(
-      'searchSites',
-    );
+    expect(
+      resolveGraphqlOperationName('searchSites', 'query other { x }'),
+    ).toBe('searchSites');
   });
 
   it('parses operation name from query when operationName is missing', () => {

--- a/backend/src/app/metrics/resolve-graphql-operation-name.ts
+++ b/backend/src/app/metrics/resolve-graphql-operation-name.ts
@@ -1,0 +1,27 @@
+import { getOperationAST, parse } from 'graphql';
+
+/**
+ * Resolves the operation label for metrics. Uses the client-provided operationName when
+ * present; otherwise parses the query document (safe fallback; does not affect execution).
+ */
+export function resolveGraphqlOperationName(
+  operationName: string | undefined | null,
+  query?: string,
+): string {
+  const trimmed = operationName?.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+
+  if (!query?.trim()) {
+    return 'anonymous';
+  }
+
+  try {
+    const document = parse(query);
+    const operation = getOperationAST(document, undefined);
+    return operation?.name?.value ?? 'anonymous';
+  } catch {
+    return 'anonymous';
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,6 +1,8 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { LoggerService } from './app/logger/logger.service';
+import { OperationalMetricsService } from './app/metrics/operational-metrics.service';
+import { createHttpMetricsMiddleware } from './app/metrics/http-metrics.middleware';
 const logger = new LoggerService();
 async function main() {
   const app = await NestFactory.create(AppModule);
@@ -9,6 +11,21 @@ async function main() {
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
     credentials: true,
   });
+
+  // --- Operational metrics (Prometheus / Sysdig) ---
+  const metricsService = app.get(OperationalMetricsService);
+  // Nest runs on Express (@nestjs/platform-express); getInstance() is the raw Express app.
+  const http = app.getHttpAdapter().getInstance();
+  http.use(createHttpMetricsMiddleware(metricsService));
+
+  // GET /metrics on Express (not a Nest @Controller) so global Keycloak APP_GUARDs in
+  // app.module.ts do not require a JWT for the cluster Prometheus/Sysdig scraper.
+  http.get('/metrics', async (_req, res) => {
+    const registry = metricsService.getPromRegistry();
+    res.set('Content-Type', registry.contentType);
+    res.end(await registry.metrics());
+  });
+
   await app.listen(process.env.PORT || 4007);
 }
 main()

--- a/charts/app/templates/backend/templates/deployment.yaml
+++ b/charts/app/templates/backend/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
     metadata:
       annotations:
         rollme: {{ randAlphaNum 5 | quote }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.backend.service.targetPort | quote }}
+        prometheus.io/path: "/metrics"
       labels:
         {{- include "backend.labels" . | nindent 8 }}
     spec:

--- a/frontend/src/app/features/cart/CartSlice.ts
+++ b/frontend/src/app/features/cart/CartSlice.ts
@@ -28,6 +28,7 @@ export const fetchCartItems = createAsyncThunk(
   async () => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getCartItemsForUser',
         query: print(getCartItemsForUserQL()),
       });
       return response.data;
@@ -41,6 +42,7 @@ export const addCartItem = createAsyncThunk(
   'addCartItem',
   async (cartInputDTO: Cart[]) => {
     const request = await getAxiosInstance().post(GRAPHQL, {
+      operationName: 'addCartItem',
       query: print(addCartItemQL()),
       variables: {
         cartDTO: cartInputDTO,
@@ -54,6 +56,7 @@ export const deleteCartItem = createAsyncThunk(
   'deleteCartItem',
   async (cartDeleteDTO: CartDeleteDTO[]) => {
     const request = await getAxiosInstance().post(GRAPHQL, {
+      operationName: 'deleteCartItem',
       query: print(deleteCartItemQL()),
       variables: {
         cartDeleteDTO: cartDeleteDTO,
@@ -67,6 +70,7 @@ export const deleteCartItemWithSiteId = createAsyncThunk(
   'deleteCartItemWithSiteId',
   async (cartDeleteDTO: CartDeleteDTOWithSiteId[]) => {
     const request = await getAxiosInstance().post(GRAPHQL, {
+      operationName: 'deleteCartItemWithSiteId',
       query: print(deleteCartWithSiteIdItemQL()),
       variables: {
         cartDeleteDTO: cartDeleteDTO,

--- a/frontend/src/app/features/dashboard/DashboardSlice.ts
+++ b/frontend/src/app/features/dashboard/DashboardSlice.ts
@@ -26,6 +26,7 @@ export const fetchRecentViews = createAsyncThunk(
   async (userId: string) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getRecentViewsByUserId',
         query: print(graphQLRecentViewsByUserId()),
         variables: {
           userId: userId,
@@ -50,6 +51,7 @@ export const addRecentView = createAsyncThunk(
   }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'addRecentView',
         query: print(graphQLAddRecentView()),
         variables: {
           recentViewDto: {

--- a/frontend/src/app/features/details/SaveSiteDetailsSlice.ts
+++ b/frontend/src/app/features/details/SaveSiteDetailsSlice.ts
@@ -28,6 +28,7 @@ export const saveSiteDetails = createAsyncThunk(
   async (_, { getState }) => {
     const saveDTO = getSiteDetailsToBeSaved(getState());
     const request = await getAxiosInstance().post(GRAPHQL, {
+      operationName: 'updateSiteDetails',
       query: print(updateSiteDetails()),
       variables: {
         siteDetailsDTO: saveDTO,

--- a/frontend/src/app/features/details/SiteDetails.tsx
+++ b/frontend/src/app/features/details/SiteDetails.tsx
@@ -1202,6 +1202,7 @@ const SiteDetails = () => {
   const handleDeleteSite = async () => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'DeleteSite',
         query: print(DELETE_SITE_MUTATION),
         variables: {
           input: {

--- a/frontend/src/app/features/details/associates/Associate.tsx
+++ b/frontend/src/app/features/details/associates/Associate.tsx
@@ -142,6 +142,7 @@ const Associate: React.FC<IComponentProps> = ({ showPending = false }) => {
           return resultCache[searchParam];
         }
         const response = await getAxiosInstance().post(GRAPHQL, {
+          operationName: 'searchSiteIds',
           query: print(graphqlSearchSiteIdsQuery()),
           variables: { searchParam },
         });

--- a/frontend/src/app/features/details/associates/AssociateSlice.ts
+++ b/frontend/src/app/features/details/associates/AssociateSlice.ts
@@ -19,6 +19,7 @@ export const fetchAssociatedSites = createAsyncThunk(
   async ({ siteId, showPending }: { siteId: string; showPending: boolean }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getAssociatedSitesBySiteId',
         query: print(graphQLAssociatedSitesBySiteId()),
         variables: {
           siteId: siteId,

--- a/frontend/src/app/features/details/disclosure/DisclosureSlice.ts
+++ b/frontend/src/app/features/details/disclosure/DisclosureSlice.ts
@@ -19,6 +19,7 @@ export const fetchSiteDisclosure = createAsyncThunk(
   async ({ siteId, showPending }: { siteId: string; showPending: boolean }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getSiteDisclosureBySiteId',
         query: print(graphQLSiteDisclosureBySiteId()),
         variables: {
           siteId: siteId,

--- a/frontend/src/app/features/details/documents/Documents.tsx
+++ b/frontend/src/app/features/details/documents/Documents.tsx
@@ -113,6 +113,7 @@ const Documents: React.FC<IComponentProps> = ({ showPending = false }) => {
         }
 
         const response = await getAxiosInstance().post(GRAPHQL, {
+          operationName: 'getPeopleOrgsCd',
           query: print(graphQLPeopleOrgsCd()),
           variables: { searchParam, entityType: 'ORG' },
         });

--- a/frontend/src/app/features/details/documents/DocumentsSlice.ts
+++ b/frontend/src/app/features/details/documents/DocumentsSlice.ts
@@ -19,6 +19,7 @@ export const fetchDocuments = createAsyncThunk(
   async ({ siteId, showPending }: { siteId: string; showPending: boolean }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getSiteDocumentsBySiteId',
         query: print(graphQLSiteDocumentsBySiteId()),
         variables: {
           siteId: siteId,

--- a/frontend/src/app/features/details/dropdowns/DropdownSlice.ts
+++ b/frontend/src/app/features/details/dropdowns/DropdownSlice.ts
@@ -41,6 +41,7 @@ export const fetchPeopleOrgsCd = createAsyncThunk(
   async (args?: { searchParam?: string; entityType?: string }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getPeopleOrgsCd',
         query: print(graphQLPeopleOrgsCd()),
         variables: {
           searchParam: args?.searchParam ?? '',
@@ -59,6 +60,7 @@ export const fetchParticipantRoleCd = createAsyncThunk(
   async () => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getParticipantRoleCd',
         query: print(graphQLParticipantRoleCd()),
       });
       return response.data.data;
@@ -73,6 +75,7 @@ export const fetchNotationParticipantRoleCd = createAsyncThunk(
   async () => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getNotationParticipantRoleCd',
         query: print(graphQLNotationParticipantRoleCd()),
       });
       return response.data.data;
@@ -87,6 +90,7 @@ export const fetchNotationClassCd = createAsyncThunk(
   async () => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getNotationClassCd',
         query: print(graphQLNotationClassCd()),
       });
       return response.data.data;
@@ -101,6 +105,7 @@ export const fetchNotationTypeCd = createAsyncThunk(
   async () => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getNotationTypeCd',
         query: print(graphQLNotationTypeCd()),
       });
       return response.data.data;
@@ -115,6 +120,7 @@ export const fetchMinistryContact = createAsyncThunk(
   async (entityType: string) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getPeopleOrgsCd',
         query: print(graphQLPeopleOrgsCd()),
         variables: {
           entityType: entityType,
@@ -132,6 +138,7 @@ export const fetchInternalUserNameForDropdown = createAsyncThunk(
   async () => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getIDIRUserListForDropDown',
         query: print(getIDIRUserListForDropDownQL()),
       });
       return response.data;
@@ -146,6 +153,7 @@ export const fetchSiteRiskCd = createAsyncThunk(
   async () => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getSiteRiskCd',
         query: print(graphQLSiteRiskCd()),
       });
       return response.data.data;
@@ -160,6 +168,7 @@ export const fetchBceRegionCd = createAsyncThunk(
   async () => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getBCeRegionCd',
         query: print(graphQLBCeRegionCd()),
       });
       return response.data.data;
@@ -174,6 +183,7 @@ export const fetchSiteStatusCd = createAsyncThunk(
   async () => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getSiteStatusCd',
         query: print(graphQLSiteStatusCd()),
       });
       return response.data.data;
@@ -188,6 +198,7 @@ export const fetchSchedule2ReferenceCd = createAsyncThunk(
   async () => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getSchedule2Ref',
         query: print(graphQLSchedule2Ref()),
       });
       return response.data.data;

--- a/frontend/src/app/features/details/landUses/LandUsesSlice.ts
+++ b/frontend/src/app/features/details/landUses/LandUsesSlice.ts
@@ -30,6 +30,7 @@ export const fetchLandUses = createAsyncThunk(
   }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getLandHistoriesForSite',
         query: print(getLandHistoriesForSiteQuery),
         variables: { siteId, searchTerm, sortDirection, pending: showPending },
       });
@@ -46,6 +47,7 @@ export const fetchLandUseCodes = createAsyncThunk(
   async () => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getLandUseCodes',
         query: print(getLandUseCodesQuery),
       });
 

--- a/frontend/src/app/features/details/landUses/graphql/LandUses.ts
+++ b/frontend/src/app/features/details/landUses/graphql/LandUses.ts
@@ -35,7 +35,7 @@ export const getLandHistoriesForSiteQuery = gql`
 `;
 
 export const getLandUseCodesQuery = gql`
-  {
+  query getLandUseCodes {
     getLandUseCodes {
       data {
         description

--- a/frontend/src/app/features/details/notations/NotationSlice.ts
+++ b/frontend/src/app/features/details/notations/NotationSlice.ts
@@ -23,6 +23,7 @@ export const fetchNotationParticipants = createAsyncThunk(
   }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getSiteNotationBySiteId',
         query: print(graphQLSiteNotationBySiteId()),
         variables: {
           siteId: args.siteId,

--- a/frontend/src/app/features/details/notations/Notations.tsx
+++ b/frontend/src/app/features/details/notations/Notations.tsx
@@ -191,6 +191,7 @@ const Notations: React.FC<IComponentProps> = ({ showPending = false }) => {
         }
 
         const response = await getAxiosInstance().post(GRAPHQL, {
+          operationName: 'getPeopleOrgsCd',
           query: print(graphQLPeopleOrgsCd()),
           variables: { searchParam },
         });

--- a/frontend/src/app/features/details/parcelDescriptions/parcelDescriptionsSlice.ts
+++ b/frontend/src/app/features/details/parcelDescriptions/parcelDescriptionsSlice.ts
@@ -34,6 +34,7 @@ export const fetchParcelDescriptions = createAsyncThunk(
     let response;
     try {
       response = await axios.post(GRAPHQL, {
+        operationName: 'getParcelDescriptionBySiteId',
         query: print(graphQLParcelDescriptionBySiteId()),
         variables: {
           siteId: params.siteId,

--- a/frontend/src/app/features/details/participants/Participant.tsx
+++ b/frontend/src/app/features/details/participants/Participant.tsx
@@ -130,6 +130,7 @@ const Participants: React.FC<IComponentProps> = ({ showPending = false }) => {
         }
 
         const response = await getAxiosInstance().post(GRAPHQL, {
+          operationName: 'getPeopleOrgsCd',
           query: print(graphQLPeopleOrgsCd()),
           variables: { searchParam },
         });

--- a/frontend/src/app/features/details/participants/ParticipantSlice.ts
+++ b/frontend/src/app/features/details/participants/ParticipantSlice.ts
@@ -19,6 +19,7 @@ export const fetchSiteParticipants = createAsyncThunk(
   async (args: { siteId: string; showPending: Boolean }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getSiteParticipantBySiteId',
         query: print(graphQLSiteParticipantsBySiteId()),
         variables: {
           siteId: args.siteId,

--- a/frontend/src/app/features/details/pdf/useSiteDetailsPdfData.ts
+++ b/frontend/src/app/features/details/pdf/useSiteDetailsPdfData.ts
@@ -52,6 +52,7 @@ const fetchAllParcelDescriptions = async (
 ): Promise<any[]> => {
   try {
     const response = await getAxiosInstance().post(GRAPHQL, {
+      operationName: 'getParcelDescriptionBySiteId',
       query: print(graphQLParcelDescriptionBySiteId()),
       variables: {
         siteId: Number(siteId),
@@ -79,6 +80,7 @@ const fetchAllLandUses = async (
 ): Promise<any[]> => {
   try {
     const response = await getAxiosInstance().post(GRAPHQL, {
+      operationName: 'getLandHistoriesForSite',
       query: print(getLandHistoriesForSiteQuery),
       variables: { siteId, pending },
     });

--- a/frontend/src/app/features/details/snapshot/SnapshotSlice.ts
+++ b/frontend/src/app/features/details/snapshot/SnapshotSlice.ts
@@ -26,6 +26,7 @@ export const fetchSnapshots = createAsyncThunk(
   async (siteId: string) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getSnapshotsBySiteId',
         query: print(graphQLSnapshotBySiteId()),
         variables: {
           siteId: siteId,
@@ -43,6 +44,7 @@ export const createSnapshotForSites = createAsyncThunk(
   'snapshots/createSnapshotForSites',
   async (inputDto: CreateSnapshotInputDto[]) => {
     const response = await getAxiosInstance().post(GRAPHQL, {
+      operationName: 'createSnapshotForSites',
       query: print(createSnapshotForSitesQL()),
       variables: {
         inputDto: inputDto,
@@ -58,6 +60,7 @@ export const getBannerType = createAsyncThunk(
   async (siteId: string) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getBannerType',
         query: print(graphQLGetBannerType()),
         variables: {
           siteId: siteId,

--- a/frontend/src/app/features/details/srUpdates/srUpdatesSlice.ts
+++ b/frontend/src/app/features/details/srUpdates/srUpdatesSlice.ts
@@ -38,6 +38,7 @@ export const updateSiteDetailsForApproval = createAsyncThunk(
   async (siteDetailsDTO: any, { getState }) => {
     const saveDTO = siteDetailsDTO;
     const request = await getAxiosInstance().post(GRAPHQL, {
+      operationName: 'updateSiteDetails',
       query: print(updateSiteDetails()),
       variables: {
         siteDetailsDTO: saveDTO,
@@ -54,6 +55,7 @@ export const fetchParcelDescriptionsForApproval = createAsyncThunk(
     let response;
     try {
       response = await axios.post(GRAPHQL, {
+        operationName: 'getParcelDescriptionBySiteId',
         query: print(graphQLParcelDescriptionBySiteId()),
         variables: {
           siteId: params.siteId,
@@ -111,6 +113,7 @@ export const fetchPendingAssociatedSites = createAsyncThunk(
   async ({ siteId, showPending }: { siteId: string; showPending: boolean }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getAssociatedSitesBySiteId',
         query: print(graphQLAssociatedSitesBySiteId()),
         variables: {
           siteId: siteId,
@@ -129,6 +132,7 @@ export const fetchPendingSiteDisclosure = createAsyncThunk(
   async ({ siteId, showPending }: { siteId: string; showPending: boolean }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getSiteDisclosureBySiteId',
         query: print(graphQLSiteDisclosureBySiteId()),
         variables: {
           siteId: siteId,
@@ -151,6 +155,7 @@ export const fetchPendingDocumentsForApproval = createAsyncThunk(
   async ({ siteId, showPending }: { siteId: string; showPending: boolean }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getSiteDocumentsBySiteId',
         query: print(graphQLSiteDocumentsBySiteId()),
         variables: {
           siteId: siteId,
@@ -169,6 +174,7 @@ export const fetchPendingSiteParticipantsForApproval = createAsyncThunk(
   async (args: { siteId: string; showPending: Boolean }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getSiteParticipantBySiteId',
         query: print(graphQLSiteParticipantsBySiteId()),
         variables: {
           siteId: args.siteId,
@@ -188,6 +194,7 @@ export const fetchPendingSitesDetailsForApproval = createAsyncThunk(
   async (args: { siteId: string; showPending: Boolean }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'findSiteBySiteIdLoggedInUser',
         query: print(graphqlSiteDetailsQueryForLoggedIn()),
         variables: {
           siteId: args.siteId,
@@ -206,6 +213,7 @@ export const fetchPendingSiteNotationBySiteId = createAsyncThunk(
   async (args: { siteId: string; showPending: Boolean }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getSiteNotationBySiteId',
         query: print(graphQLSiteNotationBySiteId()),
         variables: {
           siteId: args.siteId,
@@ -234,6 +242,7 @@ export const fetchPendingLandUses = createAsyncThunk(
   }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getLandHistoriesForSite',
         query: print(getLandHistoriesForSiteQuery),
         variables: { siteId, searchTerm, sortDirection, pending: showPending },
       });

--- a/frontend/src/app/features/details/srUpdates/state/srUpdatesTableSlice.ts
+++ b/frontend/src/app/features/details/srUpdates/state/srUpdatesTableSlice.ts
@@ -38,6 +38,7 @@ export const fetchPendingSiteForSRApproval = createAsyncThunk(
   }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getPendingSiteForSRApproval',
         query: print(getPendingSiteForSRApprovalQL()),
         variables: {
           searchParam: args.searchParam,
@@ -58,6 +59,7 @@ export const bulkAproveRejectChanges = createAsyncThunk(
   'sites/bulkAproveRejectChanges',
   async (approveRejectDTO: BulkApproveRejectChangesDTO) => {
     const request = await getAxiosInstance().post(GRAPHQL, {
+      operationName: 'bulkAproveRejectChanges',
       query: print(bulkAproveRejectChangesQL()),
       variables: {
         approveRejectDTO: approveRejectDTO,

--- a/frontend/src/app/features/folios/redux/FolioSlice.ts
+++ b/frontend/src/app/features/folios/redux/FolioSlice.ts
@@ -31,6 +31,7 @@ export const fetchFolioItems = createAsyncThunk(
   async (userId: string) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getFolioItemsForUser',
         query: print(getFolioItemsForUserQL()),
         variables: {
           userId: userId,
@@ -48,6 +49,7 @@ export const getSiteForFolio = createAsyncThunk(
   async (inputDTO: FolioMinDTO) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getSitesForFolio',
         query: print(getSitesForFolioQL()),
         variables: {
           folioDTO: inputDTO,
@@ -66,6 +68,7 @@ export const addFolioItem = createAsyncThunk(
   'addFolioItem',
   async (FolioInputDTO: Folio) => {
     const request = await getAxiosInstance().post(GRAPHQL, {
+      operationName: 'addFolioItem',
       query: print(addFolioItemQL()),
       variables: {
         FolioDTO: FolioInputDTO,
@@ -79,6 +82,7 @@ export const addSiteToFolio = createAsyncThunk(
   'addSiteToFolio',
   async (FolioInputDTO: FolioContentDTO[]) => {
     const request = await getAxiosInstance().post(GRAPHQL, {
+      operationName: 'addSiteToFolio',
       query: print(addSiteToFolioQL()),
       variables: {
         folioDTO: FolioInputDTO,
@@ -92,6 +96,7 @@ export const deleteSitesInFolio = createAsyncThunk(
   'deleteSitesInFolio',
   async (FolioInputDTO: FolioContentDTO[]) => {
     const request = await getAxiosInstance().post(GRAPHQL, {
+      operationName: 'deleteSitesInFolio',
       query: print(deleteSitesInFolioQL()),
       variables: {
         folioDTO: FolioInputDTO,
@@ -105,6 +110,7 @@ export const updateFolioItem = createAsyncThunk(
   'updateFolioItem',
   async (FolioInputDTO: Folio[]) => {
     const request = await getAxiosInstance().post(GRAPHQL, {
+      operationName: 'updateFolioItem',
       query: print(updateFolioItemQL()),
       variables: {
         FolioDTO: FolioInputDTO,
@@ -118,6 +124,7 @@ export const deleteFolioItem = createAsyncThunk(
   'deleteFolioItem',
   async (FolioId: string) => {
     const request = await getAxiosInstance().post(GRAPHQL, {
+      operationName: 'deleteFolioItem',
       query: print(deleteFolioItemQL()),
       variables: {
         folioId: parseInt(FolioId),

--- a/frontend/src/app/features/purchases/PurchasesSlice.ts
+++ b/frontend/src/app/features/purchases/PurchasesSlice.ts
@@ -42,6 +42,7 @@ export const fetchPurchasedSites = createAsyncThunk(
     sortByDir?: string;
   }) => {
     const response = await getAxiosInstance().post(GRAPHQL, {
+      operationName: 'getPurchasedSites',
       query: print(getPurchasedSitesQL()),
       variables: {
         page: args.page,

--- a/frontend/src/app/features/site/SiteSearchSlice.ts
+++ b/frontend/src/app/features/site/SiteSearchSlice.ts
@@ -42,6 +42,7 @@ export const fetchSearchSites = createAsyncThunk(
         };
       }
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'searchSites',
         query: print(graphQlSiteQuery()),
         variables: {
           searchParam: args.searchParam?.trim(),

--- a/frontend/src/app/features/site/dto/SiteSlice.ts
+++ b/frontend/src/app/features/site/dto/SiteSlice.ts
@@ -5,7 +5,6 @@ import {
   getSiteInsightsQL,
   graphqlSiteDetailsQuery,
   graphqlSiteDetailsQueryForLoggedIn,
-  graphQlSiteQueryForAuthenticatedUsers,
 } from '../graphql/Site';
 import { SiteState } from './SiteState';
 import { RequestStatus } from '../../../helpers/requests/status';
@@ -36,6 +35,9 @@ export const fetchSitesDetails = createAsyncThunk(
       const { siteId } = args;
       const user = getUser();
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: user
+          ? 'findSiteBySiteIdLoggedInUser'
+          : 'findSiteBySiteId',
         query: print(
           user
             ? graphqlSiteDetailsQueryForLoggedIn()
@@ -62,6 +64,7 @@ export const fetchSitesInsights = createAsyncThunk(
   async (args: { siteId: string; showPending?: boolean }) => {
     try {
       const response = await getAxiosInstance().post(GRAPHQL, {
+        operationName: 'getSiteInsights',
         query: print(getSiteInsightsQL()),
         variables: {
           siteId: args.siteId,

--- a/frontend/src/app/features/site/graphql/Dropdowns.ts
+++ b/frontend/src/app/features/site/graphql/Dropdowns.ts
@@ -158,7 +158,7 @@ export const graphQLSiteStatusCd = () => {
 
 export const graphQLSchedule2Ref = () => {
   return gql`
-    query {
+    query getSchedule2Ref {
       getSchedule2Ref {
         message
         httpStatusCode


### PR DESCRIPTION
# Description

Adds Prometheus-compatible operational metrics to the Site Registry backend: per-GraphQL-operation success/failure and latency, plus HTTP status and wire-level 401/403. Exposes GET /metrics for OpenShift scrape → Sysdig dashboards (panels built after deploy).

No change to GraphQL API contracts or resolver logic. Frontend only adds operationName on axios GraphQL POSTs so metrics use real operation names (not anonymous).

Fixes # (issue)

Frontend (labeling only)
operationName on GraphQL POSTs across feature slices.
Query name fixes: getSchedule2Ref, getLandUseCodes.
No new GraphQL client helper; axios pattern unchanged.

Deploy
charts/app/templates/backend/templates/deployment.yaml — prometheus.io/scrape, path, port
Metrics (5 families)
site_registry_graphql_operations_total — counter by operation, outcome, error_class
site_registry_graphql_operation_duration_seconds — histogram
site_registry_http_requests_total — counter
site_registry_http_request_duration_seconds — histogram
site_registry_auth_failures_total — wire 401/403 (guard=http)
GraphQL auth in JSON body (HTTP 200) → GraphQL failure/client, not always auth_failures_total.



# How Has This Been Tested?

cd backend && npm test -- --testPathPattern="app/metrics"
curl -s http://localhost:4007/metrics | grep site_registry
UI: search + site view → grep searchSites / findSiteBySiteIdLoggedInUser and run the above command to check for the count


# What's pending
- Documentation (follow-up PR)
- Once deployed to test will get a fair idea of how its working and what is missing
- Create panels for different operations on sysdig for better monitoring

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-551-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-551-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-551-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-551-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend](https://nr-site-registry-551-backend.apps.silver.devops.gov.bc.ca)
- [Frontend](https://nr-site-registry-551-frontend.apps.silver.devops.gov.bc.ca)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-site-registry/actions/workflows/merge.yml)