### PR TITLE
fix: Fix automatic deploys

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -501,12 +501,47 @@ configure this webhook, you need to apply and create the webhook secret:
 ```sh
 oc -n c6a6e5 -f ./openshift/site_registry/tools/site_webhook_secret.yaml
 # this is what I used to generate the secret:
-openssl rand -base64 24
+openssl rand -hex 24
 ```
 
 Now go to the GitHub repo settings and add the webhook with the generated
-secret. If you look at the BuildConfig in OpenShift, you can see the URL that
-will receive the webhook.
+secret. If you look at the BuildConfig in OpenShift, you can see, and copy, the
+URL that will receive the webhook.
+
+The automatic deploy procedure goes like this:
+
+1. Github issues a webhook to trigger the `site-backend-init` BuildConfig
+
+   1. The `site-backend-init` build completes, which triggers a new build of the
+      `site-backend` BuildConfig. See the `site-backend` BuildConfig for the
+      ImageStreamTag-based trigger.
+   2. The `site-backend` build completes, which triggers a new rollout of the
+      `site-backend` deployment. See the Deployment for the
+      `image.openshift.io/triggers`-based trigger. This annotation trigger
+      **must** be specified in a single line. A multi-line definition will fail.
+
+2. GitHub issues a webhook to trigger the `site-frontend` Buildconfig
+   1. The `site-frontend` build completes, which triggers a new rollout of the
+      `site-frontend` Deployment. It is configured in the same way as the
+      backend deployment mentioned above.
+
+```mermaid
+flowchart TD
+   github[GitHub]
+   backend-init-bc[Backend Init BuildConfig]
+   backend-bc[Backend BuildConfig]
+   frontend-bc[Frontend BuildConfig]
+   backend-rollout[Backend Rollout]
+   frontend-rollout[Frontend Rollout]
+
+   github --Sends Webhook--> backend-init-bc
+   github --Sends Webhook--> frontend-bc
+
+   backend-init-bc --Triggers--> backend-bc
+
+   backend-bc --Triggers--> backend-rollout
+   frontend-bc --Triggers--> frontend-rollout
+```
 
 ### Configuring Promotion From Dev to Test, and Test to Prod.
 

--- a/openshift/scripts/apply_site_registry_dev.sh
+++ b/openshift/scripts/apply_site_registry_dev.sh
@@ -1,0 +1,21 @@
+#! /bin/sh
+
+# This script applies all of the site registry dev environment OpenShift
+# manifests, **EXCEPT** for the secrets so that any existing secrets are not
+# overwritten.
+
+set -eu
+
+scriptdir="$(dirname "$0")"
+
+if ! command -v oc >/dev/null 2>&1; then
+    echo "oc command not found. Please install the OpenShift CLI (oc) and ensure it is in your PATH."
+    exit 1
+fi
+
+if ! oc status >/dev/null 2>&1; then
+    echo "Not logged in to OpenShift. Please log in using 'oc login' and try again."
+    exit 1
+fi
+
+find "${scriptdir}/../site_registry/dev/" -type f -name '*.yaml' ! -name '*secret*' -exec oc apply -f {} \;

--- a/openshift/scripts/apply_site_registry_tools.sh
+++ b/openshift/scripts/apply_site_registry_tools.sh
@@ -1,0 +1,21 @@
+#! /bin/sh
+
+# This script applies all of the site registry tools environment OpenShift
+# manifests, **EXCEPT** for the secrets so that any existing secrets are not
+# overwritten.
+
+set -eu
+
+scriptdir="$(dirname "$0")"
+
+if ! command -v oc >/dev/null 2>&1; then
+    echo "oc command not found. Please install the OpenShift CLI (oc) and ensure it is in your PATH."
+    exit 1
+fi
+
+if ! oc status >/dev/null 2>&1; then
+    echo "Not logged in to OpenShift. Please log in using 'oc login' and try again."
+    exit 1
+fi
+
+find "${scriptdir}/../site_registry/tools/" -type f -name '*.yaml' ! -name '*secret*' -exec oc apply -f {} \;

--- a/openshift/site_registry/dev/backend/site_backend_deployment.yaml
+++ b/openshift/site_registry/dev/backend/site_backend_deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"site-backend:dev","namespace":"c6a6e5-tools"},"fieldPath":"spec.template.spec.containers[?(@.name==\"site-backend\")].image","paused":false}]'
   name: site-backend
   namespace: c6a6e5-dev
   labels:
@@ -26,7 +28,7 @@ spec:
     spec:
       initContainers: # The container that will do the initial migrations.
         - name: site-backend-init
-          image: "image-registry.openshift-image-registry.svc:5000/c6a6e5-tools/site-backend-init:latest"
+          image: "image-registry.openshift-image-registry.svc:5000/c6a6e5-tools/site-backend-init:dev"
           imagePullPolicy: Always
           env:
             - name: POSTGRES_HOST
@@ -65,7 +67,7 @@ spec:
               memory: 128Mi
       containers:
         - name: site-backend
-          image: "image-registry.openshift-image-registry.svc:5000/c6a6e5-tools/site-backend:latest"
+          image: "image-registry.openshift-image-registry.svc:5000/c6a6e5-tools/site-backend:dev"
           imagePullPolicy: Always
           envFrom:
             - secretRef:

--- a/openshift/site_registry/dev/frontend/site_frontend_deployment.yaml
+++ b/openshift/site_registry/dev/frontend/site_frontend_deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"site-frontend:dev","namespace":"c6a6e5-tools"},"fieldPath":"spec.template.spec.containers[?(@.name==\"site-frontend\")].image","paused":false}]'
   name: site-frontend
   namespace: c6a6e5-dev
   labels:
@@ -22,7 +24,7 @@ spec:
     spec:
       containers:
         - name: site-frontend
-          image: 'image-registry.openshift-image-registry.svc:5000/c6a6e5-tools/site-frontend:latest'
+          image: 'image-registry.openshift-image-registry.svc:5000/c6a6e5-tools/site-frontend:dev'
           imagePullPolicy: Always
           env:
             - name: LOG_LEVEL

--- a/openshift/site_registry/tools/site_backend_build_config.yaml
+++ b/openshift/site_registry/tools/site_backend_build_config.yaml
@@ -19,12 +19,12 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: 'site-backend:latest'
+      name: 'site-backend:dev'
   triggers:
-    - type: ConfigChange
-    - type: GitHub
-      github:
-        secretReference:
-          name: site-webhook-secret
+    - type: ImageChange
+      imageChange:
+        from:
+          kind: ImageStreamTag
+          name: site-backend-init:dev
   successfulBuildsHistoryLimit: 5
   failedBuildsHistoryLimit: 5

--- a/openshift/site_registry/tools/site_backend_init_build_config.yaml
+++ b/openshift/site_registry/tools/site_backend_init_build_config.yaml
@@ -19,7 +19,7 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: 'site-backend-init:latest'
+      name: 'site-backend-init:dev'
   triggers:
     - type: ConfigChange
     - type: GitHub

--- a/openshift/site_registry/tools/site_frontend_build_config.yaml
+++ b/openshift/site_registry/tools/site_frontend_build_config.yaml
@@ -19,7 +19,7 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: 'site-frontend:latest'
+      name: 'site-frontend:dev'
   triggers:
     - type: ConfigChange
     - type: GitHub


### PR DESCRIPTION
The previous iteration of this work did not include automatic rollouts of new code because OpenShift does not automatically trigger them. This work corrects that.

- Add scripts to apply OpenShift manifests (This is something that has made my life much easier).
- Update documentation to include automatic deployment explanation.
- Add triggers to ensure serial building of the backend containers to avoid race condition with backend and backend-init containers.
- Add triggers to ensure automatic rollout of backend and frontend deployments once all builds are complete.
- It turns out that base64 passwords can include `/` characters, which are incompatible with GitHub webhooks because the secret goes in a URL.
- changes the `latest` tag to `dev` to make it very clear where the images are intended to be used.
